### PR TITLE
Fix render warnings when calling setState within constructor

### DIFF
--- a/src/containers/BLISAppsHomepage.tsx
+++ b/src/containers/BLISAppsHomepage.tsx
@@ -37,13 +37,13 @@ class BLISAppsHomepage extends React.Component<Props, any> {
                 display = <AppAdmin />
                 break;
             case DisplayMode.Teach:
-                display = [<AppAdmin />, <TeachSessionWindow />];
+                display = [<AppAdmin key={1} />, <TeachSessionWindow key={2} />];
                 break;
             case DisplayMode.Session:
-                display = [<AppAdmin />, <ChatSessionWindow />];
+                display = [<AppAdmin key={1} />, <ChatSessionWindow key={2} />];
                 break;
             case DisplayMode.TrainDialog:
-                display = [<AppAdmin />, <TrainDialogWindow />];
+                display = [<AppAdmin key={1} />, <TrainDialogWindow key={2} />];
                 break;
          }
         return (

--- a/src/containers/ChatSessionWindow.tsx
+++ b/src/containers/ChatSessionWindow.tsx
@@ -22,7 +22,8 @@ class SessionWindow extends React.Component<Props, any> {
         }
     }
     componentWillMount() {
-        this.props.createChatSession(this.props.userKey, this.state.chatSession, this.props.apps.current.appId);
+        let currentAppId: string = this.props.apps.current.appId;
+        this.props.createChatSession(this.props.userKey, this.state.chatSession, currentAppId);
     }
     handleQuit() {
         this.props.setDisplayMode(DisplayMode.AppAdmin);

--- a/src/containers/TeachSessionWindow.tsx
+++ b/src/containers/TeachSessionWindow.tsx
@@ -21,6 +21,8 @@ class TeachWindow extends React.Component<Props, any> {
         this.state = {
             teachSession: new Teach({})
         }
+    }
+    componentWillMount() {
         let currentAppId: string = this.props.apps.current.appId;
         this.props.createTeachSession(this.props.user.key, this.state.teachSession, currentAppId)
     }

--- a/src/containers/TrainDialogWindow.tsx
+++ b/src/containers/TrainDialogWindow.tsx
@@ -21,6 +21,8 @@ class TrainDialogWindow extends React.Component<Props, any> {
         this.state = {
             chatSession : new Session({saveToLog : true})
         }
+    }
+    componentWillMount() {
         let currentAppId: string = this.props.apps.current.appId;
         this.props.createChatSession(this.props.userKey, this.state.chatSession, currentAppId);
     }


### PR DESCRIPTION
Move calls which invoked setState to componentWillMount to avoid render warnings.
Also, add unique keys to `display` list. (Eventually will refactor these windows to not be included in display)