### PR TITLE
Update reducers' edit cases to use replace utility

### DIFF
--- a/src/reducers/actionsReducer.ts
+++ b/src/reducers/actionsReducer.ts
@@ -2,6 +2,7 @@ import { ActionObject } from '../types'
 import { ActionState } from '../types'
 import { AT } from '../types/ActionTypes'
 import { Reducer } from 'redux'
+import { replace } from '../util'
 
 const initialState: ActionState = [];
 
@@ -19,15 +20,7 @@ const actionsReducer: Reducer<ActionState> = (state = initialState, actionObject
         case AT.DELETE_ACTION_FULFILLED:
             return state.filter(a => a.actionId !== actionObject.actionGUID)
         case AT.EDIT_ACTION_FULFILLED:
-            let index: number = 0;
-            for (let i = 0; i < state.length; i++) {
-                if (state[i].actionId == actionObject.blisAction.actionId) {
-                    index = i
-                }
-            }
-            let newState = Object.assign([], state);
-            newState[index] = actionObject.blisAction;
-            return newState
+            return replace(state, actionObject.blisAction, a => a.actionId)
         default:
             return state;
     }

--- a/src/reducers/appsReducer.ts
+++ b/src/reducers/appsReducer.ts
@@ -2,6 +2,7 @@ import { AppState } from '../types'
 import { ActionObject } from '../types'
 import { AT } from '../types/ActionTypes'
 import { Reducer } from 'redux'
