### PR TITLE
Ensure all exports components have the correct Prop types (remove React.Component<any> and supply types to connect)

### DIFF
--- a/src/containers/ActionResponseCreatorEditor.tsx
+++ b/src/containers/ActionResponseCreatorEditor.tsx
@@ -940,15 +940,16 @@ const mapStateToProps = (state: State, ownProps: any) => {
     }
 }
 
-interface ReceiveProps {
+export interface ReceiveProps {
     open: boolean,
     blisAction: ActionBase | null,
-    handleClose: Function,
-    handleOpenDeleteModal: Function
+    handleClose: (action: ActionBase) => void,
+    handleOpenDeleteModal: (actionId: string) => void
 }
+
 // Props types inferred from mapStateToProps & dispatchToProps
 const stateProps = returntypeof(mapStateToProps);
 const dispatchProps = returntypeof(mapDispatchToProps);
 type Props = typeof stateProps & typeof dispatchProps & ReceiveProps;
 
-export default connect(mapStateToProps, mapDispatchToProps)(ActionResponseCreatorEditor as React.ComponentClass<any>)
+export default connect<typeof stateProps, typeof dispatchProps, ReceiveProps>(mapStateToProps, mapDispatchToProps)(ActionResponseCreatorEditor)

--- a/src/containers/Error.tsx
+++ b/src/containers/Error.tsx
@@ -60,4 +60,4 @@ const stateProps = returntypeof(mapStateToProps);
 const dispatchProps = returntypeof(mapDispatchToProps);
 type Props = typeof stateProps & typeof dispatchProps;
 
-export default connect(mapStateToProps, mapDispatchToProps)(UIError);
+export default connect<typeof stateProps, typeof dispatchProps, {}>(mapStateToProps, mapDispatchToProps)(UIError);

--- a/src/containers/ExtractorTextVariationCreator.tsx
+++ b/src/containers/ExtractorTextVariationCreator.tsx
@@ -74,4 +74,4 @@ const stateProps = returntypeof(mapStateToProps);
 const dispatchProps = returntypeof(mapDispatchToProps);
 type Props = typeof stateProps & typeof dispatchProps;
 
-export default connect<typeof stateProps, typeof dispatchProps, {}>(mapStateToProps, mapDispatchToProps)(ExtractorTextVariationCreator as React.ComponentClass<any>);
+export default connect<typeof stateProps, typeof dispatchProps, {}>(mapStateToProps, mapDispatchToProps)(ExtractorTextVariationCreator);

--- a/src/containers/SpinnerWindow.tsx
+++ b/src/containers/SpinnerWindow.tsx
@@ -33,4 +33,4 @@ const mapStateToProps = (state: State) => {
 const stateProps = returntypeof(mapStateToProps);
 type Props = typeof stateProps;
 
-export default connect(mapStateToProps, null)(SpinnerWindow);
+export default connect<typeof stateProps, {}, {}>(mapStateToProps, null)(SpinnerWindow);

--- a/src/containers/TeachSessionExtractor.tsx
+++ b/src/containers/TeachSessionExtractor.tsx
@@ -212,4 +212,4 @@ const stateProps = returntypeof(mapStateToProps);
 const dispatchProps = returntypeof(mapDispatchToProps);
 type Props = typeof stateProps & typeof dispatchProps;
 
-export default connect<typeof stateProps, typeof dispatchProps, {}>(mapStateToProps, mapDispatchToProps)(TeachSessionExtractor as React.ComponentClass<any>);
+export default connect<typeof stateProps, typeof dispatchProps, {}>(mapStateToProps, mapDispatchToProps)(TeachSessionExtractor);

--- a/src/containers/TeachSessionScorer.tsx
+++ b/src/containers/TeachSessionScorer.tsx
@@ -87,7 +87,7 @@ interface ComponentState {
 }
 
 class TeachSessionScorer extends React.Component<Props, ComponentState> {
-    constructor(p: any) {
+    constructor(p: Props) {
         super(p);
         this.state = initState;
         this.handleActionSelection = this.handleActionSelection.bind(this);
@@ -96,6 +96,7 @@ class TeachSessionScorer extends React.Component<Props, ComponentState> {
         this.handleCloseActionModal = this.handleCloseActionModal.bind(this)
         this.renderItemColumn = this.renderItemColumn.bind(this)
         this.onColumnClick = this.onColumnClick.bind(this)
+        this.onClickOpenDeleteActionResponse = this.onClickOpenDeleteActionResponse.bind(this)
     }
     componentDidUpdate() {
         this.autoSelect();
@@ -373,6 +374,11 @@ class TeachSessionScorer extends React.Component<Props, ComponentState> {
 
         return filteredScores;
     }
+
+    onClickOpenDeleteActionResponse(actionId: string) {
+        console.log(`Not Implemented: onClickOpenDeleteActionResponse(${actionId})`)
+    }
+
     render() {
         let scores = this.renderScores();
         if (!scores) {
@@ -417,6 +423,7 @@ class TeachSessionScorer extends React.Component<Props, ComponentState> {
                     open={this.state.actionModalOpen}
                     blisAction={null}
                     handleClose={this.handleCloseActionModal}
+                    handleOpenDeleteModal={this.onClickOpenDeleteActionResponse}
                 />
             </div>
         )


### PR DESCRIPTION
Prevents bugs where the components props are undefined but not detected by the compiler since the component was assumed to have any props.