### PR TITLE
Add ability to select activity in existing log dialog and show related entity, memory, and action

### DIFF
--- a/public/App.css
+++ b/public/App.css
@@ -388,10 +388,10 @@
 .teachSessionWindow{
   width: 100%
 }
-.teachVariationBox{
+/* .teachVariationBox{
   margin-top: 5px;
   margin-left: 10px;
-}
+} */
 .teachVariation{
   overflow: hidden;
 }
@@ -481,7 +481,7 @@
     border-width: 1px;
     border-color: #999999;
     padding: 10px;
-    margin-bottom: 10px;
+    /* margin-bottom: 10px; */
 }
 .extractorResponseBoxInvalid{
   border-style: solid;
@@ -541,6 +541,7 @@
   grid-template-rows: 1fr min-content;
 }
 .blis-chatmodal_admin-controls {
+  padding: 1em;
 }
 .blis-chatmodal_modal-controls{
   background-color: var(--color-secondary);
@@ -563,4 +564,18 @@
 }
 .ms-Button--primary:hover {
   background-color: var(--color-primary-darker) !important;
+}
+
+
+/** Log Dialog Admin */
+.log-dialog-admin {
+  display: grid;
+  grid-gap: 1rem;
+}
+.log-dialog-admin__title {
+  font-weight: bold;
+  border-bottom: 1px solid black;
+}
+.log-dialog-admin__content {
+  padding-bottom: 1em;
 }

--- a/src/containers/LogDialogAdmin.tsx
+++ b/src/containers/LogDialogAdmin.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { returntypeof } from 'react-redux-typescript';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { State } from '../types'
+import ExtractorResponseEditor from './ExtractorResponseEditor';
+import { Activity, Message } from 'botframework-directlinejs'
+import { LogDialog, LogRound, LogScorerStep, ActionBase, EntityBase } from 'blis-models'
+
+class LogDialogAdmin extends React.Component<Props, any> {
+    findRoundAndScorerStep(logDialog: LogDialog, activity: Activity): { round: LogRound, scorerStep: LogScorerStep } {
+        // TODO: Add roundIndex and scoreIndex to activity instead of hiding within id if these are needed as first class properties.
+        const [roundIndex, scoreIndex] = activity.id.split(":").map(s => parseInt(s))
+
+        if (roundIndex > logDialog.rounds.length) {
+            throw new Error(`Index out of range: You are attempting to access round by index: ${roundIndex} but there are only: ${logDialog.rounds.length} rounds.`)
+        }
+
+        const round = logDialog.rounds[roundIndex]
+        
+        if (scoreIndex > round.scorerSteps.length) {
+            throw new Error(`Index out of range: You are attempting to access scorer step by index: ${scoreIndex} but there are only: ${round.scorerSteps.length} scorere steps.`)
+        }
+
+        const scorerStep = round.scorerSteps[scoreIndex]
+
+        return {
+            round,
+            scorerStep
+        }
+    }
+
+    render() {
+        let round: LogRound = null
+        let scorerStep: LogScorerStep = null
+        let action: ActionBase = null
+        let entities: EntityBase[] = []
+
+        if (this.props.logDialog && this.props.selectedActivity) {
+            const result = this.findRoundAndScorerStep(this.props.logDialog, this.props.selectedActivity)
+            round = result.round
+            scorerStep = result.scorerStep
+            action = this.props.actions.find(action => action.actionId == scorerStep.predictedAction)
+            entities = this.props.entities.filter(entity => scorerStep.input.filledEntities.includes(entity.entityId))
+        }
+
+        return (
+            <div className="log-dialog-admin ms-font-l">
+                <div className="log-dialog-admin__title">Entity Detection</div>
+                <div className="log-dialog-admin__content">
+                    {round
+                        ? <ExtractorResponseEditor isPrimary={true} isValid={true} extractResponse={round.extractorStep} />
+                        : "Select an activity"}
+                </div>
+                <div className="log-dialog-admin__title">Memory</div>
+                <div className="log-dialog-admin__content">
+                    {entities.length !== 0 && entities.map(entity => <div key={entity.entityName}>{entity.entityName}</div>)}
+                </div>
+                <div className="log-dialog-admin__title">Action</div>
+                <div className="log-dialog-admin__content">
+                    {action && action.payload}
+                </div>
+            </div>
+        );
+    }
+}
+const mapDispatchToProps = (dispatch: any) => {
+    return bindActionCreators({
+    }, dispatch);
+}
+const mapStateToProps = (state: State) => {
+    return {
+        actions: state.actions,
+        entities: state.entities
+    }
+}
+
+export interface ReceivedProps {
+    logDialog: LogDialog,
+    selectedActivity: Activity
+}
+
+// Props types inferred from mapStateToProps & dispatchToProps
+const stateProps = returntypeof(mapStateToProps);
+const dispatchProps = returntypeof(mapDispatchToProps);
+type Props = typeof stateProps & typeof dispatchProps & ReceivedProps;
+
+export default connect<typeof stateProps, typeof dispatchProps, ReceivedProps>(mapStateToProps, mapDispatchToProps)(LogDialogAdmin);

