### PR TITLE
Prevent ChatSessionWindow from attempting to delete a session that does not exist.

### DIFF
--- a/src/containers/ChatSessionWindow.tsx
+++ b/src/containers/ChatSessionWindow.tsx
@@ -28,7 +28,10 @@ class SessionWindow extends React.Component<Props, any> {
     handleQuit() {
         this.props.setDisplayMode(DisplayMode.AppAdmin);
         let currentAppId: string = this.props.apps.current.appId;
-        this.props.deleteChatSession(this.props.userKey, this.props.chatSession.current, currentAppId)
+
+        if (this.props.chatSession.current !== null) {
+            this.props.deleteChatSession(this.props.userKey, this.props.chatSession.current, currentAppId)
+        }
     }
     render() {
         return (


### PR DESCRIPTION
There was possibility that the modal would open, but it's attempt to create a session would fail. Then when you attempt to close the modal it would try to delete the session but since the session was never created it would be null and fail.