### PR TITLE
625,627

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^0.16.2",
-    "blis-models": "^0.61.0",
+    "blis-models": "^0.62.0",
     "blis-webchat": "^0.18.0",
     "botframework-directlinejs": "^0.9.12",
     "office-ui-fabric-react": "^4.47.0",

--- a/src/actions/teachActions.ts
+++ b/src/actions/teachActions.ts
@@ -1,7 +1,7 @@
 import { ActionObject } from '../types'
 import { AT } from '../types/ActionTypes'
 import { UserInput, ExtractResponse, UIScoreInput, UIExtractResponse, 
-    UIScoreResponse, UITrainScorerStep, TeachResponse,
+    UIScoreResponse, UITrainScorerStep, UITeachResponse,
     DialogType } from 'blis-models'
 
 export const runExtractorAsync = (key: string, appId: string, extractType: DialogType, sessionId: string, turnIndex: number, userInput: UserInput) : ActionObject => { 
@@ -82,24 +82,24 @@ export const postScorerFeedbackAsync = (key: string, appId: string, teachId: str
 }
 
 // Score has been posted.  Action is Terminal
-export const postScorerFeedbackWaitFulfilled = (key: string, appId: string, teachId: string, teachResponse: TeachResponse) : ActionObject => { 
+export const postScorerFeedbackWaitFulfilled = (key: string, appId: string, teachId: string, uiTeachResponse: UITeachResponse) : ActionObject => { 
     return {
         type: AT.POST_SCORE_FEEDBACK_FULFILLEDWAIT,
         key: key,
         appId: appId,
         sessionId: teachId,
-        teachResponse: teachResponse
+        uiTeachResponse: uiTeachResponse
     }
 }
 
 // Score has been posted.  Action is not Terminal
-export const postScorerFeedbackNoWaitFulfilled = (key: string, appId: string, teachId: string, teachResponse: TeachResponse, uiScoreInput: UIScoreInput) : ActionObject => { 
+export const postScorerFeedbackNoWaitFulfilled = (key: string, appId: string, teachId: string, uiTeachResponse: UITeachResponse, uiScoreInput: UIScoreInput) : ActionObject => { 
     return {
         type: AT.POST_SCORE_FEEDBACK_FULFILLEDNOWAIT,
         key: key,
         appId: appId,
         sessionId: teachId,
-        teachResponse: teachResponse, 
+        uiTeachResponse: uiTeachResponse, 
         uiScoreInput: uiScoreInput
     }
 }

--- a/src/reducers/teachSessionReducer.ts
+++ b/src/reducers/teachSessionReducer.ts
@@ -65,9 +65,9 @@ const teachSessionReducer: Reducer<TeachSessionState> = (state = initialState, a
         case AT.RUN_SCORER_FULFILLED:
             return { ...state, mode: TeachMode.Scorer, memories: action.uiScoreResponse.memories, prevMemories: state.memories, scoreInput: action.uiScoreResponse.scoreInput, scoreResponse: action.uiScoreResponse.scoreResponse };
         case AT.POST_SCORE_FEEDBACK_FULFILLEDWAIT:
-            return { ...state, mode: TeachMode.Wait };
+            return { ...state, mode: TeachMode.Wait, memories: action.uiTeachResponse.memories };
         case AT.POST_SCORE_FEEDBACK_FULFILLEDNOWAIT:
-            return { ...state, mode: TeachMode.Scorer };
+            return { ...state, mode: TeachMode.Scorer, memories: action.uiTeachResponse.memories };
         case AT.TOGGLE_AUTO_TEACH:
             return { ...state, autoTeach: action.autoTeach }
         case AT.CREATE_ACTION_FULFILLED:

--- a/src/types/ActionObject.ts
+++ b/src/types/ActionObject.ts
@@ -6,7 +6,7 @@ import {
     TrainDialog, LogDialog, Session, Teach,
     UserInput, ExtractResponse, DialogType,
     UIExtractResponse, UITrainScorerStep,
-    TeachResponse, UIScoreInput, UIScoreResponse
+    UITeachResponse, UIScoreInput, UIScoreResponse
 } from 'blis-models'
 import { DisplayMode } from '../types/const'
 import { AT } from '../types/ActionTypes'
@@ -339,13 +339,13 @@ export type TeachAction = {
     key: string,
     appId: string,
     sessionId: string
-    teachResponse: TeachResponse
+    uiTeachResponse: UITeachResponse
 } | {
     type: AT.POST_SCORE_FEEDBACK_FULFILLEDNOWAIT,
     key: string,
     appId: string,
     sessionId: string
-    teachResponse: TeachResponse,
+    uiTeachResponse: UITeachResponse,
     uiScoreInput: UIScoreInput
 } | {
     type: AT.TEACH_MESSAGE_RECEIVED,


### PR DESCRIPTION
API calls take memory manager as arg so bot dev can update memory
SDK returns updated memory to UI after scoring (for API callbacks)