### PR TITLE
Remove incorrect call to deleteTeachSessionAsync before user has confirmed the delete.

### DIFF
--- a/src/containers/TeachSessionWindow.tsx
+++ b/src/containers/TeachSessionWindow.tsx
@@ -40,8 +40,6 @@ class TeachWindow extends React.Component<Props, ComponentState> {
         this.setState({
             isConfirmDeleteOpen: true
         })
-        let currentAppId: string = this.props.apps.current.appId;
-        this.props.deleteTeachSessionAsync(this.props.user.key, this.props.teachSession.current, currentAppId, false); // False = abandon
     }
 
     onClickSave() {


### PR DESCRIPTION
Looks like the earlier PR which broke train dialog view also was attempting to delete train dialogs before the user has confirmed to delete the dialog.  If the user clicks cancel it should not delete but resume.