### PR TITLE
Refactor modals to use BEM convention classes. Remove more un-used CSS

### DIFF
--- a/public/App.css
+++ b/public/App.css
@@ -1,86 +1,3 @@
-/*
-  PRIMARY: #004b50
-  SECONDARY: #ffb900
-  TERTIARY: #
-*/
-
-.app{
-  width: 100%;
-  height: 100%;
-}
-.header{
-   height: 8%;
-   width: 100%;
-   background-color: #004b50;
-}
-.headerTitleDiv{
-  height: 100%;
-  width: 50%;
-  display: inline-block;
-}
-.headerListDiv{
-  height: 100%;
-  width: 44%;
-  margin-left: 5%;
-  display: inline-block;
-}
-.headerLink{
-  text-decoration: none;
-  color: white;
-  position: relative;
-  float: left;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-.headerElementDiv{
-  height: 100%;
-  display: inline-block;
-  text-align: center;
-  vertical-align: middle;
-  width:17%;
-}
-.selectedHeaderElementDiv{
-  height: 100%;
-  display: inline-block;
-  text-align: center;
-  vertical-align: middle;
-  width:17%;
-  background-color: #ffb900 !important;
-}
-.selectedHeaderElementDiv *{
-  color:black !important;
-}
-.headerTitle{
-  height: 100%;
-  display: inline-block;
-  text-align: center;
-  vertical-align: middle;
-  width: 13%;
-  margin-left: 60%;
-}
-.headerElementDiv:hover, .headerTitle:hover{ 
-    background-color: #ffb900;
-}
-.headerElementDiv:hover *{ 
-    color: black;
-}
-.headerTitle:hover *{ 
-    color: black;
-}
-.dummyContent *{
-  position: relative;
-  float: left;
-  top: 30%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  color: #004b50;
-}
-.content{
-  margin-left: 5%;
-  margin-top: 2%;
-}
-
 .blis-button--gold:hover {
   border: 1px solid #004b50;
 }
@@ -117,28 +34,7 @@
   height: 1px;
   opacity: 0.0;
 }
-.trainingGroundArena{
-  width: 80%;
-  margin-left: 5%;
-  display: inline-block;
-  vertical-align: top;
-}
-.trainingGroundNavigationArea{
-  width: 14%;
-  display: inline-block;
-  vertical-align: top;
-}
-.orangeButton:hover {
-  border: 1px solid #a80000;
-}
-.orangeButton{
-  background-color: #ea4300 !important;
-  color: black !important;
-  padding: 0em 2em !important;
-}
-.orangeButton *{
-  color: black !important;
-}
+
 .blis-action {
   border: none;
   background: none;
@@ -146,102 +42,22 @@
   margin: 0;
   cursor: ponter;
 }
-.tgNavDiv{
-  border-top: 1px solid lightgrey;
-  border-bottom: 1px solid lightgrey;
-  height: 13.5em;
-}
-.trainingGroundNav *{
-  color: gray !important;
-  margin-left: -.1em !important;
-}
-.trainingGroundNav *:hover{
-  color: lightgrey !important;
-}
-.tgSettingsDiv{
-  border-top: 1px solid lightgrey;
-  margin-top: 1em;
-  color: gray;
-  padding: .5em 0em;
-}
-.backToApps{
-  color: gray !important;
-  text-decoration: none;
-  margin-top: 1.2em;
-  font-size: 14px !important;
-}
-.backToAppsIcon{
-  text-decoration: none;
-  color:gray;
-  font-size: 14px;
-}
-.tgbackToAppsDiv *:hover, .tgSettingsDiv *:hover {
-  color: lightgrey !important;
-  cursor: pointer !important;
-}
 