--- a/src/containers/TrainDialogAdmin.tsx
+++ b/src/containers/TrainDialogAdmin.tsx
@@ -47,7 +47,7 @@ class TrainDialogAdmin extends React.Component<Props, any> {
             details = [];
             for (let entityId of entityIds) {
                 let entity: EntityBase = this.props.entities.find((a: EntityBase) => a.entityId == entityId);
-                details.push(<div className='ms-font-l'>{entity.entityName}</div>);     
+                details.push(<div className='ms-font-l' key={entity.entityName}>{entity.entityName}</div>);     
             }
         }
         return (

--- a/src/containers/Webchat.tsx
+++ b/src/containers/Webchat.tsx
@@ -17,6 +17,11 @@ class Webchat extends React.Component<Props, any> {
     private behaviorSubject : BehaviorSubject<any> = null;
     private chatProps : BotChat.ChatProps = null;
 
+    static defaultProps = {
+        onSelectActivity: () => {},
+        onPostActivity: () => {}
+    }
+
     constructor(p: any) {
         super(p);
         this.behaviorSubject = null;
@@ -29,7 +34,15 @@ class Webchat extends React.Component<Props, any> {
             this.behaviorSubject = new BehaviorSubject<any>({});
             this.behaviorSubject.subscribe((value) => {
                 if (value.activity) {
+                    const activity: Activity = value.activity
+                    this.props.onSelectActivity(activity)
+
+                    // TODO: Remove split of id here.
+                    // This is coupling knowledge about how ID was constructed within the generateHistory function
+                    // Id should be an opaque and unique identifier.
                     let [roundNum, scoreNum] = value.activity.id.split(":");
+
+                    // TODO: Remove hard coding of train related actions from web chat
                     this.props.setTrainDialogView(roundNum, scoreNum);
                 }
             })
@@ -50,6 +63,8 @@ class Webchat extends React.Component<Props, any> {
             const _dl = {
                 ...dl,
                 postActivity: (activity: any) => {
+                    // TODO: Remove hard coding of adding message to stack
+                    // Webchat should not be aware of what happens when activity is posted, only that is is posted.
                     if (activity.type = "message")
                     {
                         if (this.props.sessionType === 'teach') {
@@ -63,6 +78,8 @@ class Webchat extends React.Component<Props, any> {
                         } else {
                             this.props.addMessageToChatConversationStack(activity)
                         }
+
+                        this.props.onPostActivity(activity)
                     }
                     return dl.postActivity(activity)
                 },
@@ -113,7 +130,9 @@ const mapStateToProps = (state: State, ownProps: any) => {
 
 interface ReceivedProps {
     sessionType: string,
-    history: Activity[]
+    history: Activity[],
+    onSelectActivity: (a: Activity) => void,
+    onPostActivity: (a: Activity) => void
 }
 
 // Props types inferred from mapStateToProps & dispatchToProps


### PR DESCRIPTION
Previously you could open a log dialog, but there was no interaction other than deletion.

This PR adds new component LogDialogAdmin similar to the TrainDialogAdmin.
At first glance it seems like they only differ in minor areas such as:
1. using `extractorStep` directly instead of `extractorStep.textVariations` since logDialogs don't have variations
2. using `predictedAction` instead of `labelAction` when getting related action.

However, there are deeper variations such as how they handle state which I want to avoid.  If this solution works out as I intend then eventually will refactor the other modals to use the same pattern but I wanted to keep the PR smaller and focused on current task instead of wide sweeping change. (partly because of time, other because I'm still learning how the current app is constructed as I go and don't want to change too much as there are hidden side affects)

Overall there are four goals I will be trying to achieve:
1. Reduce dependency on global state
2. Remove coupling between components
3. Restyle components to use BEM where possible
4. Keep JSX contained to render method where possible.

1 and 2 usually come together as in example below:
For example the WebChat is hard coded to update the state of trainDialog, but can be used by many different contexts and should not know about trainDialog.  However, because it is directly updating trainDialog state, the trainDialogAdmin then depends on observing these changes to things like `roundNum` or `selectedActivity` which couples the two compnent behaviors and makes the app less flexible / harder to reason about.

For example there is a bug with the TrainDialogAdmin where if you open one and select an Activity, then close and re-open another dialog that selected activity is still persisted and shows up in the admin control even though the user hasn't selected anything.  These things are hard to debug when they're global because you dont know who else depends on those values so it's not easy to simply reset them. When using container components you know precisely that only the children can know about this data and it is safe to reset which is what I do in the new LogDialogAdmin.

The global store should only be for the persistent collections of data such as trainDialogs, logDialogs, etc.  Knowing which is the current item selected is contextual and is better served by "container" components: https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0

Notice in this example, I extended WebChat to have generic calllbacks that can be assigned by the parent container.

For 3, just another example of BEM, not as important as the above though.
For 4, the TrainDialogAdmin had many different places that were outputting JSX. Methods such as `getMemory`, `getAction`, etc this makes it more difficult to reason about what the component layout is when you have to look in multiple locations.  Sometimes breaking it out is beneficial but if that's true then it would likely be a whole separate component.  Notice the LogDialogAdmin outputs the same markup, but is drastically clearer in it's intent.  (E.g. Find the current round and scorerStep related to the selectedActivit and if there is memory, or action, render it.)
