### PR TITLE
Remove circular logic loop caused by programmatically setting current app

### DIFF
--- a/src/reducers/appsReducer.ts
+++ b/src/reducers/appsReducer.ts
@@ -16,7 +16,7 @@ const appsReducer: Reducer<AppState> = (state = initialState, action: ActionObje
             return { ...state, all: action.allBlisApps };
         case AT.CREATE_BLIS_APPLICATION_FULFILLED:
             let newApp = { ...action.blisApp, appId: action.blisAppId };
-            return { ...state, current: newApp, all: [...state.all, newApp] };
+            return { ...state, all: [...state.all, newApp] };
         case AT.SET_CURRENT_BLIS_APP_FULFILLED:
             return { ...state, current: action.app };
         case AT.DELETE_BLIS_APPLICATION_FULFILLED:

--- a/src/reducers/displayReducer.ts
+++ b/src/reducers/displayReducer.ts
@@ -31,7 +31,7 @@ const displayReducer: Reducer<DisplayState> = (state = initialState, action: Act
         case AT.SET_LOGIN_DISPLAY:
             return { ...state, displayLogin: action.setLoginDisplay };
         case AT.CREATE_BLIS_APPLICATION_FULFILLED:
-            return { ...state, displayMode: DisplayMode.AppAdmin, displaySpinner: removeSpinner(state.displaySpinner, action.type) }
+            return { ...state, displaySpinner: removeSpinner(state.displaySpinner, action.type) }
         case AT.SET_CURRENT_BLIS_APP_FULFILLED:
             return { ...state, displayMode: DisplayMode.AppAdmin, displaySpinner: removeSpinner(state.displaySpinner, action.type) }
         case AT.SET_ERROR_DISPLAY:

--- a/src/routes/Apps/AppsIndex.tsx
+++ b/src/routes/Apps/AppsIndex.tsx
@@ -31,9 +31,6 @@ class AppsIndex extends React.Component<Props, ComponentState> {
             this.props.fetchApplicationsAsync(this.props.user.key, this.props.userId);
             this.props.fetchBotInfoAsync();
         }
-        if (this.props.blisApps.current && this.state.selectedApp != this.props.blisApps.current) {
-            this.onSelectedAppChanged(this.props.blisApps.current);
-        }
     }
 
     onSelectedAppChanged(selectedApp: BlisAppBase) {


### PR DESCRIPTION
When the user clicks an app it was setting the local state selectedApp immediately and calling action setCurrentApp which will set the global current app after async all to bot completes.  However, the componentDidUpdate would fire after the local state change notice the selectedAPp did not match the global app and re-fire the call again with the old global current app.  This could cause never ending cycle depending on sequence of asynchronous calls returning before the local state changes.

*User now has to click on the app after creation.*

It might still be possible to automatically forward them to the app page, but for that we would need to await the call to create the new app and only once it's created do we make the calls to fetch all the data for that particular app.  We could hack it into the apiHelper since the promises live there, but that is not good idea.  