### PR TITLE
Remove TypeScript anti-patterns.

### DIFF
--- a/src/containers/ActionResponseCreatorEditor.tsx
+++ b/src/containers/ActionResponseCreatorEditor.tsx
@@ -114,7 +114,7 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
     }
     componentWillReceiveProps(p: Props) {
         if (p.open === true && this.state.open === true) {
-            let entities = this.props.entities.map((e: EntityBase) => {
+            let entities = this.props.entities.map(e => {
                 return {
                     key: e.entityName,
                     name: e.entityName
@@ -130,22 +130,20 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
                 this.setState({ ...initState, open: p.open });
             } else {
                 // we are editing the action and need to load necessary properties
-                let entities = this.props.entities.map((e: EntityBase) => {
-                    return {
+                let entities = this.props.entities.map<EntityPickerObject>(e =>
+                    ({
                         key: e.entityName,
                         name: e.entityName
-                    }
-                })
-                let requiredEntities: EntityPickerObject[] = p.blisAction.requiredEntities.map((entityId: string) => {
-                    let found: EntityBase = this.props.entities.find((e: EntityBase) => e.entityId == entityId);
+                    }))
+                let requiredEntities = p.blisAction.requiredEntities.map<EntityPickerObject>(entityId => {
+                    let found = this.props.entities.find(e => e.entityId == entityId);
                     return {
                         key: found.entityName,
                         name: found.entityName
                     }
                 })
-                let negativeEntities: EntityPickerObject[] = p.blisAction.negativeEntities.map((entityId: string) => {
-                    let found: EntityBase = this.props.entities.find((e: EntityBase) => e.entityId == entityId);
-
+                let negativeEntities: EntityPickerObject[] = p.blisAction.negativeEntities.map(entityId => {
+                    let found = this.props.entities.find(e => e.entityId == entityId);
                     return {
                         key: found.entityName,
                         name: found.entityName
@@ -255,15 +253,15 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
     }
     createOnClick() {
         let currentAppId: string = this.props.blisApps.current.appId;
-        let requiredEntities = this.state.reqEntitiesVal.map((req: EntityPickerObject) => {
-            let found: EntityBase = this.props.entities.find((e: EntityBase) => e.entityName == req.key)
+        let requiredEntities = this.state.reqEntitiesVal.map(req => {
+            let found = this.props.entities.find(e => e.entityName == req.key)
             return found.entityId
         })
-        let negativeEntities = this.state.negEntitiesVal.map((neg: EntityPickerObject) => {
-            let found: EntityBase = this.props.entities.find((e: EntityBase) => e.entityName == neg.key)
+        let negativeEntities = this.state.negEntitiesVal.map(neg => {
+            let found = this.props.entities.find(e => e.entityName == neg.key)
             return found.entityId
         })
-        let suggestedEntity: EntityBase = this.state.suggEntitiesVal[0] ? this.props.entities.find((e: EntityBase) => e.entityName == this.state.suggEntitiesVal[0].name) : null;
+        let suggestedEntity = this.state.suggEntitiesVal[0] ? this.props.entities.find(e => e.entityName == this.state.suggEntitiesVal[0].name) : null;
 
         let meta = new ActionMetaData({
             actionType: this.state.actionTypeVal,
@@ -307,63 +305,36 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
             waitVal: !this.state.waitVal,
         })
     }
-    actionTypeChanged(obj: { text: string }) {
+    actionTypeChanged(obj: TextObject) {
         this.setState({
             actionTypeVal: obj.text,
         })
     }
-    apiChanged(obj: { text: string }) {
+    apiChanged(obj: TextObject) {
         this.setState({
             apiVal: obj.text,
         })
     }
-    requiredEntityOnResolve(filterText: string, tagList: EntityPickerObject[]) {
+    requiredEntityOnResolve(filterText: string, tagList: EntityPickerObject[]): EntityPickerObject[] {
         //required entites available should exclude all saved entities
-        let entList = filterText ? this.state.availableRequiredEntities.filter((ent: EntityPickerObject) => ent.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0).filter((item: EntityPickerObject) => !this.listContainsDocument(item, tagList)) : [];
+        let entList = filterText ? this.state.availableRequiredEntities.filter(ent => ent.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0).filter(item => !this.listContainsDocument(item, tagList)) : [];
         let usedEntities = this.state.reqEntitiesVal.concat(this.state.negEntitiesVal).concat(this.state.suggEntitiesVal)
-        let entListToReturn = entList.filter((e: EntityPickerObject) => {
-            let decision: boolean = true;
-            usedEntities.map((u: EntityPickerObject) => {
-                if (e.key == u.key) {
-                    decision = false;
-                }
-            })
-            return decision;
-        })
-        return entListToReturn;
+        return entList.filter(e => !usedEntities.some(u => e.key === u.key))
     }
-    negativeEntityOnResolve(filterText: string, tagList: EntityPickerObject[]) {
+    negativeEntityOnResolve(filterText: string, tagList: EntityPickerObject[]): EntityPickerObject[] {
         //negative entites available should exclude those in required entities, and its own saved entities, but not suggested ones
-        let entList = filterText ? this.state.availableRequiredEntities.filter((ent: EntityPickerObject) => ent.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0).filter((item: EntityPickerObject) => !this.listContainsDocument(item, tagList)) : [];
+        let entList = filterText ? this.state.availableRequiredEntities.filter(ent => ent.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0).filter(item => !this.listContainsDocument(item, tagList)) : [];
         let usedEntities = this.state.reqEntitiesVal.concat(this.state.negEntitiesVal)
-        let entListToReturn = entList.filter((e: EntityPickerObject) => {
-            let decision: boolean = true;
-            usedEntities.map((u: EntityPickerObject) => {
-                if (e.key == u.key) {
-                    decision = false;
-                }
-            })
-            return decision;
-        })
-        return entListToReturn;
+        return entList.filter(e => !usedEntities.some(u => e.key === u.key))
     }
-    suggestedEntityOnResolve(filterText: string, tagList: EntityPickerObject[]) {
+    suggestedEntityOnResolve(filterText: string, tagList: EntityPickerObject[]): EntityPickerObject[] {
         //suggested entites available should exclude those in required entities, and its own saved entities, but not negative ones
         if (this.state.suggEntitiesVal.length > 0) {
             return [];
         }
         let entList = filterText ? this.state.availableRequiredEntities.filter((ent: EntityPickerObject) => ent.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0).filter((item: EntityPickerObject) => !this.listContainsDocument(item, tagList)) : [];
         let usedEntities = this.state.reqEntitiesVal.concat(this.state.suggEntitiesVal)
-        let entListToReturn = entList.filter((e: EntityPickerObject) => {
-            let decision: boolean = true;
-            usedEntities.map((u: EntityPickerObject) => {
-                if (e.key == u.key) {
-                    decision = false;
-                }
-            })
-            return decision;
-        })
-        return entListToReturn;
+        return entList.filter(e => !usedEntities.some(u => e.key === u.key))
     }
 
     listContainsDocument(tag: EntityPickerObject, tagList: EntityPickerObject[]) {
@@ -381,10 +352,10 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
         if (items.length < this.state.negEntitiesVal.length) {
             //we deleted one, need to make sure it isnt a suggested entity;
             if (this.state.suggEntitiesVal.length == 1) {
-                let suggestedEntity: EntityPickerObject = this.state.suggEntitiesVal[0];
-                let deletedNegativeEntity: EntityPickerObject = this.findDeletedEntity(items, this.state.negEntitiesVal);
+                let suggestedEntity = this.state.suggEntitiesVal[0];
+                let deletedNegativeEntity = this.findDeletedEntity(items, this.state.negEntitiesVal);
                 if (suggestedEntity.name == deletedNegativeEntity.name) {
-                    let negativeEntities: EntityPickerObject[] = this.state.negEntitiesVal;
+                    let negativeEntities = this.state.negEntitiesVal;
                     //do nothing. Picker will internally update so we need to overwrite that
                     this.setState({
                         negEntitiesVal: negativeEntities,
@@ -423,7 +394,7 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
     }
 
     payloadChanged(text: string) {
-        let specialIndexes: SpecialIndex[] = this.updateSpecialCharIndexesToDisregard(text);
+        let specialIndexes = this.updateSpecialCharIndexesToDisregard(text);
         this.checkForSpecialCharacters(text, specialIndexes);
         this.setState({
             payloadVal: text
@@ -435,7 +406,7 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
         let updatedIndex = this.findUpdatedIndex(newPayload);
         if (newPayload.length > this.state.payloadVal.length) {
             //we added a letter. Find which index was updated. Increment every index in the current special indexes array >= to the updated index
-            indexesToSet = this.state.specialCharIndexesToDisregard.map((i: SpecialIndex) => {
+            indexesToSet = this.state.specialCharIndexesToDisregard.map(i => {
                 if (i.index >= updatedIndex) {
                     return { ...i, index: i.index + 1 }
                 } else {
@@ -445,10 +416,10 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
         } else {
             //we deleted a letter. Find which index was updated. Decrement every index in the current special indexes array <= to the updated index
             //If the character deleted was actually one of the special characters, remove it from the array.
-            indexesToSet = this.state.specialCharIndexesToDisregard.filter((s: SpecialIndex) => {
-                if (s.index == updatedIndex) {
+            indexesToSet = this.state.specialCharIndexesToDisregard.filter(specialCharIndex => {
+                if (specialCharIndex.index == updatedIndex) {
                     //we have deleted a special character. Need to remove it from the array and remove its corresponding entity from the required entities picker
-                    let newRequiredEntities = this.state.reqEntitiesVal.filter((re: EntityPickerObject) => re.name !== s.entityPickerObject.name);
+                    let newRequiredEntities = this.state.reqEntitiesVal.filter(re => re.name !== specialCharIndex.entityPickerObject.name);
                     this.setState({
                         reqEntitiesVal: newRequiredEntities,
                         defaultRequiredEntities: newRequiredEntities,
@@ -458,11 +429,11 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
                 } else {
                     return true;
                 }
-            }).map((i: SpecialIndex) => {
-                if (i.index > updatedIndex) {
-                    return { ...i, index: i.index - 1 }
+            }).map(specialCharIndex => {
+                if (specialCharIndex.index > updatedIndex) {
+                    return { ...specialCharIndex, index: specialCharIndex.index - 1 }
                 } else {
-                    return i
+                    return specialCharIndex
                 }
             })
         }
@@ -490,11 +461,11 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
             //we only care about $ if dropdown isnt displayed yet
             for (let letter of text) {
                 if (letter === "$") {
-                    let indexFound: SpecialIndex = specialIndexes.find((i: SpecialIndex) => i.index == pixels);
+                    let indexFound = specialIndexes.find(specialIndex => specialIndex.index == pixels);
                     if (!indexFound) {
                         //need to see if there is already text following the special character
-                        let isLastCharacter: boolean = text.length == (pixels + 1);
-                        let precedesSpace: boolean = text[pixels + 1] ? text[pixels + 1] == " " : false;
+                        let isLastCharacter = text.length == (pixels + 1);
+                        let precedesSpace = text[pixels + 1] ? text[pixels + 1] === " " : false;
                         if (isLastCharacter || precedesSpace) {
                             this.setState({
                                 displayAutocomplete: true,

--- a/src/containers/ActionResponsesList.tsx
+++ b/src/containers/ActionResponsesList.tsx
@@ -6,7 +6,7 @@ import TrainingGroundArenaHeader from '../components/TrainingGroundArenaHeader';
 import { deleteActionAsync } from '../actions/deleteActions'
 import { DetailsList, CommandButton, Link, CheckboxVisibility, List, IColumn, SearchBox } from 'office-ui-fabric-react';
 import ConfirmDeleteModal from '../components/ConfirmDeleteModal';
-import { BlisAppBase, ActionBase, EntityBase, ModelUtils } from 'blis-models'
+import { BlisAppBase, ActionBase, ModelUtils } from 'blis-models'
 import ActionResponseCreatorEditor from './ActionResponseCreatorEditor';
 import EntityTile from '../components/EntityTile';
 import { State } from '../types'
@@ -150,7 +150,7 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
             createEditModalOpen: true
         })
     }
-    onColumnClick(event: any, column: any) {
+    onColumnClick(event: any, column: IColumn) {
         let { columns } = this.state;
         let isSortedDescending = column.isSortedDescending;
 
@@ -161,7 +161,7 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
 
         // Reset the items and columns to match the state.
         this.setState({
-            columns: columns.map((col: any) => {
+            columns: columns.map(col => {
                 col.isSorted = (col.key === column.key);
 
                 if (col.isSorted) {
@@ -173,7 +173,7 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
             sortColumn: column
         });
     }
-    renderItemColumn(item?: any, index?: number, column?: IColumn) {
+    renderItemColumn(item?: ActionBase, index?: number, column?: IColumn) {
         let fieldContent = item[column.fieldName];
         switch (column.key) {
             case 'wait':
@@ -228,10 +228,7 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
         }
     }
     renderEntityList(entityIDs: string[]) {
-        let entityObjects: EntityBase[];
-        entityObjects = entityIDs.map((id: string) => {
-            return this.props.entities.find((e: EntityBase) => e.entityId == id)
-        })
+        let entityObjects = entityIDs.map(id => this.props.entities.find(e => e.entityId == id))
         return (
             <List
                 items={entityObjects}
@@ -241,13 +238,13 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
             />
         )
     }
-    getValue(entity: any, col: IColumn): any {
+    getValue(action: ActionBase, col: IColumn): any {
         let value;
         if (col.key == 'actionType') {
-            value = entity.metadata.actionType;
+            value = action.metadata.actionType;
         }
         else {
-            value = entity[col.fieldName];
+            value = action[col.fieldName];
         }
 
         if (typeof value == 'string' || value instanceof String) {
@@ -259,15 +256,15 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
     renderActionItems(): ActionBase[] {
         //runs when user changes the text 
         let lcString = this.state.searchValue.toLowerCase();
-        let filteredActions = this.props.actions.filter((a: ActionBase) => {
+        let filteredActions = this.props.actions.filter(a => {
             let nameMatch = a.payload.toLowerCase().includes(lcString);
             let typeMatch = a.metadata.actionType ? a.metadata.actionType.toLowerCase().includes(lcString) : true;
-            let negativeEntities: string[] = a.negativeEntities.map((entityId: string) => {
-                let found: EntityBase = this.props.entities.find((e: EntityBase) => e.entityId == entityId);
+            let negativeEntities = a.negativeEntities.map(entityId => {
+                let found = this.props.entities.find(e => e.entityId == entityId);
                 return found.entityName;
             })
-            let positiveEntities: string[] = a.requiredEntities.map((entityId: string) => {
-                let found: EntityBase = this.props.entities.find((e: EntityBase) => e.entityId == entityId);
+            let positiveEntities = a.requiredEntities.map(entityId => {
+                let found = this.props.entities.find(e => e.entityId == entityId);
                 return found.entityName;
             })
             let requiredEnts = positiveEntities.join('');

--- a/src/containers/EntitiesList.tsx
+++ b/src/containers/EntitiesList.tsx
@@ -8,7 +8,7 @@ import ConfirmDeleteModal from '../components/ConfirmDeleteModal';
 import { deleteEntityAsync } from '../actions/deleteActions'
 import { DetailsList, CommandButton, CheckboxVisibility, IColumn, SearchBox } from 'office-ui-fabric-react';
 import { State } from '../types';
-import { BlisAppBase, EntityBase, ActionBase } from 'blis-models'
+import { BlisAppBase, EntityBase } from 'blis-models'
 import { Modal } from 'office-ui-fabric-react/lib/Modal';
 import { findDOMNode } from 'react-dom';
 
@@ -91,7 +91,7 @@ class EntitiesList extends React.Component<Props, ComponentState> {
         findDOMNode<HTMLButtonElement>(this.refs.newEntity).focus();
     }
     deleteSelectedEntity() {
-        let entityToDelete: EntityBase = this.props.entities.find((a: EntityBase) => a.entityId == this.state.entityIDToDelete)
+        let entityToDelete = this.props.entities.find(entity => entity.entityId == this.state.entityIDToDelete)
         this.props.deleteEntityAsync(this.props.user.key, this.state.entityIDToDelete, entityToDelete, this.props.app.appId)
         this.setState({
             confirmDeleteEntityModalOpen: false,
@@ -121,14 +121,8 @@ class EntitiesList extends React.Component<Props, ComponentState> {
         }, 500);
     }
     openDeleteModal(guid: string) {
-        let tiedToAction: boolean;
-        this.props.actions.map((a: ActionBase) => {
-            if (a.negativeEntities.includes(guid) || a.requiredEntities.includes(guid)) {
-                tiedToAction = true;
-                return;
-            }
-        })
-        if (tiedToAction && tiedToAction === true) {
+        let tiedToAction = this.props.actions.some(a => a.negativeEntities.includes(guid) || a.requiredEntities.includes(guid))
+        if (tiedToAction === true) {
             this.setState({
                 errorModalOpen: true
             })
@@ -139,7 +133,7 @@ class EntitiesList extends React.Component<Props, ComponentState> {
             })
         }
     }
-    onColumnClick(event: any, column: any) {
+    onColumnClick(event: any, column: IColumn) {
         let { columns } = this.state;
         let isSortedDescending = column.isSortedDescending;
 
@@ -150,7 +144,7 @@ class EntitiesList extends React.Component<Props, ComponentState> {
 
         // Reset the items and columns to match the state.
         this.setState({
-            columns: columns.map((col: any) => {
+            columns: columns.map(col => {
                 col.isSorted = (col.key === column.key);
 
                 if (col.isSorted) {
@@ -163,7 +157,7 @@ class EntitiesList extends React.Component<Props, ComponentState> {
         });
     }
 
-    renderItemColumn(item?: any, index?: number, column?: IColumn) {
+    renderItemColumn(item?: EntityBase, index?: number, column?: IColumn) {
         let fieldContent = item[column.fieldName];
         switch (column.key) {
             case 'isBucketable':
@@ -191,7 +185,7 @@ class EntitiesList extends React.Component<Props, ComponentState> {
     renderEntityItems(): EntityBase[] {
         //runs when user changes the text or sort
         let lcString = this.state.searchValue.toLowerCase();
-        let filteredEntities = this.props.entities.filter((e: EntityBase) => {
+        let filteredEntities = this.props.entities.filter(e => {
             let nameMatch = e.entityName.toLowerCase().includes(lcString);
             let typeMatch = e.entityType.toLowerCase().includes(lcString);
             let match = nameMatch || typeMatch

--- a/src/containers/EntityCreatorEditor.tsx
+++ b/src/containers/EntityCreatorEditor.tsx
@@ -5,9 +5,9 @@ import { editEntityAsync } from '../actions/updateActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Modal } from 'office-ui-fabric-react/lib/Modal';
-import { CommandButton, Dropdown, DropdownMenuItemType, Checkbox } from 'office-ui-fabric-react';
+import { CommandButton, IDropdownOption, Dropdown, DropdownMenuItemType, Checkbox } from 'office-ui-fabric-react';
 import { TextFieldPlaceholder } from './TextFieldPlaceholder';
-import { State, PreBuiltEntities, LocalePreBuilts } from '../types';
+import { State, PreBuiltEntities } from '../types';
 import { EntityBase, EntityMetaData, EntityType } from 'blis-models'
 
 const initState: ComponentState = {
@@ -24,11 +24,6 @@ interface ComponentState {
     isBucketableVal: boolean
     isNegatableVal: boolean
     editing: boolean
-}
-
-interface IOption {
-    key: string
-    text: string
 }
 
 class EntityCreatorEditor extends React.Component<Props, ComponentState> {
@@ -54,7 +49,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
         }
     }
     createEntity() {
-        let currentAppId: string = this.props.blisApps.current.appId;
+        let currentAppId = this.props.blisApps.current.appId;
         let meta = new EntityMetaData({
             isBucket: this.state.isBucketableVal,
             isReversable: this.state.isNegatableVal,
@@ -86,7 +81,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
             entityNameVal: text
         })
     }
-    typeChanged(obj: IOption) {
+    typeChanged(obj: IDropdownOption) {
         this.setState({
             entityTypeVal: obj.text
         })
@@ -105,22 +100,18 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
         return value ? "" : "Required Value";
     }
     render() {
-        let vals: string[] = [EntityType.LOCAL, EntityType.LUIS]
-        let options: {}[] = vals.map<IOption>(v => {
-            return {
+        let options = [EntityType.LOCAL, EntityType.LUIS].map<IDropdownOption>(v =>
+            ({
                 key: v,
                 text: v
-            }
-        })
+            }))
+
         options.unshift({ key: 'BlisHeader', text: 'BLIS Entity Types', itemType: DropdownMenuItemType.Header })
         options.push({ key: 'divider', text: '-', itemType: DropdownMenuItemType.Divider })
         options.push({ key: 'LuisHeader', text: 'LUIS Pre-Built Entity Types', itemType: DropdownMenuItemType.Header })
 
-        let localePreBuilts: LocalePreBuilts = PreBuiltEntities.find((obj: LocalePreBuilts) => obj.locale == this.props.blisApps.current.locale)
-        let prebuiltVals: string[] = localePreBuilts.preBuiltEntities.map((entityName: string) => {
-            return entityName
-        })
-        prebuiltVals.map((entityName: string) => {
+        let localePreBuilts = PreBuiltEntities.find(obj => obj.locale === this.props.blisApps.current.locale)
+        localePreBuilts.preBuiltEntities.forEach(entityName => {
             options.push({
                 key: entityName,
                 text: entityName

--- a/src/containers/Error.tsx
+++ b/src/containers/Error.tsx
@@ -7,11 +7,6 @@ import { CommandButton } from 'office-ui-fabric-react';
 import { clearErrorDisplay } from '../actions/displayActions'
 import { State } from '../types'
 
-// TODO: This was unused, but interested what was this used for?
-// type CultureObject = {
-//     CultureCode: string;
-//     CultureName: string;
-// }
 class UIError extends React.Component<Props, any> {
     constructor(p: any) {
         super(p);

--- a/src/containers/ExtractorResponseEditor.tsx
+++ b/src/containers/ExtractorResponseEditor.tsx
@@ -94,12 +94,12 @@ const styles = {
 }
 
 interface ComponentState {
-    input: string,
-    predictedEntities: PredictedEntity[],
-    definitions: AppDefinition,
-    substringObjects: SubstringObject[],
-    substringsClicked: SubstringObject[],
-};
+    input: string
+    predictedEntities: PredictedEntity[]
+    definitions: AppDefinition
+    substringObjects: SubstringObject[]
+    substringsClicked: SubstringObject[]
+}
 
 class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
     constructor(p: any) {
@@ -109,7 +109,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
             predictedEntities: [],
             definitions: null,
             substringObjects: [],
-            substringsClicked: [],
+            substringsClicked: []
         }
         this.renderSubstringObject = this.renderSubstringObject.bind(this)
         this.createSubstringObjects = this.createSubstringObjects.bind(this)
@@ -152,15 +152,15 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
     }
     updateCurrentPredictedEntities(substringObjects: SubstringObject[]) {
         let predictions: PredictedEntity[] = [];
-        substringObjects.map((s: SubstringObject) => {
+        substringObjects.map(s => {
             if (s.entityId !== null) {
-                let predictedEntity: PredictedEntity = new PredictedEntity({
+                let predictedEntity = new PredictedEntity({
                     startCharIndex: s.startIndex,
                     endCharIndex: (s.startIndex + (s.text.length - 1)),
                     entityId: s.entityId,
                     entityName: s.entityName,
                     entityText: s.text,
-                    metadata: this.props.entities.find((e: EntityBase) => e.entityName == s.entityName).metadata,
+                    metadata: this.props.entities.find(e => e.entityName == s.entityName).metadata,
                     score: 1.0
                 });
                 predictions.push(predictedEntity);
@@ -181,11 +181,11 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
             end: null,
             entity: null
         }
-        predictedEntities.map((p: PredictedEntity) => {
+        predictedEntities.map(p => {
             if (count == 0) {
                 if (p.startCharIndex == 0) {
                     //handle the case where the first character of the input is part of an entity
-                    currentIndexGroup = { ...currentIndexGroup, end: p.endCharIndex + 1, entity: this.props.entities.find((e: EntityBase) => e.entityId == p.entityId) }
+                    currentIndexGroup = { ...currentIndexGroup, end: p.endCharIndex + 1, entity: this.props.entities.find(e => e.entityId == p.entityId) }
                     indexGroups.push(currentIndexGroup);
                     currentIndexGroup = {
                         start: p.endCharIndex + 1,
@@ -196,7 +196,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                     //handle the case where the first character of the input is part of a piece of regular text
                     currentIndexGroup = { ...currentIndexGroup, end: p.startCharIndex }
                     indexGroups.push(currentIndexGroup);
-                    currentIndexGroup = { ...currentIndexGroup, start: p.startCharIndex, end: p.endCharIndex + 1, entity: this.props.entities.find((e: EntityBase) => e.entityId == p.entityId) }
+                    currentIndexGroup = { ...currentIndexGroup, start: p.startCharIndex, end: p.endCharIndex + 1, entity: this.props.entities.find(e => e.entityId == p.entityId) }
                     indexGroups.push(currentIndexGroup);
                     currentIndexGroup = {
                         start: p.endCharIndex + 1,
@@ -207,7 +207,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
             } else {
                 if (currentIndexGroup.start == p.startCharIndex) {
                     //handle the case where the first character after the last entity is part of another entity
-                    currentIndexGroup = { ...currentIndexGroup, end: p.endCharIndex, entity: this.props.entities.find((e: EntityBase) => e.entityId == p.entityId) }
+                    currentIndexGroup = { ...currentIndexGroup, end: p.endCharIndex, entity: this.props.entities.find(e => e.entityId == p.entityId) }
                     indexGroups.push(currentIndexGroup);
                     currentIndexGroup = {
                         start: p.endCharIndex + 1,
@@ -218,7 +218,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                     //handle the case where the first character after the last entity is part of a piece of regular text
                     currentIndexGroup = { ...currentIndexGroup, end: p.startCharIndex }
                     indexGroups.push(currentIndexGroup);
-                    currentIndexGroup = { ...currentIndexGroup, start: p.startCharIndex, end: p.endCharIndex + 1, entity: this.props.entities.find((e: EntityBase) => e.entityId == p.entityId) }
+                    currentIndexGroup = { ...currentIndexGroup, start: p.startCharIndex, end: p.endCharIndex + 1, entity: this.props.entities.find(e => e.entityId == p.entityId) }
                     indexGroups.push(currentIndexGroup);
                     currentIndexGroup = {
                         start: p.endCharIndex + 1,
@@ -374,7 +374,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                         }
                     }
                 }
-                nonEntities.map((s: SubstringObject) => {
+                nonEntities.map(s => {
                     substringObjects.push(s)
                 })
             } else {
@@ -400,7 +400,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
     substringHasBeenClicked(s: SubstringObject): boolean {
         let result: boolean = false;
         if (this.state.substringsClicked.length > 0) {
-            this.state.substringsClicked.map((sub: SubstringObject) => {
+            this.state.substringsClicked.map(sub => {
                 if (sub.startIndex == s.startIndex) {
                     result = true
                 }
@@ -410,22 +410,22 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
     }
     findLeftMostClickedSubstring(): SubstringObject {
         let min: SubstringObject = this.state.substringsClicked[0];
-        this.state.substringsClicked.map((sub: SubstringObject) => {
+        this.state.substringsClicked.map(sub => {
             if (sub.startIndex < min.startIndex) {
                 min = sub
             }
         })
-        let objWithPersistentClassInfo = this.state.substringObjects.find((s: SubstringObject) => s.startIndex == min.startIndex)
+        let objWithPersistentClassInfo = this.state.substringObjects.find(s => s.startIndex == min.startIndex)
         return objWithPersistentClassInfo;
     }
     findRightMostClickedSubstring(): SubstringObject {
         let min: SubstringObject = this.state.substringsClicked[0];
-        this.state.substringsClicked.map((sub: SubstringObject) => {
+        this.state.substringsClicked.map(sub => {
             if (sub.startIndex > min.startIndex) {
                 min = sub
             }
         })
-        let objWithPersistentClassInfo = this.state.substringObjects.find((s: SubstringObject) => s.startIndex == min.startIndex)
+        let objWithPersistentClassInfo = this.state.substringObjects.find(s => s.startIndex == min.startIndex)
         return objWithPersistentClassInfo;
     }
     findIndexOfHoveredSubstring(hovered: SubstringObject): number {
@@ -439,11 +439,11 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
         return index;
     }
     isDefinedEntityBetweenClickedSubstrings(startIndex: number, endIndex: number): boolean {
-        let result: boolean = false;
+        let result = false;
         if (this.state.substringsClicked.length > 0) {
             // TODO: This array may have holes of undefined in it, how can it be iterated without filtring?
             let entityStartIndexes: number[] = this.state.substringObjects.map(s => (s.entityId !== null) ? s.startIndex : undefined)
-            entityStartIndexes.map((entityStartIndex: number) => {
+            entityStartIndexes.map(entityStartIndex => {
                 if (startIndex < entityStartIndex && endIndex > entityStartIndex) {
                     result = true
                 }
@@ -454,7 +454,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
     removeBracketsFromAllSelectedSubstrings() {
         let allObjects = this.state.substringObjects;
         let clickedObjects = this.state.substringsClicked;
-        clickedObjects.map((c: SubstringObject) => {
+        clickedObjects.map(c => {
             let indexOfClickedSubstring: number = this.findIndexOfHoveredSubstring(c);
             let newClickedSubstringObject = { ...c, leftBracketStyle: styles.leftBracketDisplayedWhite, rightBracketStyle: styles.rightBracketDisplayedWhite, dropdownStyle: styles.hidden }
             allObjects[indexOfClickedSubstring] = newClickedSubstringObject;
@@ -467,9 +467,9 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
         if (!this.props.canEdit) {
             return;
         }
-        let indexOfHoveredSubstring: number = this.findIndexOfHoveredSubstring(s);
+        let indexOfHoveredSubstring = this.findIndexOfHoveredSubstring(s);
         let allObjects = this.state.substringObjects;
-        let updateClickedSubstrings: boolean = true;
+        let updateClickedSubstrings = true;
         //hovering over a specified entity does nothing
         if (s.entityId === null) {
             if (this.state.substringsClicked.length == 0) {
@@ -489,14 +489,14 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                     updateClickedSubstrings = false
                 } else {
                     //we already have an entity clicked but not set, and this is a different string than has previously been clicked
-                    let left: SubstringObject = this.findLeftMostClickedSubstring();
-                    let right: SubstringObject = this.findRightMostClickedSubstring();
+                    let left = this.findLeftMostClickedSubstring();
+                    let right = this.findRightMostClickedSubstring();
                     if (s.startIndex < left.startIndex && (this.isDefinedEntityBetweenClickedSubstrings(s.startIndex, left.startIndex) == false)) {
                         //place a gray bracket to left of hovered substring
                         let newSubstringObj = { ...s, leftBracketStyle: styles.leftBracketDisplayedBlack }
                         allObjects[indexOfHoveredSubstring] = newSubstringObj;
                         //now remove the left bracket for the leftmost clicked substring object
-                        let indexOfClickedSubstring: number = this.findIndexOfHoveredSubstring(left);
+                        let indexOfClickedSubstring = this.findIndexOfHoveredSubstring(left);
                         let newClickedSubstringObject = { ...left, leftBracketStyle: styles.leftBracketDisplayedWhite, rightBracketStyle: styles.rightBracketDisplayedBlack };
                         allObjects[indexOfClickedSubstring] = newClickedSubstringObject;
                         this.setState({
@@ -507,7 +507,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                         let newSubstringObj = { ...s, rightBracketStyle: styles.rightBracketDisplayedBlack }
                         allObjects[indexOfHoveredSubstring] = newSubstringObj;
                         //now remove the right bracket for the rightmost clicked substring object
-                        let indexOfClickedSubstring: number = this.findIndexOfHoveredSubstring(right);
+                        let indexOfClickedSubstring = this.findIndexOfHoveredSubstring(right);
                         let newClickedSubstringObject = { ...right, rightBracketStyle: styles.rightBracketDisplayedWhite, leftBracketStyle: styles.leftBracketDisplayedBlack, }
                         allObjects[indexOfClickedSubstring] = newClickedSubstringObject;
                         this.setState({
@@ -540,7 +540,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
         if (!this.props.canEdit) {
             return;
         }
-        let indexOfHoveredSubstring: number = this.findIndexOfHoveredSubstring(s);
+        let indexOfHoveredSubstring = this.findIndexOfHoveredSubstring(s);
         let allObjects = this.state.substringObjects;
         let currentHoverIsPreviouslyClickedSubstring = this.substringHasBeenClicked(s)
 
@@ -555,14 +555,14 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                 })
             } else {
                 //weve clicked a string and need to extend the bracket
-                let left: SubstringObject = this.findLeftMostClickedSubstring();
-                let right: SubstringObject = this.findRightMostClickedSubstring();
+                let left = this.findLeftMostClickedSubstring();
+                let right = this.findRightMostClickedSubstring();
                 if (s.startIndex < left.startIndex && (this.isDefinedEntityBetweenClickedSubstrings(s.startIndex, left.startIndex) == false)) {
                     //place a gray bracket to left of hovered substring
                     let newSubstringObj = { ...s, leftBracketStyle: styles.leftBracketDisplayedGray }
                     allObjects[indexOfHoveredSubstring] = newSubstringObj;
                     //now remove the left bracket for the clicked substring object
-                    let indexOfClickedSubstring: number = this.findIndexOfHoveredSubstring(left);
+                    let indexOfClickedSubstring = this.findIndexOfHoveredSubstring(left);
                     let newClickedSubstringObject = { ...left, leftBracketStyle: styles.leftBracketDisplayedWhite, rightBracketStyle: styles.rightBracketDisplayedBlack };
                     allObjects[indexOfClickedSubstring] = newClickedSubstringObject;
                     this.setState({
@@ -573,7 +573,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                     let newSubstringObj = { ...s, rightBracketStyle: styles.rightBracketDisplayedGray }
                     allObjects[indexOfHoveredSubstring] = newSubstringObj;
                     //now remove the right bracket for the clicked substring object
-                    let indexOfClickedSubstring: number = this.findIndexOfHoveredSubstring(right);
+                    let indexOfClickedSubstring = this.findIndexOfHoveredSubstring(right);
                     let newClickedSubstringObject = { ...right, rightBracketStyle: styles.rightBracketDisplayedWhite, leftBracketStyle: styles.leftBracketDisplayedBlack, }
                     allObjects[indexOfClickedSubstring] = newClickedSubstringObject;
                     this.setState({
@@ -584,7 +584,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
         }
     }
     handleHoverOut(s: SubstringObject) {
-        let indexOfHoveredSubstring: number = this.findIndexOfHoveredSubstring(s);
+        let indexOfHoveredSubstring = this.findIndexOfHoveredSubstring(s);
         let allObjects = this.state.substringObjects;
         let currentHoverIsPreviouslyClickedSubstring = this.substringHasBeenClicked(s)
         if (s.entityId === null && currentHoverIsPreviouslyClickedSubstring == false) {
@@ -596,14 +596,14 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                     substringObjects: allObjects
                 })
             } else {
-                let left: SubstringObject = this.findLeftMostClickedSubstring();
-                let right: SubstringObject = this.findRightMostClickedSubstring();
+                let left = this.findLeftMostClickedSubstring();
+                let right = this.findRightMostClickedSubstring();
                 if (s.startIndex < left.startIndex && (this.isDefinedEntityBetweenClickedSubstrings(s.startIndex, left.startIndex) == false)) {
                     //place a gray bracket to left of hovered substring
                     let newSubstringObj = { ...s, leftBracketStyle: styles.leftBracketDisplayedWhite }
                     allObjects[indexOfHoveredSubstring] = newSubstringObj;
                     //now remove the left bracket for the clicked substring object
-                    let indexOfClickedSubstring: number = this.findIndexOfHoveredSubstring(left);
+                    let indexOfClickedSubstring = this.findIndexOfHoveredSubstring(left);
                     let newClickedSubstringObject = { ...left, leftBracketStyle: styles.leftBracketDisplayedBlack };
                     allObjects[indexOfClickedSubstring] = newClickedSubstringObject;
                     this.setState({
@@ -614,7 +614,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                     let newSubstringObj = { ...s, rightBracketStyle: styles.rightBracketDisplayedWhite }
                     allObjects[indexOfHoveredSubstring] = newSubstringObj;
                     //now remove the right bracket for the clicked substring object
-                    let indexOfClickedSubstring: number = this.findIndexOfHoveredSubstring(right);
+                    let indexOfClickedSubstring = this.findIndexOfHoveredSubstring(right);
                     let newClickedSubstringObject = { ...right, rightBracketStyle: styles.rightBracketDisplayedBlack }
                     allObjects[indexOfClickedSubstring] = newClickedSubstringObject;
                     this.setState({
@@ -626,7 +626,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
     }
     getFullStringBetweenSubstrings(left: SubstringObject, right: SubstringObject): string {
         let fullString: string = "";
-        this.state.substringObjects.map((s: SubstringObject) => {
+        this.state.substringObjects.map(s => {
             if ((s.startIndex >= left.startIndex) && (s.startIndex <= right.startIndex)) {
                 fullString += s.text;
             }
@@ -636,7 +636,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
     entitySelected(obj: { text: string }, substringClicked: SubstringObject) {
         //is this thing already an entity or was it a string before?
         let indexOfClickedSubstring: number = this.findIndexOfHoveredSubstring(substringClicked);
-        let entitySelected: EntityBase = this.props.entities.find((e: EntityBase) => e.entityName == obj.text)
+        let entitySelected = this.props.entities.find(e => e.entityName == obj.text)
         let allObjects = this.state.substringObjects;
 
         if (substringClicked.entityId === null) {
@@ -656,7 +656,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                 let allObjectsBeforeLeftmost: SubstringObject[] = []
                 let allObjectsAfterRightmost: SubstringObject[] = [];
 
-                this.state.substringObjects.map((s: SubstringObject) => {
+                this.state.substringObjects.map(s => {
                     if (s.startIndex < left.startIndex) {
                         allObjectsBeforeLeftmost.push(s);
                     } else if (s.startIndex > right.startIndex) {
@@ -691,24 +691,22 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
         this.updateCurrentPredictedEntities(allObjects)
     }
     getAlphabetizedEntityOptions(): IDropdownOption[] {
-        let luisEntities = this.props.entities.filter((e: EntityBase) => e.entityType == EntityType.LUIS);
-        let names: string[] = luisEntities.map((e: EntityBase) => {
-            return e.entityName;
-        })
+        let luisEntities = this.props.entities.filter(e => e.entityType == EntityType.LUIS);
+        let names: string[] = luisEntities.map(e => e.entityName)
         names.sort();
-        let options: IDropdownOption[] = names.map((name: string) => {
-            let ent: EntityBase = this.props.entities.find((e: EntityBase) => e.entityName == name);
+        return names.map<IDropdownOption>(name => {
+            let ent = this.props.entities.find(e => e.entityName == name);
             return {
                 key: ent.entityName,
                 text: ent.entityName
             }
         })
-        return options;
     }
     renderSubstringObject(s: SubstringObject, key: number) {
-        let allOptions: IDropdownOption[] = this.getAlphabetizedEntityOptions();
-        let options: IDropdownOption[] = allOptions.filter((o: IDropdownOption) => {
-            let found: PredictedEntity = this.state.predictedEntities.find((p: PredictedEntity) => p.entityName == o.text);
+        let allOptions = this.getAlphabetizedEntityOptions();
+        let options = allOptions.filter(o => {
+            // TODO: Entities are label entities, but here we depend on properties from PredictedEntity
+            let found = this.state.predictedEntities.find(p => p.entityName == o.text) as PredictedEntity;
             if (found && (!found.metadata || found.metadata.isBucket == false)) {
                 return false;
             }
@@ -760,7 +758,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
         this.props.removeExtractResponse(removedResponse);
     }
     render() {
-        let key: number = 0;
+        let key = 0;
         let boxClass = this.props.isValid ? 'extractorResponseBox' : 'extractorResponseBox extractorResponseBoxInvalid';
         let button = this.props.isPrimary ? null :
             <div>
@@ -771,9 +769,7 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
                 {button}
                 <div className='teachVariation'>
                     <div className={boxClass}>
-                        {this.state.substringObjects.map((s: SubstringObject) => {
-                            return this.renderSubstringObject(s, ++key)
-                        })}
+                        {this.state.substringObjects.map(s => this.renderSubstringObject(s, ++key))}
                     </div>
                 </div>
             </div>

--- a/src/containers/ExtractorTextVariationCreator.tsx
+++ b/src/containers/ExtractorTextVariationCreator.tsx
@@ -27,8 +27,8 @@ class ExtractorTextVariationCreator extends React.Component<Props, ComponentStat
         })
     }
     handleAddVariation() {
-        let appId: string = this.props.apps.current.appId;
-        let teachId: string = this.props.teachSessions.current.teachId;
+        let appId = this.props.apps.current.appId;
+        let teachId = this.props.teachSessions.current.teachId;
         let userInput = new UserInput({ text: this.state.variationValue })
         this.props.runExtractorAsync(this.props.user.key, appId, teachId, userInput);
         this.setState({

--- a/src/containers/TeachSessionExtractor.tsx
+++ b/src/containers/TeachSessionExtractor.tsx
@@ -63,13 +63,13 @@ class TeachSessionExtractor extends React.Component<Props, ComponentState> {
     isValid(extractResponse: ExtractResponse): boolean {
         let primaryResponse = this.props.teachSession.extractResponses[0] as ExtractResponse;
         let missing = primaryResponse.predictedEntities.filter(item =>
-            !extractResponse.predictedEntities.find(er => { return item.entityName == er.entityName }));
+            !extractResponse.predictedEntities.find(er => item.entityName == er.entityName));
 
         if (missing.length > 0) {
             return false;
         }
         missing = extractResponse.predictedEntities.filter(item =>
-            !primaryResponse.predictedEntities.find(er => { return item.entityName == er.entityName }));
+            !primaryResponse.predictedEntities.find(er => item.entityName == er.entityName));
         if (missing.length > 0) {
             return false;
         }
@@ -101,8 +101,8 @@ class TeachSessionExtractor extends React.Component<Props, ComponentState> {
 
         let uiScoreInput = new UIScoreInput({ trainExtractorStep: trainExtractorStep, extractResponse: this.props.teachSession.extractResponses[0] });
 
-        let appId: string = this.props.apps.current.appId;
-        let teachId: string = this.props.teachSession.current.teachId;
+        let appId = this.props.apps.current.appId;
+        let teachId = this.props.teachSession.current.teachId;
         this.props.runScorerAsync(this.props.user.key, appId, teachId, uiScoreInput);
     }
     render() {

--- a/src/containers/TeachSessionMemory.tsx
+++ b/src/containers/TeachSessionMemory.tsx
@@ -47,7 +47,7 @@ class TeachSessionMemory extends React.Component<Props, ComponentState> {
             sortColumn: null
         }
     }
-    onColumnClick(event: any, column: any) {
+    onColumnClick(event: any, column: IColumn) {
         let { columns } = this.state;
         let isSortedDescending = column.isSortedDescending;
 
@@ -58,7 +58,7 @@ class TeachSessionMemory extends React.Component<Props, ComponentState> {
 
         // Reset the items and columns to match the state.
         this.setState({
-            columns: columns.map((col: any) => {
+            columns: columns.map(col => {
                 col.isSorted = (col.key === column.key);
 
                 if (col.isSorted) {

--- a/src/containers/TeachSessionScorer.tsx
+++ b/src/containers/TeachSessionScorer.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { returntypeof } from 'react-redux-typescript';
 import { ModelUtils } from 'blis-models';
 import { State } from '../types'
-import { UITrainScorerStep, TrainScorerStep, ScoredBase, ActionBase, EntityBase, Memory, ScoredAction, UnscoredAction, ScoreReason, UIScoreInput } from 'blis-models';
+import { UITrainScorerStep, TrainScorerStep, ScoredBase, ActionBase, ScoredAction, UnscoredAction, ScoreReason, UIScoreInput } from 'blis-models';
 import { postScorerFeedbackAsync, toggleAutoTeach } from '../actions/teachActions'
 import { CommandButton, PrimaryButton } from 'office-ui-fabric-react';
 import { TeachMode } from '../types/const'
@@ -189,9 +189,9 @@ class TeachSessionScorer extends React.Component<Props, ComponentState> {
         }
     }
     handleActionSelection(actionId: string) {
-        let scoredAction = this.props.teachSession.scoreResponse.scoredActions.filter((a: ScoredAction) => a.actionId == actionId)[0];
+        let scoredAction = this.props.teachSession.scoreResponse.scoredActions.find(a => a.actionId == actionId);
         if (!scoredAction) {
-            let unscoredAction = this.props.teachSession.scoreResponse.unscoredActions.filter((a: UnscoredAction) => a.actionId == actionId)[0];
+            let unscoredAction = this.props.teachSession.scoreResponse.unscoredActions.find(a => a.actionId == actionId);
             scoredAction = new ScoredAction(unscoredAction);
         }
         let trainScorerStep = new TrainScorerStep(
@@ -218,18 +218,18 @@ class TeachSessionScorer extends React.Component<Props, ComponentState> {
     }
     /** Check if entity is in memory and return it's name */
     entityInMemory(entityId: string): { match: boolean, name: string } {
-        let entity = this.props.entities.filter((e: EntityBase) => e.entityId == entityId)[0];
+        let entity = this.props.entities.filter(e => e.entityId == entityId)[0];
 
         // If entity is null - there's a bug somewhere
         if (!entity) {
             return { match: false, name: "ERROR" };
         }
 
-        let memory = this.props.teachSession.memories.filter((m: Memory) => m.entityName == entity.entityName)[0];
+        let memory = this.props.teachSession.memories.filter(m => m.entityName == entity.entityName)[0];
         return { match: (memory != null), name: entity.entityName };
     }
     renderEntityRequirements(actionId: string) {
-        let action = this.props.actions.filter((a: ActionBase) => a.actionId == actionId)[0];
+        let action = this.props.actions.filter(a => a.actionId == actionId)[0];
 
         // If action is null - there's a bug somewhere
         if (!action) {

--- a/src/epics/teachEpics.ts
+++ b/src/epics/teachEpics.ts
@@ -5,10 +5,12 @@ import { State, ActionObject } from '../types'
 import { AT } from '../types/ActionTypes'
 import { putExtract, putScore, postScore } from "./apiHelpers";
 
+const assertNever = () => { throw Error(`Should not reach here`) }
+
 export const runExtractorEpic: Epic<ActionObject, State> = (action$: ActionsObservable<ActionObject>): Rx.Observable<ActionObject> => {
     return action$.ofType(AT.RUN_EXTRACTOR_ASYNC)
-        .flatMap((action: any) =>
-            putExtract(action.key, action.appId, action.teachId, action.userInput)
+        .flatMap(action => 
+            (action.type === AT.RUN_EXTRACTOR_ASYNC) ? putExtract(action.key, action.appId, action.teachId, action.userInput) : assertNever()
         );
 }
 

--- a/src/types/StateTypes.ts
+++ b/src/types/StateTypes.ts
@@ -60,12 +60,6 @@ export type UserState = {
     id: string,
     key: string
 }
-export type TeachState = {
-    name: string,
-    password: string,
-    id: string,
-    key: string
-}
 export type State = {
     user: UserState,
     bot: BotState

--- a/src/types/const.ts
+++ b/src/types/const.ts
@@ -1,7 +1,6 @@
 export enum DisplayMode {
     AppList,
-    AppAdmin,
-    Session
+    AppAdmin
 }
 
 export enum TeachMode {


### PR DESCRIPTION
**Removal of unecessary type casting**
Should not respecify known types. Types should flow from parents through.
- Allows mistakes to be caught instead of forcing the type by casting which masks type mismatches
- Allows easier refactoring, only have to change parent type instead of every place it's used
- Easier to read

**Specify expected return type on maps which transform object types**
- This ensures you return what you intended instead of the variable being assigned to casting it to the type.