### PR TITLE
Update settings to use local typescript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
         "**/node_modules": true,
         "**/bower_components": true,
         "dist": true
-    }
+    },
+    "typescript.tsdk": "/node_modules/typescript/lib"
 }


### PR DESCRIPTION
Forces VS code to do compilation using the same version as the build so there are consistent error output between the two, regardless of the different versions of typescript on different developer's machines.