### PR TITLE
Remove all data-automation-id and disabled={false}

### DIFF
--- a/src/components/ConfirmDeleteModal.tsx
+++ b/src/components/ConfirmDeleteModal.tsx
@@ -21,7 +21,6 @@ const ConfirmDeleteModal: React.SFC<Props> = (props: Props) => {
             </div>
             <div className='blis-modal_footer'>
                 <CommandButton
-                    disabled={false}
                     onClick={() => props.onConfirm()}
                     className='blis-button--gold'
                     ariaDescription='Confirm'
@@ -29,7 +28,6 @@ const ConfirmDeleteModal: React.SFC<Props> = (props: Props) => {
                 />
                 <CommandButton
                     className="blis-button--gray"
-                    disabled={false}
                     onClick={() => props.onCancel()}
                     ariaDescription='Cancel'
                     text='Cancel'

--- a/src/components/Home/App/Actions.tsx
+++ b/src/components/Home/App/Actions.tsx
@@ -119,8 +119,6 @@ class component extends React.Component<any, any> {
                 <p className="ms-font-m-plus">Manage a list of actions that your application can take given it's state and user input...</p>
                 <div>
                     <PrimaryButton
-                        data-automation-id='randomID20'
-                        disabled={false}
                         onClick={() => this.onClickCreateAction()}
                         className='blis-button blis-button--primary'
                         ariaDescription='Create a New Action'

--- a/src/components/Home/App/LogDialogs.tsx
+++ b/src/components/Home/App/LogDialogs.tsx
@@ -7,8 +7,6 @@ const component = (props: any) => (
         <p className="ms-font-m-plus">Use this tool to test the current versions of your application, to check if you are progressing on the right track ...</p>
         <div>
             <PrimaryButton
-                data-automation-id='randomID20'
-                disabled={false}
                 className='blis-button blis-button--primary'
                 ariaDescription='Create a New Chat Session'
                 text='New Chat Session'

--- a/src/components/PopUpMessage.tsx
+++ b/src/components/PopUpMessage.tsx
@@ -20,7 +20,6 @@ const PopUpMessage: React.SFC<Props> = (props: Props) => {
             </div>
             <div className='blis-modal_footer'>
                 <CommandButton
-                    disabled={false}
                     onClick={() => props.onConfirm()}
                     className='blis-button--gold'
                     ariaDescription='Ok'

--- a/src/containers/ActionResponseCreatorEditor.tsx
+++ b/src/containers/ActionResponseCreatorEditor.tsx
@@ -736,9 +736,7 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
             createButtonText = "Save"
             deleteButton =
                 <CommandButton
-                    data-automation-id='randomID9'
                     className="blis-button--gray"
-                    disabled={false}
                     onClick={() => this.props.handleOpenDeleteModal(this.props.blisAction.actionId)}
                     ariaDescription='Delete'
                     text='Delete'
@@ -896,7 +894,6 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
                     </div>
                     <div className="blis-modal_footer">
                         <CommandButton
-                            data-automation-id='randomID6'
                             disabled={createDisabled}
                             onClick={this.createOnClick}
                             className='blis-button--gold'
@@ -904,17 +901,13 @@ class ActionResponseCreatorEditor extends React.Component<Props, ComponentState>
                             text={createButtonText}
                         />
                         <CommandButton
-                            data-automation-id='randomID7'
                             className="blis-button--gray"
-                            disabled={false}
                             onClick={this.cancelOnClick}
                             ariaDescription='Cancel'
                             text='Cancel'
                         />
                         <CommandButton
-                            data-automation-id='randomID8'
                             className="blis-button--gold blis-button--right"
-                            disabled={false}
                             onClick={this.entityOnClick}
                             ariaDescription='Entity'
                             text='Entity'

--- a/src/containers/ActionResponsesList.tsx
+++ b/src/containers/ActionResponsesList.tsx
@@ -308,8 +308,6 @@ class ActionResponsesHomepage extends React.Component<Props, ComponentState> {
                 <span className="ms-font-m-plus">Manage a list of actions that your application can take given it's state and user input...</span>
                 <div>
                     <CommandButton
-                        data-automation-id='randomID4'
-                        disabled={false}
                         onClick={this.handleOpenCreateModal.bind(this)}
                         className='blis-button--gold'
                         ariaDescription='Create a New Action'

--- a/src/containers/AppSettings.tsx
+++ b/src/containers/AppSettings.tsx
@@ -171,8 +171,6 @@ class AppSettings extends React.Component<Props, ComponentState> {
                                 value={this.state.newBotVal}
                             />
                             <CommandButton
-                                data-automation-id='randomID16'
-                                disabled={false}
                                 onClick={this.botAdded.bind(this)}
                                 className='blis-button--gold buttonWithTextField'
                                 ariaDescription='Add'

--- a/src/containers/BLISAppCreator.tsx
+++ b/src/containers/BLISAppCreator.tsx
@@ -165,7 +165,6 @@ class BLISAppCreator extends React.Component<Props, ComponentState> {
                     </div>
                     <div className='blis-modal_footer'>
                         <CommandButton
-                            data-automation-id='randomID2'
                             disabled={!this.state.appNameVal || !this.state.luisKeyVal}
                             onClick={this.createApplication.bind(this)}
                             className='blis-button--gold'
@@ -173,9 +172,7 @@ class BLISAppCreator extends React.Component<Props, ComponentState> {
                             text='Create'
                         />
                         <CommandButton
-                            data-automation-id='randomID3'
                             className="blis-button--gray"
-                            disabled={false}
                             onClick={this.onDismissCreateNewApp.bind(this)}
                             ariaDescription='Cancel'
                             text='Cancel'

--- a/src/containers/EntitiesList.tsx
+++ b/src/containers/EntitiesList.tsx
@@ -245,8 +245,6 @@ class EntitiesList extends React.Component<Props, ComponentState> {
                 <span className="ms-font-m-plus">Manage a list of entities in your application and track and control their instances within actions...</span>
                 <div>
                     <CommandButton
-                        data-automation-id='randomID4'
-                        disabled={false}
                         onClick={this.handleOpenCreateModal.bind(this)}
                         className='blis-button--gold'
                         ariaDescription='Create a New Entity'
@@ -279,7 +277,6 @@ class EntitiesList extends React.Component<Props, ComponentState> {
                     </div>
                     <div className='blis-modal_footer'>
                         <CommandButton
-                            disabled={false}
                             onClick={() => this.handleCloseDeleteModal()}
                             className='blis-button--gold'
                             ariaDescription='Close'

--- a/src/containers/EntityCreatorEditor.tsx
+++ b/src/containers/EntityCreatorEditor.tsx
@@ -166,7 +166,6 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                     </div>
                     <div className='blis-modal_footer'>
                         <CommandButton
-                            data-automation-id='randomID2'
                             disabled={!this.state.entityNameVal}
                             onClick={this.createEntity.bind(this)}
                             className='blis-button--gold'
@@ -174,9 +173,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                             text={createButtonText}
                         />
                         <CommandButton
-                            data-automation-id='randomID3'
                             className="blis-button--gray"
-                            disabled={false}
                             onClick={() => this.props.handleClose()}
                             ariaDescription='Cancel'
                             text='Cancel'

--- a/src/containers/Error.tsx
+++ b/src/containers/Error.tsx
@@ -33,8 +33,6 @@ class UIError extends React.Component<Props, any> {
                 {message}
                 <div className='blis-modal_footer'>
                     <CommandButton
-                        data-automation-id='randomID2'
-                        disabled={false}
                         onClick={this.handleClose.bind(this)}
                         className='blis-button--gold'
                         ariaDescription='Ok'

--- a/src/containers/TeachSessionExtractor.tsx
+++ b/src/containers/TeachSessionExtractor.tsx
@@ -121,9 +121,7 @@ class TeachSessionExtractor extends React.Component<Props, ComponentState> {
             variationCreator = <ExtractorTextVariationCreator />
             addEntity =
                 <CommandButton
-                    data-automation-id='randomID8'
                     className="blis-button--gold teachCreateButton"
-                    disabled={false}
                     onClick={this.entityButtonOnClick}
                     ariaDescription='Cancel'
                     text='Entity'
@@ -132,8 +130,6 @@ class TeachSessionExtractor extends React.Component<Props, ComponentState> {
             editComponents =
                 <div>
                     <CommandButton
-                        data-automation-id='randomID16'
-                        disabled={false}
                         onClick={this.scoreButtonOnClick}
                         className='ms-font-su blis-button--gold'
                         ariaDescription='Score Actions'

--- a/src/containers/TeachSessionScorer.tsx
+++ b/src/containers/TeachSessionScorer.tsx
@@ -378,18 +378,14 @@ class TeachSessionScorer extends React.Component<Props, ComponentState> {
         let addAction = noEdit ? null : (
             <div>
                 <CommandButton
-                    data-automation-id='randomID8'
                     className="blis-button--hidden"
-                    disabled={false}
                     onClick={this.handleDefaultSelection.bind(this)}
                     ariaDescription='Accept'
                     text=''
                     ref="acceptDefault"
                 />
                 <CommandButton
-                    data-automation-id='randomID9'
                     className="blis-button--gold teachCreateButton"
-                    disabled={false}
                     onClick={this.handleOpenActionModal.bind(this)}
                     ariaDescription='Cancel'
                     text='Action'

--- a/src/containers/UserLogin.tsx
+++ b/src/containers/UserLogin.tsx
@@ -82,8 +82,6 @@ class UserLogin extends React.Component<Props, ComponentState> {
                 </div>;
             button =
                 <CommandButton
-                    data-automation-id='randomID2'
-                    disabled={false}
                     onClick={this.createUser.bind(this)}
                     className='blis-button--gold'
                     ariaDescription='Log In'
@@ -96,17 +94,13 @@ class UserLogin extends React.Component<Props, ComponentState> {
             button =
                 <div>
                     <CommandButton
-                        data-automation-id='randomID2'
-                        disabled={false}
                         onClick={this.logout.bind(this)}
                         className='blis-button--gold'
                         ariaDescription='Log Out'
                         text='Log Out'
                     />
                     <CommandButton
-                        data-automation-id='randomID3'
                         className="blis-button--gray"
-                        disabled={false}
                         onClick={this.handleClose.bind(this)}
                         ariaDescription='Cancel'
                         text='Cancel'


### PR DESCRIPTION
It looks like these values were copy pasted from the Office UI react documentation and didn't add any value in our application.

- disabled defaults to false so setting it to false is awkward
- data-automation-id seems to be random string up to developer to define and there was not a consistent pattern I could see.  There were also many different conflicts with `randomID2` etc which did not make sense for something that should be unique.  As far as I can tell it was some internal property for testing their components, but if we need to add it back we should do it in well-defined manner.