-.checkIcon{
+.blis-icon.ms-Icon--CheckMark{
   color: green;
   font-size: 20px;
 }
-.notFoundIcon{
+.blis-icon.ms-Icon--Remove{
   color: lightgrey;
   font-size: 18px
 }
-.modalHeader{
-  display: block;
-  text-align: center;
-  padding: 1em;
-}
-.modalFooter{
-  margin-top: 1.5em;
-}
-.createModal{
-  border: 2px solid #004b50;
-  width: 40%;
-  padding: 1em;
-  position: relative
-}
-.spinnerBox
-{
-    width: 500px;
-    height: 500px;
-    background-color: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-    position: relative
-}
-.container{
-  height: 100%;
-}
-.emulatorDisplay{
-  background: #323232;
-  border: 2px solid #ffb900;
-  height: 99.5%;
-  margin-top: -2.2%;
-  width:80.7%;
-  margin-left: 5%;
-  display: inline-block;
-  vertical-align: top;
-}
-.webchatContainer *{
-  position: relative;
-  float: left;
-  top: 30%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-.fluidCont{
-  height: 91.5%;
-}
+
+
 .ms-Icon--Delete:hover, .ms-Icon--Edit:hover{
   cursor: pointer;
 }
-.emulatorContent{
-  margin-left: 5%;
-  margin-top: 2%;
-  height: 100%;
-}
+
+
 .blis-font--emphasis 
 {
   font-weight: bold;
@@ -251,96 +67,24 @@
 {
   text-decoration: line-through;
 }
-.entityMatch
-{
-    flex-shrink: 1;
-    background: #e0ffe0;
-    margin: 1px;
-    display: inline-block;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    padding: 4px;
-    text-align: center;
-}
-.entityMismatch
-{
-    flex-shrink: 1;
-    background: #ffe0e0;
-    margin: 1px;
-    display: inline-block;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    padding: 4px;
-    text-align: center;
-}
 
-.goldText{
-  color: #ffb900
+.wc-chatview-panel:focus {
+  outline: 0;
 }
-.actionSelect{
-  color: #ffb900;
-  font-size: 24px;
-}
-.actionUnavailable{
-  color: #cc0000;
-  font-size: 24px;
-}
-.saveAppChangesButtonsDiv{
-  width: 100%;
-  display: block;
-  margin-top: 1em;
-}
-
 .wc-disable{
   width: 100%;
   height: 100%;
   opacity: 0.09;
   background-color: #000000;
 }
-.toggleTrainDialog{
-  background-color: #323232 !important;
-  padding: 0em 2em !important;
-  display: block !important;
-  margin-top: 20em;
-}
-.toggleTrainDialogForward{
-  height: 99.8%;
-  border-left: 1px solid #ffb900;
-  display: inline-block;
-  vertical-align: top;
-}
-.toggleTrainDialogBack{
-  border-right: 1px solid #ffb900;
-  height: 99.8%;
-  display: inline-block;
-  vertical-align: top;
-}
-.toggleTrainDialog *{
-  color: #ffb900 !important;
-}
-.textFieldInlineButtonDiv{
-  display: block;
-}
+
 .textFieldWithButton{
   display: inline-block;
   width: 85%;
 }
 .buttonWithTextField{
-  display: inline-block;
   float: right;
   margin-top: -.1em
-}
-.webchat, .sessionAdmin{
-  display: inline-block;
-  vertical-align: top;
-  padding: 0px;
-}
-.sessionAdmin{
-  width: 67%;
-}
-.teachBody{
-  width: 100%;
-  height: 92%;
 }
 
 .teachVariation{
@@ -366,12 +110,7 @@
   font-style: italic;
   margin: 10px 10px 10px 20px;
 }
-.teachAuto
-{
-  color: #ffffff;
-  margin: 30px 20px 20px 20px !important;
-  float: right;
-}
+
 .teachAutoMask
 {
   width: 100%;
@@ -382,27 +121,7 @@
   z-index: 1000;
   visibility: visible !important
 }
-.fakeInputDiv{
-  display: inline-block;
-  vertical-align: top;
-  float: right;
-}
-.fakeInputDiv *{
-  margin-left: 1em;
-  display: inline-block;
-  vertical-align: top;
-}
-.fakeInputText *{
-  width: 25em !important;
-}
-.teachSessionFullMode{
-  width: 100%;
-  height: 100%;
-}
-.teachSessionHalfMode{
-  width: 49.5%;
-  height: 100%;
-}
+
 .teachTitleBox{
   display: inline-block;
   margin-top: 15px;
@@ -457,12 +176,40 @@
 }
 
 /** New CSS using BEM to eventually replace above */
+
+/** Modals */
 .blis-modal--large {
   width: 90%;
   height: 90%;
 }
+.blis-modal--small{
+  width: 40%;
+  /* TODO: Remove padding here, it should be the content inside that decides padding, otherwise all modals should have padding */
+  padding: 1em;
+}
+.blis-modal--border {
+  border: 2px solid #004b50;
+}
 
-/** Modals */
+.blis-modal_header {
+  display: block;
+  text-align: center;
+  padding: 1em;
+}
+.blis-modal_footer{
+  margin-top: 1.5em;
+}
+
+.blis-spinner
+{
+    width: 500px;
+    height: 500px;
+    background-color: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    position: relative
+}
+
 .blis-chatmodal {
   height: 100%;
   display: grid;
@@ -507,33 +254,33 @@
 }
 
 /** Log Dialog Admin */
-.log-dialog-admin {
+.blis-log-dialog-admin {
   display: grid;
   grid-gap: 1rem;
 }
-.log-dialog-admin__title {
+.blis-log-dialog-admin__title {
   font-weight: bold;
   border-bottom: 1px solid black;
 }
-.log-dialog-admin__content {
+.blis-log-dialog-admin__content {
   padding-bottom: 1em;
 }
-.log-dialog-admin__chosen-action {
+.blis-log-dialog-admin__chosen-action {
   padding: 1em 0;
   font-weight: bold
 }
 
 /** Scorer Classes */
-.ms-Icon--Action {
+.blis-action-icon {
   font-size: 24px;
 }
-.ms-Icon--Action.ms-Icon--ChromeClose {
+.blis-action-icon.ms-Icon--ChromeClose {
   color: #cc0000;
 }
-.ms-Icon--Action.ms-Icon--CompletedSolid {
+.blis-action-icon.ms-Icon--CompletedSolid {
   color: #ffb900;
 }
-.ms-Icon--Action.ms-Icon--Remove {
+.blis-action-icon.ms-Icon--Remove {
     color: lightgrey;
     font-size: 18px
 }

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -45,6 +45,7 @@
 }
 .blis-header_links a:link,
 .blis-header_links a:visisted {
+    color: white;
 }
 .blis-header_links a.active,
 .blis-header_links a:hover {

--- a/src/components/ConfirmDeleteModal.tsx
+++ b/src/components/ConfirmDeleteModal.tsx
@@ -14,12 +14,12 @@ const ConfirmDeleteModal: React.SFC<Props> = (props: Props) => {
         <Modal
             isOpen={props.open}
             isBlocking={false}
-            containerClassName='createModal'
+            containerClassName='blis-modal blis-modal--small blis-modal--border'
         >
-            <div className='modalHeader'>
+            <div className='blis-modal_header'>
                 <span className='ms-font-xl ms-fontWeight-semilight'>{props.title}</span>
             </div>
-            <div className='modalFooter'>
+            <div className='blis-modal_footer'>
                 <CommandButton
                     disabled={false}
                     onClick={() => props.onConfirm()}

--- a/src/components/Home/App.css
+++ b/src/components/Home/App.css
@@ -12,6 +12,12 @@
     padding: 0.5rem 0;
     color: grey;
 }
+.blis-nav_section:last-of-type {
+    border-bottom: 1px solid lightgrey;
+}
+.blis-nav_section * {
+    color: grey !important;
+}
 .blis-nav_section *:hover {
     color: lightgrey !important;
     cursor: pointer !important;

--- a/src/components/PopUpMessage.tsx
+++ b/src/components/PopUpMessage.tsx
@@ -13,12 +13,12 @@ const PopUpMessage: React.SFC<Props> = (props: Props) => {
         <Modal
             isOpen={props.open}
             isBlocking={false}
-            containerClassName='createModal'
+            containerClassName='blis-modal blis-modal--small blis-modal--border'
         >
-            <div className='modalHeader'>
+            <div className='blis-modal_header'>
                 <span className='ms-font-xl ms-fontWeight-semilight'>{props.title}</span>
             </div>
-            <div className='modalFooter'>
+            <div className='blis-modal_footer'>
                 <CommandButton
                     disabled={false}
                     onClick={() => props.onConfirm()}

--- a/src/containers/ActionResponseCreatorEditor.tsx
+++ b/src/containers/ActionResponseCreatorEditor.tsx
@@ -821,9 +821,9 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
                     isOpen={this.props.open}
                     onDismiss={this.cancelOnClick}
                     isBlocking={false}
-                    containerClassName='createModal'
+                    containerClassName='blis-modal blis-modal--small blis-modal--border'
                 >
-                    <div className='modalHeader'>
+                    <div className='blis-modal_header'>
                         <span className='ms-font-xxl ms-fontWeight-semilight'>{title}</span>
                     </div>
                     <div>
@@ -894,7 +894,7 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
                             disabled={this.state.editing}
                         />
                     </div>
-                    <div className="modalFooter">
+                    <div className="blis-modal_footer">
                         <CommandButton
                             data-automation-id='randomID6'
                             disabled={createDisabled}

--- a/src/containers/ActionResponsesList.tsx
+++ b/src/containers/ActionResponsesList.tsx
@@ -177,9 +177,9 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
         switch (column.key) {
             case 'wait':
                 if (fieldContent == true) {
-                    return <span className="ms-Icon ms-Icon--CheckMark checkIcon" aria-hidden="true"></span>;
+                    return <span className="ms-Icon ms-Icon--CheckMark blis-icon" aria-hidden="true"></span>;
                 } else {
-                    return <span className="ms-Icon ms-Icon--Remove notFoundIcon" aria-hidden="true"></span>;
+                    return <span className="ms-Icon ms-Icon--Remove blis-icon" aria-hidden="true"></span>;
                 }
             case 'actionType':
                 return <span className='ms-font-m-plus'>{fieldContent.actionType}</span>;
@@ -187,13 +187,13 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
                 if (fieldContent.length > 0) {
                     return this.renderEntityList(fieldContent)
                 } else {
-                    return <span className="ms-Icon ms-Icon--Remove notFoundIcon" aria-hidden="true"></span>;
+                    return <span className="ms-Icon ms-Icon--Remove blis-icon" aria-hidden="true"></span>;
                 }
             case 'negativeEntities':
                 if (fieldContent.length > 0) {
                     return this.renderEntityList(fieldContent)
                 } else {
-                    return <span className="ms-Icon ms-Icon--Remove notFoundIcon" aria-hidden="true"></span>;
+                    return <span className="ms-Icon ms-Icon--Remove blis-icon" aria-hidden="true"></span>;
                 }
             case 'suggestedEntity':
                 if (fieldContent != null) {
@@ -205,7 +205,7 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
                         </div>
                     )
                 } else {
-                    return <span className="ms-Icon ms-Icon--Remove notFoundIcon" aria-hidden="true"></span>;
+                    return <span className="ms-Icon ms-Icon--Remove blis-icon" aria-hidden="true"></span>;
                 }
             case 'payload':
                 fieldContent = ModelUtils.GetPrimaryPayload(item);

--- a/src/containers/AppAdmin.tsx
+++ b/src/containers/AppAdmin.tsx
@@ -76,8 +76,8 @@ class AppAdmin extends React.Component<Props, ComponentState> {
                                 }]}
                             />
                         </div>
-                        <div className="blis-nav_section">
-                            <Link className="backToApps" onClick={() => this.props.setDisplayMode(DisplayMode.AppList)}><span className="ms-Icon ms-Icon--Back backToApps backToAppsIcon" aria-hidden="true"></span>&nbsp;&nbsp;App List</Link>
+                        <div className="blis-nav_section backToApps">
+                            <Link onClick={() => this.props.setDisplayMode(DisplayMode.AppList)}><span className="ms-Icon ms-Icon--Back" aria-hidden="true"></span>&nbsp;&nbsp;App List</Link>
                         </div>
                     </div>
                 </div>

--- a/src/containers/AppSettings.tsx
+++ b/src/containers/AppSettings.tsx
@@ -97,7 +97,7 @@ class AppSettings extends React.Component<Props, ComponentState> {
     }
     onRenderBotListRow(item?: any, index?: number) {
         return (
-            <div className="textFieldInlineButtonDiv">
+            <div>
                 <TextField className="ms-font-m-plus textFieldWithButton" disabled={true} value={item} />
             </div>
         )
@@ -146,51 +146,54 @@ class AppSettings extends React.Component<Props, ComponentState> {
             <div className="blis-page">
                 <span className="ms-font-xxl">Settings</span>
                 <span className="ms-font-m-plus">Control your application versions, who has access to it and whether it is public or private....</span>
-                <TextField className="ms-font-m-plus" onChanged={(text) => this.appNameChanged(text)} label="Name" value={this.state.appNameVal} />
-                <TextField className="ms-font-m-plus" disabled={true} label="App ID" value={this.state.appIdVal} />
-                <TextField className="ms-font-m-plus" onChanged={(text) => this.luisKeyChanged(text)} label="LUIS Key" value={this.state.luisKeyVal} />
-                <Label className="ms-font-m-plus">Locale</Label>
-                <Dropdown
-                    className="ms-font-m-plus"
-                    options={options}
-                    selectedKey={this.state.localeVal}
-                    disabled={true}
-                />
                 <div>
-                    <Label className="ms-font-m-plus">Bot Framework Apps</Label>
-                    <List
-                        items={this.state.botFrameworkAppsVal}
-                        onRenderCell={this.onRenderBotListRow.bind(this)}
+                    <TextField className="ms-font-m-plus" onChanged={(text) => this.appNameChanged(text)} label="Name" value={this.state.appNameVal} />
+                    <TextField className="ms-font-m-plus" disabled={true} label="App ID" value={this.state.appIdVal} />
+                    <TextField className="ms-font-m-plus" onChanged={(text) => this.luisKeyChanged(text)} label="LUIS Key" value={this.state.luisKeyVal} />
+                    <Label className="ms-font-m-plus">Locale</Label>
+                    <Dropdown
+                        className="ms-font-m-plus"
+                        options={options}
+                        selectedKey={this.state.localeVal}
+                        disabled={true}
                     />
                     <div>
-                        <TextFieldPlaceholder className="ms-font-m-plus textFieldWithButton" onChanged={(text) => this.botIdChanged(text)} placeholder="Application ID" value={this.state.newBotVal} />
+                        <Label className="ms-font-m-plus">Bot Framework Apps</Label>
+                        <List
+                            items={this.state.botFrameworkAppsVal}
+                            onRenderCell={this.onRenderBotListRow.bind(this)}
+                        />
+                        <div>
+                            <TextFieldPlaceholder
+                                className="ms-font-m-plus textFieldWithButton"
+                                onChanged={(text) => this.botIdChanged(text)}
+                                placeholder="Application ID"
+                                value={this.state.newBotVal}
+                            />
+                            <CommandButton
+                                data-automation-id='randomID16'
+                                disabled={false}
+                                onClick={this.botAdded.bind(this)}
+                                className='blis-button--gold buttonWithTextField'
+                                ariaDescription='Add'
+                                text='Add'
+                            />
+                        </div>
+                    </div>
+                    <div style={buttonsDivStyle}>
                         <CommandButton
-                            data-automation-id='randomID16'
-                            disabled={false}
-                            onClick={this.botAdded.bind(this)}
-                            className='blis-button--gold buttonWithTextField'
-                            ariaDescription='Add'
-                            text='Add'
+                            onClick={this.editApp.bind(this)}
+                            className='blis-button--gold'
+                            ariaDescription='Save Changes'
+                            text='Save Changes'
+                        />
+                        <CommandButton
+                            className="blis-button--gray"
+                            onClick={this.discardChanges.bind(this)}
+                            ariaDescription='Discard'
+                            text='Discard'
                         />
                     </div>
-                </div>
-                <div style={buttonsDivStyle} className="saveAppChangesButtonsDiv">
-                    <CommandButton
-                        data-automation-id='randomID6'
-                        disabled={false}
-                        onClick={this.editApp.bind(this)}
-                        className='blis-button--gold'
-                        ariaDescription='Save Changes'
-                        text='Save Changes'
-                    />
-                    <CommandButton
-                        data-automation-id='randomID7'
-                        className="blis-button--gray"
-                        disabled={false}
-                        onClick={this.discardChanges.bind(this)}
-                        ariaDescription='Discard'
-                        text='Discard'
-                    />
                 </div>
             </div>
         );

--- a/src/containers/BLISAppCreator.tsx
+++ b/src/containers/BLISAppCreator.tsx
@@ -136,9 +136,9 @@ class BLISAppCreator extends React.Component<Props, ComponentState> {
                     isOpen={this.state.isCreateAppModalOpen}
                     onDismiss={() => this.onDismissCreateNewApp()}
                     isBlocking={false}
-                    containerClassName='createModal'
+                    containerClassName='blis-modal blis-modal--small blis-modal--border'
                 >
-                    <div className='modalHeader'>
+                    <div className='blis-modal_header'>
                         <span className='ms-font-xxl ms-fontWeight-semilight'>Create a BLIS App</span>
                     </div>
                     <div>
@@ -163,7 +163,7 @@ class BLISAppCreator extends React.Component<Props, ComponentState> {
                             onChanged={this.localeChanged.bind(this)}
                         />
                     </div>
-                    <div className='modalFooter'>
+                    <div className='blis-modal_footer'>
                         <CommandButton
                             data-automation-id='randomID2'
                             disabled={!this.state.appNameVal || !this.state.luisKeyVal}

--- a/src/containers/EntitiesList.tsx
+++ b/src/containers/EntitiesList.tsx
@@ -272,12 +272,12 @@ class EntitiesList extends React.Component<Props, ComponentState> {
                 <Modal
                     isOpen={this.state.errorModalOpen}
                     isBlocking={false}
-                    containerClassName='createModal'
+                    containerClassName='blis-modal blis-modal--small blis-modal--border'
                 >
-                    <div className='modalHeader'>
+                    <div className='blis-modal_header'>
                         <span className='ms-font-xl ms-fontWeight-semilight'>You cannot delete this entity because it is being used in an action.</span>
                     </div>
-                    <div className='modalFooter'>
+                    <div className='blis-modal_footer'>
                         <CommandButton
                             disabled={false}
                             onClick={() => this.handleCloseDeleteModal()}

--- a/src/containers/EntityCreatorEditor.tsx
+++ b/src/containers/EntityCreatorEditor.tsx
@@ -131,9 +131,9 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                 <Modal
                     isOpen={this.props.open}
                     isBlocking={false}
-                    containerClassName='createModal'
+                    containerClassName='blis-modal blis-modal--small blis-modal--border'
                 >
-                    <div className='modalHeader'>
+                    <div className='blis-modal_header'>
                         <span className='ms-font-xxl ms-fontWeight-semilight'>{title}</span>
                     </div>
                     <div>
@@ -164,7 +164,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                             style={{ marginTop: "1em", display: "inline-block" }}
                         />
                     </div>
-                    <div className='modalFooter'>
+                    <div className='blis-modal_footer'>
                         <CommandButton
                             data-automation-id='randomID2'
                             disabled={!this.state.entityNameVal}

--- a/src/containers/Error.tsx
+++ b/src/containers/Error.tsx
@@ -23,15 +23,15 @@ class UIError extends React.Component<Props, any> {
                 isOpen={this.props.error.error != null}
                 onDismiss={this.handleClose.bind(this)}
                 isBlocking={false}
-                containerClassName='createModal'
+                containerClassName='blis-modal blis-modal--small blis-modal--border'
             >
-                <div className='modalHeader'>
+                <div className='blis-modal_header'>
                     <span className='ms-font-xxl ms-fontWeight-semilight'>Error</span>
                 </div>
                 <div className='ms-font-l ms-fontWeight-semilight'>{this.props.error.route} Failed</div>
                 <div className='ms-font-m ms-fontWeight-semilight'>{this.props.error.error}</div>
                 {message}
-                <div className='modalFooter'>
+                <div className='blis-modal_footer'>
                     <CommandButton
                         data-automation-id='randomID2'
                         disabled={false}

--- a/src/containers/LogDialogAdmin.tsx
+++ b/src/containers/LogDialogAdmin.tsx
@@ -66,7 +66,7 @@ let columns: IRenderableColumn[] = [
         isResizable: true,
         render: renderableAction => renderableAction.arguments
             ? <List items={renderableAction.arguments} onRenderCell={item => <span className='ms-ListItem-primaryText'>{item}</span>} />
-            : <span className="ms-Icon ms-Icon--Remove ms-Icon--Action"></span>
+            : <span className="ms-Icon ms-Icon--Remove blis-action-icon"></span>
     },
     {
         key: 'score',
@@ -415,9 +415,9 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
         }
 
         return (
-            <div className="log-dialog-admin ms-font-l">
-                <div className="log-dialog-admin__title">Entity Detection</div>
-                <div className="log-dialog-admin__content">
+            <div className="blis-log-dialog-admin ms-font-l">
+                <div className="blis-log-dialog-admin__title">Entity Detection</div>
+                <div className="blis-log-dialog-admin__content">
                     {round
                         ? <div>
                             <ExtractorResponseEditor
@@ -436,15 +436,15 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
                         : <span>Click on text from the dialog to the left to view how the bot interpretted the conversation.  You can then make corrections to the bots behavior.</span>
                     }
                 </div>
-                <div className="log-dialog-admin__title">Memory</div>
-                <div className="log-dialog-admin__content">
+                <div className="blis-log-dialog-admin__title">Memory</div>
+                <div className="blis-log-dialog-admin__content">
                     {filledEntities.length !== 0 && filledEntities.map(entity => <div key={entity.entityName}>{entity.entityName}</div>)}
                 </div>
-                <div className="log-dialog-admin__title">Action</div>
-                <div className="log-dialog-admin__content">
+                <div className="blis-log-dialog-admin__title">Action</div>
+                <div className="blis-log-dialog-admin__content">
                     {action && <div>
                         <div>Action the bot chose:</div>
-                        <div className="log-dialog-admin__chosen-action">
+                        <div className="blis-log-dialog-admin__chosen-action">
                             {action.payload}
                         </div>
                         <div>Alternate actions available to choose:</div>
@@ -456,7 +456,7 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
                         />
                     </div>}
                 </div>
-                <div className="log-dialog-admin__dialogs">
+                <div className="blis-log-dialog-admin__dialogs">
                     <Dialog
                         hidden={this.state.isSaveConfirmationDialogHidden}
                         onDismiss={() => this.onDismisSaveConfirmation()}

--- a/src/containers/SpinnerWindow.tsx
+++ b/src/containers/SpinnerWindow.tsx
@@ -16,7 +16,7 @@ class SpinnerWindow extends React.Component<Props, any> {
             <Modal
                 isOpen={this.props.displaySpinner.length > 0}
                 isBlocking={true}
-                containerClassName='spinnerBox'>
+                containerClassName='blis-spinner'>
                 <Spinner size={SpinnerSize.large} />
             </Modal>
         );

--- a/src/containers/TeachSessionScorer.tsx
+++ b/src/containers/TeachSessionScorer.tsx
@@ -239,11 +239,11 @@ class TeachSessionScorer extends React.Component<Props, ComponentState> {
         let items = [];
         for (let entityId of action.requiredEntities) {
             let found = this.entityInMemory(entityId);
-            items.push({ name: found.name, type: found.match ? "entityMatch" : "entityMismatch", neg: false });
+            items.push({ name: found.name, type: found.match ? "blis-entity blis-entity--match" : "blis-entity--mismatch", neg: false });
         }
         for (let entityId of action.negativeEntities) {
             let found = this.entityInMemory(entityId);
-            items.push({ name: found.name, type: found.match ? "entityMismatch" : "entityMatch", neg: true });
+            items.push({ name: found.name, type: found.match ? "blis-entity blis-entity--mismatch" : "blis-entity blis-entity--match", neg: true });
         }
         return (
             <List

--- a/src/containers/TrainDialogAdmin.tsx
+++ b/src/containers/TrainDialogAdmin.tsx
@@ -47,9 +47,9 @@ class TrainDialogAdmin extends React.Component<Props, any> {
         }
 
         return (
-            <div className="log-dialog-admin ms-font-l">
-                <div className="log-dialog-admin__title">Entity Detection</div>
-                <div className="log-dialog-admin__content">
+            <div className="blis-log-dialog-admin ms-font-l">
+                <div className="blis-log-dialog-admin__title">Entity Detection</div>
+                <div className="blis-log-dialog-admin__content">
                     {round
                         ? round.extractorStep.textVariations.map((textVariaion, i) =>
                             <ExtractorResponseEditor
@@ -64,12 +64,12 @@ class TrainDialogAdmin extends React.Component<Props, any> {
                             />)
                         : "Select an activity"}
                 </div>
-                <div className="log-dialog-admin__title">Memory</div>
-                <div className="log-dialog-admin__content">
+                <div className="blis-log-dialog-admin__title">Memory</div>
+                <div className="blis-log-dialog-admin__content">
                     {entities.length !== 0 && entities.map(entity => <div key={entity.entityName}>{entity.entityName}</div>)}
                 </div>
-                <div className="log-dialog-admin__title">Action</div>
-                <div className="log-dialog-admin__content">
+                <div className="blis-log-dialog-admin__title">Action</div>
+                <div className="blis-log-dialog-admin__content">
                     {action && action.payload}
                 </div>
             </div>

--- a/src/containers/UserLogin.tsx
+++ b/src/containers/UserLogin.tsx
@@ -118,13 +118,13 @@ class UserLogin extends React.Component<Props, ComponentState> {
                 isOpen={(this.props.displayLogin || !this.props.user.key) && !this.props.displayError}
                 onDismiss={this.handleClose.bind(this)}
                 isBlocking={isBlocking}
-                containerClassName='createModal'
+                containerClassName='blis-modal blis-modal--small blis-modal--border'
             >
-                <div className='modalHeader'>
+                <div className='blis-modal_header'>
                     <span className='ms-font-xxl ms-fontWeight-semilight'>{title}</span>
                 </div>
                 {input}
-                <div className='modalFooter'>
+                <div className='blis-modal_footer'>
                     {button}
                 </div>
             </Modal>


### PR DESCRIPTION
Wanted to point out the idea of separation between content and presentation since this refactor is good example. A class name such as `createModal` is coupling that styling of the component (presentation) with the intention of content inside it which is not good.  It makes re-using the css hard. What if we want a similar sized modal but it's just used for Error windows?  Now the class is wrong.  However, that's exactly what happened in this code.

It's similar to how we name functions after what they do, not what they mean in the parent's context.

Atomic CSS is part of BEM, and classes should try to be re-usable.