+import { replace } from '../util'
 
 const initialState: AppState = {
     all: [],
@@ -21,19 +22,10 @@ const appsReducer: Reducer<AppState> = (state = initialState, action: ActionObje
         case AT.DELETE_BLIS_APPLICATION_FULFILLED:
             return { ...state, all: state.all.filter(app => app.appId !== action.blisAppGUID) };
         case AT.EDIT_BLIS_APPLICATION_FULFILLED:
-            let index: number = 0;
-            for (let i = 0; i < state.all.length; i++) {
-                if (state.all[i].appId == action.blisApp.appId) {
-                    index = i
-                }
-            }
-            let newAll = Object.assign([], state.all);
-            newAll[index] = action.blisApp;
-            let stateToReturn: AppState = {
-                all: newAll,
+            return {
+                all: replace(state.all, action.blisApp, app => app.appId),
                 current: action.blisApp
             }
-            return stateToReturn
         default:
             return state;
     }

--- a/src/reducers/chatSessionReducer.ts
+++ b/src/reducers/chatSessionReducer.ts
@@ -1,7 +1,6 @@
 import { ActionObject, ChatSessionState } from '../types'
 import { AT } from '../types/ActionTypes'
 import { Reducer } from 'redux'
-import { Session } from 'blis-models'
 
 const initialState: ChatSessionState = {
     all: [],
@@ -20,7 +19,7 @@ const chatSessionReducer: Reducer<ChatSessionState> = (state = initialState, act
         case AT.DELETE_CHAT_SESSION_FULFILLED:
             return {
                 ...state,
-                all: state.all.filter((s: Session) => s.sessionId !== action.sessionId),
+                all: state.all.filter(s => s.sessionId !== action.sessionId),
                 current: state.current.sessionId === action.sessionId ? null : state.current
             }
         case AT.SET_CURRENT_CHAT_SESSION:

--- a/src/reducers/entitiesReducer.ts
+++ b/src/reducers/entitiesReducer.ts
@@ -3,6 +3,7 @@ import { EntityState } from '../types'
 import { AT } from '../types/ActionTypes'
 import { EntityBase } from 'blis-models';
 import { Reducer } from 'redux'
+import { replace } from '../util'
 
 const initialState: EntityState = [];
 
@@ -24,15 +25,7 @@ const entitiesReducer: Reducer<EntityState> = (state = initialState, action: Act
         case AT.DELETE_REVERSE_ENTITY_ASYNC:
             return state.filter(ent => ent.entityId !== action.deletedEntityId);
         case AT.EDIT_ENTITY_FULFILLED:
-            let index: number = 0;
-            for (let i = 0; i < state.length; i++) {
-                if (state[i].entityId == action.entity.entityId) {
-                    index = i
-                }
-            }
-            let newState = Object.assign([], state);
-            newState[index] = action.entity;
-            return newState;
+            return replace(state, action.entity, e => e.entityId)
         default:
             return state;
     }

--- a/src/reducers/logDialogsReducer.ts
+++ b/src/reducers/logDialogsReducer.ts
@@ -18,23 +18,7 @@ const logDialogsReducer: Reducer<LogDialogState> = (state = initialState, action
         case AT.CREATE_LOG_DIALOG:
             return { ...state, all: [...state.all, action.logDialog] };
         case AT.DELETE_LOG_DIALOG_FULFILLED:
-            return { ...state, all: state.all.filter(dialog => dialog.logDialogId !== action.logDialogId) };
-        /* TODO
-            case AT.EDIT_LOG_DIALOG_FULFILLED:
-                let index: number = 0;
-                for (let i = 0; i < state.all.length; i++) {
-                    if (state.all[i].logDialogId == action.logDialog.logDialogId) {
-                        index = i
-                    }
-                }
-                let newAll = Object.assign([], state.all);
-                newAll[index] = action.logDialog;
-                let stateToReturn: AppState = {
-                    all: newAll,
-                    current: action.logDialog
-                }
-                return stateToReturn
-        */
+            return { ...state, all: state.all.filter(dialog => dialog.logDialogId !== action.logDialogId) }
         default:
             return state;
     }

--- a/src/reducers/teachSessionReducer.ts
+++ b/src/reducers/teachSessionReducer.ts
@@ -3,6 +3,7 @@ import { Reducer } from 'redux'
 import { Teach, ExtractResponse, UnscoredAction, ScoreReason } from 'blis-models'
 import { DialogMode } from '../types/const'
 import { AT } from '../types/ActionTypes'
+import { replace } from '../util'
 
 const initialState: TeachSessionState = {
     all: [],
@@ -40,9 +41,8 @@ const teachSessionReducer: Reducer<TeachSessionState> = (state = initialState, a
             return { ...state, currentConversationStack: [...state.currentConversationStack, action.message], input: action.message, scoreInput: null, scoreResponse: null, extractResponses: [] };
         case AT.RUN_EXTRACTOR_FULFILLED:
             // Replace existing extract response (if any) with new one
-            let extractResponses: ExtractResponse[] = state.extractResponses.filter((e: ExtractResponse) => e.text != action.uiExtractResponse.extractResponse.text);
-            extractResponses.push(action.uiExtractResponse.extractResponse);
-            return { ...state, mode: DialogMode.Extractor, memories: action.uiExtractResponse.memories, prevMemories: action.uiExtractResponse.memories, extractResponses: extractResponses };
+            const updatedExtractResponses = replace(state.extractResponses, action.uiExtractResponse.extractResponse, e => e.text)
+            return { ...state, mode: DialogMode.Extractor, memories: action.uiExtractResponse.memories, prevMemories: action.uiExtractResponse.memories, extractResponses: updatedExtractResponses };
         case AT.UPDATE_EXTRACT_RESPONSE:
             // Replace existing extract response (if any) with new one and maintain ordering
             let index = state.extractResponses.findIndex((e: ExtractResponse) => e.text == action.extractResponse.text);

--- a/src/reducers/trainDialogsReducer.ts
+++ b/src/reducers/trainDialogsReducer.ts
@@ -2,6 +2,7 @@ import { ActionObject } from '../types'
 import { TrainDialogState } from '../types'
 import { AT } from '../types/ActionTypes'
 import { Reducer } from 'redux'
+import { replace } from '../util'
 
 const initialState: TrainDialogState = [];
 
@@ -18,15 +19,7 @@ const trainDialogsReducer: Reducer<TrainDialogState> = (state = initialState, ac
         case AT.DELETE_TRAIN_DIALOG_FULFILLED:
             return state.filter(dialog => dialog.trainDialogId !== action.trainDialogGUID);
         case AT.EDIT_TRAIN_DIALOG_FULFILLED:
-            let index: number = 0;
-            for (let i = 0; i < state.length; i++) {
-                if (state[i].trainDialogId == action.trainDialog.trainDialogId) {
-                    index = i
-                }
-            }
-            let newState = Object.assign([], state);
-            newState[index] = action.trainDialog;
-            return newState;
+            return replace(state, action.trainDialog, trainDialog => trainDialog.trainDialogId)
         default:
             return state;
     }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,0 +1,19 @@
+import { replace } from './util'
+
+describe('util', () => {
+    describe('replace', () => {
+        it('returns new array with item replaced and preserves order', () => {
+            // Arrange
+            const list = [{ id: 1, value: 'a' }, { id: 2, value: 'b' }, { id: 3, value: 'c' }]
+            const newItem = { id: 2, value: 'edited' }
+            const expected = [...list.slice(0, 1), newItem, ...list.slice(2)]
+
+            // Act
+            const actual = replace(list, newItem, x => x.id)
+
+            // Assert
+            expect(actual).not.toBe(expected)
+            expect(actual).toEqual(expected)
+        })
+    })
+})

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,3 +7,12 @@ export function generateGUID(): string {
     });
     return guid;
 }
+
+export function replace<T>(xs: T[], updatedX: T, getId: (x: T) => any): T[] {
+    const index = xs.findIndex(x => getId(x) === getId(updatedX))
+    if (index < 0) {
+        throw new Error(`You attempted to replace item in list with id: ${getId(updatedX)} but no item could be found.  Perhaps you meant to add the item to the list or it was already removed.`)
+    }
+
+    return [...xs.slice(0, index), updatedX, ...xs.slice(index + 1)]
+}


### PR DESCRIPTION
There was really weird code for update that was iterating through the whole list of item even though it already found a matching index.  It was also a standard operation that should be consistent for all arrays so I moved it to utility.