### PR TITLE
Preserve action types on props, remove all unused actions.

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,8 +97,8 @@ class Header extends React.Component<Props, any> {
 
 const mapDispatchToProps = (dispatch: any) => {
   return bindActionCreators({
-    setDisplayMode: setDisplayMode,
-    setLoginDisplay: setLoginDisplay,
+    setDisplayMode,
+    setLoginDisplay,
   }, dispatch);
 }
 

--- a/src/containers/ActionResponseCreatorEditor.tsx
+++ b/src/containers/ActionResponseCreatorEditor.tsx
@@ -232,7 +232,7 @@ class ActionResponseCreatorEditor extends React.Component<Props, any> {
             packageDeletionId: null
         })
         if (this.state.editing === false) {
-            this.props.createAction(this.props.userKey, actionToAdd, currentAppId);
+            this.props.createActionAsync(this.props.userKey, actionToAdd, currentAppId);
         } else {
             this.editAction(actionToAdd, currentAppId);
         }
@@ -241,7 +241,7 @@ class ActionResponseCreatorEditor extends React.Component<Props, any> {
     }
     editAction(actionToAdd: ActionBase, currentAppId: string) {
         actionToAdd.actionId = this.props.blisAction.actionId;
-        this.props.editAction(this.props.userKey, actionToAdd, currentAppId);
+        this.props.editActionAsync(this.props.userKey, actionToAdd, currentAppId);
     }
     checkPayload(value: string): string {
         return value ? "" : "Payload is required";
@@ -884,8 +884,8 @@ class ActionResponseCreatorEditor extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        createAction: createActionAsync,
-        editAction: editActionAsync
+        createActionAsync,
+        editActionAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {

--- a/src/containers/ActionResponsesList.tsx
+++ b/src/containers/ActionResponsesList.tsx
@@ -94,7 +94,7 @@ class ActionResponsesHomepage extends React.Component<Props, any> {
     deleteSelectedAction() {
         let currentAppId: string = this.props.apps.current.appId;
         let actionToDelete: ActionBase = this.props.actions.find((a: ActionBase) => a.actionId == this.state.actionIDToDelete)
-        this.props.deleteAction(this.props.userKey, this.state.actionIDToDelete, actionToDelete, currentAppId);
+        this.props.deleteActionAsync(this.props.userKey, this.state.actionIDToDelete, actionToDelete, currentAppId);
         this.setState({
             confirmDeleteActionModalOpen: false,
             createEditModalOpen: false,
@@ -329,7 +329,7 @@ class ActionResponsesHomepage extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        deleteAction: deleteActionAsync
+        deleteActionAsync
     }, dispatch)
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/AppAdmin.tsx
+++ b/src/containers/AppAdmin.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { returntypeof } from 'react-redux-typescript';
-import { fetchApplicationsAsync } from '../actions/fetchActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import EntitiesList from './EntitiesList';
@@ -148,8 +147,7 @@ class AppAdmin extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        fetchApplications: fetchApplicationsAsync,
-        setDisplayMode: setDisplayMode
+        setDisplayMode
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/AppSettings.tsx
+++ b/src/containers/AppSettings.tsx
@@ -117,7 +117,7 @@ class AppSettings extends React.Component<Props, any> {
             locale: current.locale,
             metadata: meta
         })
-        this.props.editBLISApplication(this.props.userKey, appToAdd);
+        this.props.editBLISApplicationAsync(this.props.userKey, appToAdd);
         this.setState({
             localeVal: current.locale,
             appIdVal: current.appId,
@@ -188,7 +188,7 @@ class AppSettings extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        editBLISApplication: editBLISApplicationAsync,
+        editBLISApplicationAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/BLISAppCreator.tsx
+++ b/src/containers/BLISAppCreator.tsx
@@ -7,8 +7,7 @@ import { connect } from 'react-redux';
 import { Modal } from 'office-ui-fabric-react/lib/Modal';
 import { CommandButton, Dropdown } from 'office-ui-fabric-react';
 import { TextFieldPlaceholder } from './TextFieldPlaceholder';
-import { setDisplayMode, emptyStateProperties } from '../actions/displayActions'
-import { fetchAllActionsAsync, fetchAllEntitiesAsync, fetchAllTrainDialogsAsync } from '../actions/fetchActions';
+import { emptyStateProperties } from '../actions/displayActions'
 import { BlisAppBase, BlisAppMetaData } from 'blis-models'
 import { developmentSubKeyLUIS } from '../secrets'
 import { State } from '../types'
@@ -93,7 +92,7 @@ class BLISAppCreator extends React.Component<Props, any> {
             locale: this.state.localeVal,
             metadata: meta
         })
-        this.props.createBLISApplication(this.props.userKey, this.props.userId, appToAdd);
+        this.props.createBLISApplicationAsync(this.props.userKey, this.props.userId, appToAdd);
         //need to empty entities, actions, and trainDialogs arrays
         this.props.emptyStateProperties();
         this.handleClose();
@@ -174,12 +173,8 @@ class BLISAppCreator extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        createBLISApplication: createBLISApplicationAsync,
-        fetchAllActions: fetchAllActionsAsync,
-        fetchAllEntities: fetchAllEntitiesAsync,
-        fetchAllTrainDialogs: fetchAllTrainDialogsAsync,
-        setDisplayMode: setDisplayMode,
-        emptyStateProperties: emptyStateProperties
+        createBLISApplicationAsync,
+        emptyStateProperties
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/BLISAppsHomepage.tsx
+++ b/src/containers/BLISAppsHomepage.tsx
@@ -24,8 +24,8 @@ class BLISAppsHomepage extends React.Component<Props, any> {
             this.setState({
                 displayedUserId: this.props.userId
             })
-            this.props.fetchApplications(this.props.userKey, this.props.userId);
-            this.props.fetchBotInfo();
+            this.props.fetchApplicationsAsync(this.props.userKey, this.props.userId);
+            this.props.fetchBotInfoAsync();
         }
     }
     render() {
@@ -57,8 +57,8 @@ class BLISAppsHomepage extends React.Component<Props, any> {
 
 const mapDispatchToProps = (dispatch: any) => {
   return bindActionCreators({
-    fetchApplications: fetchApplicationsAsync,
-    fetchBotInfo: fetchBotInfoAsync
+    fetchApplicationsAsync,
+    fetchBotInfoAsync
   }, dispatch);
 }
 

--- a/src/containers/BLISAppsList.tsx
+++ b/src/containers/BLISAppsList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { returntypeof } from 'react-redux-typescript';
-import { fetchAllActionsAsync, fetchAllEntitiesAsync, fetchApplicationsAsync, fetchAllTrainDialogsAsync, fetchAllLogDialogsAsync, fetchAllChatSessionsAsync, fetchAllTeachSessionsAsync } from '../actions/fetchActions';
-import { setCurrentBLISApp, setDisplayMode } from '../actions/displayActions';
+import { fetchAllActionsAsync, fetchAllEntitiesAsync, fetchAllTrainDialogsAsync, fetchAllLogDialogsAsync, fetchAllChatSessionsAsync } from '../actions/fetchActions';
+import { setCurrentBLISApp } from '../actions/displayActions';
 import { deleteBLISApplicationAsync } from '../actions/deleteActions'
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -70,7 +70,7 @@ class BLISAppsList extends React.Component<Props, any> {
     }
     deleteApp() {
         let blisAppToDelete: BlisAppBase = this.props.blisApps.all.find((app: BlisAppBase) => app.appId == this.state.appIDToDelete);
-        this.props.deleteBLISApplication(this.props.user.key, this.state.appIDToDelete, blisAppToDelete);
+        this.props.deleteBLISApplicationAsync(this.props.user.key, this.state.appIDToDelete, blisAppToDelete);
         this.setState({
             confirmDeleteAppModalOpen: false,
             appIDToDelete: null,
@@ -92,11 +92,11 @@ class BLISAppsList extends React.Component<Props, any> {
     BLISAppSelected(appName: string) {
         let appSelected = this.props.blisApps.all.find((app: BlisAppBase) => app.appName == appName);
         this.props.setCurrentBLISApp(this.props.user.key, appSelected);
-        this.props.fetchAllActions(this.props.user.key, appSelected.appId);
-        this.props.fetchAllEntities(this.props.user.key, appSelected.appId);
-        this.props.fetchAllTrainDialogs(this.props.user.key, appSelected.appId);
-        this.props.fetchAllLogDialogs(this.props.user.key, appSelected.appId);
-        this.props.fetchAllChatSessions(this.props.user.key, appSelected.appId);
+        this.props.fetchAllActionsAsync(this.props.user.key, appSelected.appId);
+        this.props.fetchAllEntitiesAsync(this.props.user.key, appSelected.appId);
+        this.props.fetchAllTrainDialogsAsync(this.props.user.key, appSelected.appId);
+        this.props.fetchAllLogDialogsAsync(this.props.user.key, appSelected.appId);
+        this.props.fetchAllChatSessionsAsync(this.props.user.key, appSelected.appId);
         // this.props.fetchAllTeachSessions(this.props.user.key, appSelected.appId);
     }
     onColumnClick(event: any, column : any) {
@@ -201,16 +201,13 @@ class BLISAppsList extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        fetchApplications: fetchApplicationsAsync,
-        fetchAllActions: fetchAllActionsAsync,
-        fetchAllEntities: fetchAllEntitiesAsync,
-        fetchAllTrainDialogs: fetchAllTrainDialogsAsync,
-        fetchAllLogDialogs: fetchAllLogDialogsAsync,
-        setCurrentBLISApp: setCurrentBLISApp,
-        setDisplayMode: setDisplayMode,
-        deleteBLISApplication: deleteBLISApplicationAsync,
-        fetchAllChatSessions: fetchAllChatSessionsAsync,
-        fetchAllTeachSessions: fetchAllTeachSessionsAsync
+        fetchAllActionsAsync,
+        fetchAllEntitiesAsync,
+        fetchAllTrainDialogsAsync,
+        fetchAllLogDialogsAsync,
+        setCurrentBLISApp,
+        deleteBLISApplicationAsync,
+        fetchAllChatSessionsAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/ChatSessionAdmin.tsx
+++ b/src/containers/ChatSessionAdmin.tsx
@@ -21,7 +21,7 @@ class ChatSessionAdmin extends React.Component<Props, any> {
         // TODO: Add confirmation modal
         this.props.setDisplayMode(DisplayMode.AppAdmin);
         let currentAppId: string = this.props.apps.current.appId;
-        this.props.deleteChatSession(this.props.userKey, this.props.chatSession, currentAppId);
+        this.props.deleteChatSessionAsync(this.props.userKey, this.props.chatSession, currentAppId);
     }
     handleCloseModal() {
         this.setState({
@@ -43,8 +43,8 @@ class ChatSessionAdmin extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        setDisplayMode: setDisplayMode,
-        deleteChatSession: deleteChatSessionAsync
+        setDisplayMode,
+        deleteChatSessionAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/ChatSessionWindow.tsx
+++ b/src/containers/ChatSessionWindow.tsx
@@ -23,14 +23,14 @@ class SessionWindow extends React.Component<Props, any> {
     }
     componentWillMount() {
         let currentAppId: string = this.props.apps.current.appId;
-        this.props.createChatSession(this.props.userKey, this.state.chatSession, currentAppId);
+        this.props.createChatSessionAsync(this.props.userKey, this.state.chatSession, currentAppId);
     }
     handleQuit() {
         this.props.setDisplayMode(DisplayMode.AppAdmin);
         let currentAppId: string = this.props.apps.current.appId;
 
         if (this.props.chatSession.current !== null) {
-            this.props.deleteChatSession(this.props.userKey, this.props.chatSession.current, currentAppId)
+            this.props.deleteChatSessionAsync(this.props.userKey, this.props.chatSession.current, currentAppId)
         }
     }
     render() {
@@ -63,9 +63,9 @@ class SessionWindow extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        createChatSession: createChatSessionAsync,
-        deleteChatSession: deleteChatSessionAsync,
-        setDisplayMode: setDisplayMode
+        createChatSessionAsync,
+        deleteChatSessionAsync,
+        setDisplayMode
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/EntitiesList.tsx
+++ b/src/containers/EntitiesList.tsx
@@ -79,7 +79,7 @@ class EntitiesList extends React.Component<Props, any> {
     deleteSelectedEntity() {
         let currentAppId: string = this.props.apps.current.appId;
         let entityToDelete: EntityBase = this.props.entities.find((a: EntityBase) => a.entityId == this.state.entityIDToDelete)
-        this.props.deleteEntity(this.props.userKey, this.state.entityIDToDelete, entityToDelete, currentAppId)
+        this.props.deleteEntityAsync(this.props.userKey, this.state.entityIDToDelete, entityToDelete, currentAppId)
         this.setState({
             confirmDeleteEntityModalOpen: false,
             entityIDToDelete: null
@@ -288,7 +288,7 @@ class EntitiesList extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        deleteEntity: deleteEntityAsync
+        deleteEntityAsync
     }, dispatch)
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/EntityCreatorEditor.tsx
+++ b/src/containers/EntityCreatorEditor.tsx
@@ -59,7 +59,7 @@ class EntityCreatorEditor extends React.Component<Props, any> {
             packageDeletionId: null
         })
         if (this.state.editing === false) {
-            this.props.createEntity(this.props.userKey, entityToAdd, currentAppId);
+            this.props.createEntityAsync(this.props.userKey, entityToAdd, currentAppId);
         } else {
             this.editEntity(entityToAdd);
         }
@@ -68,7 +68,7 @@ class EntityCreatorEditor extends React.Component<Props, any> {
     }
     editEntity(ent: EntityBase) {
         ent.entityId = this.props.entity.entityId;
-        this.props.editEntity(this.props.userKey, ent);
+        this.props.editEntityAsync(this.props.userKey, ent);
     }
     nameChanged(text: string) {
         this.setState({
@@ -187,8 +187,8 @@ class EntityCreatorEditor extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        createEntity: createEntityAsync,
-        editEntity: editEntityAsync
+        createEntityAsync,
+        editEntityAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {

--- a/src/containers/Error.tsx
+++ b/src/containers/Error.tsx
@@ -54,7 +54,7 @@ class UIError extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        clearErrorDisplay: clearErrorDisplay
+        clearErrorDisplay
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/ExtractorResponseEditor.tsx
+++ b/src/containers/ExtractorResponseEditor.tsx
@@ -752,8 +752,8 @@ class ExtractorResponseEditor extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        updateExtractResponse: updateExtractResponse,
-        removeExtractResponse: removeExtractResponse
+        updateExtractResponse,
+        removeExtractResponse
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {

--- a/src/containers/ExtractorTextVariationCreator.tsx
+++ b/src/containers/ExtractorTextVariationCreator.tsx
@@ -27,7 +27,7 @@ class ExtractorTextVariationCreator extends React.Component<Props, any> {
         let appId: string = this.props.apps.current.appId;
         let teachId: string = this.props.teachSessions.current.teachId;
         let userInput = new UserInput({text: this.state.variationValue})
-        this.props.runExtractor(this.props.user.key, appId, teachId, userInput);
+        this.props.runExtractorAsync(this.props.user.key, appId, teachId, userInput);
         this.setState({
             variationValue: ''
         })
@@ -54,7 +54,7 @@ class ExtractorTextVariationCreator extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        runExtractor: runExtractorAsync
+        runExtractorAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {

--- a/src/containers/TeachSessionExtractor.tsx
+++ b/src/containers/TeachSessionExtractor.tsx
@@ -98,7 +98,7 @@ class TeachSessionExtractor extends React.Component<Props, any> {
 
         let appId: string = this.props.apps.current.appId;
         let teachId: string = this.props.teachSession.current.teachId;
-        this.props.runScorer(this.props.user.key, appId, teachId, uiScoreInput);
+        this.props.runScorerAsync(this.props.user.key, appId, teachId, uiScoreInput);
     }
     render() {
         if (!this.props.teachSession.extractResponses[0])  {
@@ -175,7 +175,7 @@ class TeachSessionExtractor extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        runScorer: runScorerAsync
+        runScorerAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {

--- a/src/containers/TeachSessionMemory.tsx
+++ b/src/containers/TeachSessionMemory.tsx
@@ -3,7 +3,6 @@ import { returntypeof } from 'react-redux-typescript';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { State } from '../types'
-import { setDisplayMode } from '../actions/displayActions'
 import { IColumn, DetailsList, CheckboxVisibility } from 'office-ui-fabric-react';
 import { Memory, EntityBase } from 'blis-models'
 
@@ -128,7 +127,6 @@ class TeachSessionMemory extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        setDisplayMode: setDisplayMode
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {

--- a/src/containers/TeachSessionScorer.tsx
+++ b/src/containers/TeachSessionScorer.tsx
@@ -203,7 +203,7 @@ class TeachSessionScorer extends React.Component<Props, any> {
         // Pass score input (minus extractor step) for subsequent actions when this one is non-terminal
         let uiScoreInput = {...this.props.teachSession.uiScoreInput, trainExtractorStep: null};
 
-        this.props.postScorerFeedback(this.props.user.key, appId, teachId, trainScorerStep, waitForUser, uiScoreInput);
+        this.props.postScorerFeedbackAsync(this.props.user.key, appId, teachId, trainScorerStep, waitForUser, uiScoreInput);
     }
     /** Check if entity is in memory and return it's name */
     entityInMemory(entityId : string) : {match: boolean, name: string} {
@@ -402,8 +402,8 @@ class TeachSessionScorer extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        postScorerFeedback: postScorerFeedbackAsync,
-        toggleAutoTeach: toggleAutoTeach
+        postScorerFeedbackAsync,
+        toggleAutoTeach
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {

--- a/src/containers/TeachSessionWindow.tsx
+++ b/src/containers/TeachSessionWindow.tsx
@@ -24,17 +24,17 @@ class TeachWindow extends React.Component<Props, any> {
     }
     componentWillMount() {
         let currentAppId: string = this.props.apps.current.appId;
-        this.props.createTeachSession(this.props.user.key, this.state.teachSession, currentAppId)
+        this.props.createTeachSessionAsync(this.props.user.key, this.state.teachSession, currentAppId)
     }
     handleAbandon() {
         this.props.setDisplayMode(DisplayMode.AppAdmin);
         let currentAppId: string = this.props.apps.current.appId;
-        this.props.deleteTeachSession(this.props.user.key, this.props.teachSession.current, currentAppId, false); // False = abandon
+        this.props.deleteTeachSessionAsync(this.props.user.key, this.props.teachSession.current, currentAppId, false); // False = abandon
     }
     handleSave() {
         this.props.setDisplayMode(DisplayMode.AppAdmin);
         let currentAppId: string = this.props.apps.current.appId;
-        this.props.deleteTeachSession(this.props.user.key, this.props.teachSession.current, currentAppId, true); // True = save to train dialog
+        this.props.deleteTeachSessionAsync(this.props.user.key, this.props.teachSession.current, currentAppId, true); // True = save to train dialog
     }
     confirmDelete() {
         this.setState({
@@ -105,10 +105,10 @@ class TeachWindow extends React.Component<Props, any> {
 
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        createTeachSession: createTeachSessionAsync,
-        deleteTeachSession: deleteTeachSessionAsync,
-        setDisplayMode: setDisplayMode,
-        toggleAutoTeach: toggleAutoTeach
+        createTeachSessionAsync,
+        deleteTeachSessionAsync,
+        setDisplayMode,
+        toggleAutoTeach
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/TrainDialogWindow.tsx
+++ b/src/containers/TrainDialogWindow.tsx
@@ -9,7 +9,7 @@ import { DisplayMode } from '../types/const';
 import Webchat from './Webchat'
 import TrainDialogAdmin from './TrainDialogAdmin'
 import { ActionBase } from 'blis-models'
-import { deleteChatSessionAsync, deleteTrainDialogAsync } from '../actions/deleteActions'
+import { deleteTrainDialogAsync } from '../actions/deleteActions'
 import ConfirmDeleteModal from '../components/ConfirmDeleteModal';
 import { setDisplayMode } from '../actions/displayActions'
 import { Activity } from 'botframework-directlinejs';
@@ -48,7 +48,7 @@ class TrainDialogWindow extends React.Component<Props, ComponentState> {
     }
     deleteSelectedDialog() {
         let currentAppId: string = this.props.apps.current.appId;
-        this.props.deleteTrainDialog(this.props.userKey, this.props.trainDialog, currentAppId);
+        this.props.deleteTrainDialogAsync(this.props.userKey, this.props.trainDialog, currentAppId);
         this.props.setDisplayMode(DisplayMode.AppAdmin);
         this.setState({
             confirmDeleteModalOpen: false,
@@ -126,9 +126,8 @@ class TrainDialogWindow extends React.Component<Props, ComponentState> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        deleteChatSession: deleteChatSessionAsync,
-        deleteTrainDialog: deleteTrainDialogAsync,
-        setDisplayMode: setDisplayMode
+        deleteTrainDialogAsync,
+        setDisplayMode
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/TrainDialogsList.tsx
+++ b/src/containers/TrainDialogsList.tsx
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import TrainingGroundArenaHeader from '../components/TrainingGroundArenaHeader'
 import { DetailsList, CommandButton, CheckboxVisibility, IColumn, SearchBox } from 'office-ui-fabric-react';
-import { setDisplayMode, setCurrentTrainDialog, setCurrentTeachSession } from '../actions/displayActions'
+import { setDisplayMode, setCurrentTrainDialog } from '../actions/displayActions'
 import { createTrainDialog } from '../actions/createActions'
 import { fetchAllTrainDialogsAsync } from '../actions/fetchActions';
 import { State } from '../types'
@@ -179,11 +179,10 @@ class TrainDialogsList extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        setDisplayMode: setDisplayMode,
-        setCurrentTrainDialog: setCurrentTrainDialog,
-        setCurrentTeachSession: setCurrentTeachSession,
-        createTrainDialog: createTrainDialog,
-        fetchAllTrainDialogs : fetchAllTrainDialogsAsync,
+        setDisplayMode,
+        setCurrentTrainDialog,
+        createTrainDialog,
+        fetchAllTrainDialogsAsync,
     }, dispatch)
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/UserLogin.tsx
+++ b/src/containers/UserLogin.tsx
@@ -132,9 +132,9 @@ class UserLogin extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        setUser: setUser,
-        logout: logout,
-        setLoginDisplay: setLoginDisplay
+        setUser,
+        logout,
+        setLoginDisplay
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/containers/Webchat.tsx
+++ b/src/containers/Webchat.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { returntypeof } from 'react-redux-typescript';
-import { toggleTrainDialog, addMessageToTeachConversationStack, addMessageToChatConversationStack } from '../actions/displayActions';
+import { addMessageToTeachConversationStack, addMessageToChatConversationStack } from '../actions/displayActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { State } from '../types';
@@ -72,7 +72,7 @@ class Webchat extends React.Component<Props, any> {
                             let userInput = new UserInput({ text: activity.text});
                             let appId: string = this.props.apps.current.appId;
                             let teachId: string = this.props.teachSessions.current.teachId;
-                            this.props.runExtractor(this.props.user.key, appId, teachId, userInput);
+                            this.props.runExtractorAsync(this.props.user.key, appId, teachId, userInput);
     
                         } else {
                             this.props.addMessageToChatConversationStack(activity)
@@ -111,11 +111,10 @@ class Webchat extends React.Component<Props, any> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        toggleTrainDialog: toggleTrainDialog,
-        setTrainDialogView: setTrainDialogView,
-        addMessageToTeachConversationStack: addMessageToTeachConversationStack,
-        addMessageToChatConversationStack: addMessageToChatConversationStack,
-        runExtractor: runExtractorAsync
+        setTrainDialogView,
+        addMessageToTeachConversationStack,
+        addMessageToChatConversationStack,
+        runExtractorAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {


### PR DESCRIPTION
By using the short-hand syntax for object properties TypeScript will show references from the imported action all the way on props.

This has two benefits:
- Find References: Allows an easy way to determine if the action is actually used
- Refactor Rename: Will rename the action an it's usage in all components instead of having to update all components individually which is tedious