### PR TITLE
Remove usage of global blisApps.current in favor of app props.

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -10,7 +10,7 @@ import {
     PrimaryButton, DefaultButton, Dropdown, TagPicker,
     TextField, Label, Checkbox, List, ITag
 } from 'office-ui-fabric-react'
-import { ActionBase, ActionMetaData, ActionTypes, EntityBase, ModelUtils } from 'blis-models'
+import { ActionBase, ActionMetaData, ActionTypes, BlisAppBase, EntityBase, ModelUtils } from 'blis-models'
 import { State } from '../../types';
 import EntityCreatorEditor from './EntityCreatorEditor';
 import { BlisTagItem, IBlisPickerItemProps, IBlisTag } from './BlisTagItem';
@@ -245,7 +245,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         this.props.handleClose(null);
     }
     onClickCreate() {
-        let currentAppId: string = this.props.blisApps.current.appId;
+        let currentAppId: string = this.props.app.appId;
         let requiredEntities = this.state.reqEntitiesVal.map(req => {
             let found = this.props.entities.find(e => e.entityName === req.key)
             return found.entityId
@@ -970,6 +970,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                         </div>
                     </div>
                     <EntityCreatorEditor
+                        app={this.props.app}
                         open={this.state.entityModalOpen}
                         entity={null}
                         handleClose={this.entityCreatorHandleClose}
@@ -992,7 +993,6 @@ const mapStateToProps = (state: State, ownProps: any) => {
     return {
         userKey: state.user.key,
         actions: state.actions,
-        blisApps: state.apps,
         entities: state.entities,
         botInfo: state.bot.botInfo
     }
@@ -1002,6 +1002,7 @@ export interface ReceiveProps {
     open: boolean,
     blisAction: ActionBase | null,
     handleClose: (action: ActionBase) => void,
+    app: BlisAppBase
     handleOpenDeleteModal: (actionId: string) => void
 }
 

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -5,7 +5,7 @@ import { returntypeof } from 'react-redux-typescript';
 import { ModelUtils } from 'blis-models';
 import { State } from '../../types'
 import { 
-    TrainScorerStep, Memory, ScoredBase, ScoreInput, ScoreResponse, 
+    BlisAppBase, TrainScorerStep, Memory, ScoredBase, ScoreInput, ScoreResponse, 
     ActionBase, ScoredAction, UnscoredAction, ScoreReason, DialogType } from 'blis-models';
 import { toggleAutoTeach } from '../../actions/teachActions'
 import { PrimaryButton } from 'office-ui-fabric-react';
@@ -509,6 +509,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
                         onRenderDetailsHeader(detailsHeaderProps, defaultRender)}
                 />
                 <ActionCreatorEditor
+                    app={this.props.app}
                     open={this.state.actionModalOpen}
                     blisAction={null}
                     handleClose={this.handleCloseActionModal}
@@ -520,7 +521,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
 }
 
 export interface ReceivedProps {
-    appId: string,
+    app: BlisAppBase
     dialogType: DialogType,
     sessionId: string,
     autoTeach: boolean,
@@ -543,9 +544,10 @@ const mapStateToProps = (state: State, ownProps: any) => {
         actions: state.actions
     }
 }
+
 // Props types inferred from mapStateToProps & dispatchToProps
 const stateProps = returntypeof(mapStateToProps);
 const dispatchProps = returntypeof(mapDispatchToProps);
 type Props = typeof stateProps & typeof dispatchProps & ReceivedProps;
 
-export default connect<typeof stateProps, typeof dispatchProps, {}>(mapStateToProps, mapDispatchToProps)(ActionScorer);
+export default connect<typeof stateProps, typeof dispatchProps, ReceivedProps>(mapStateToProps, mapDispatchToProps)(ActionScorer);

--- a/src/components/modals/EntityCreatorEditor.tsx
+++ b/src/components/modals/EntityCreatorEditor.tsx
@@ -10,7 +10,7 @@ import ActionDetailsList from '../ActionDetailsList'
 import { State, PreBuiltEntities } from '../../types';
 import { BlisDropdownOption } from './BlisDropDownOption'
 import { GetTip, TipType } from '../ToolTips'
-import { EntityBase, EntityMetaData, EntityType, ActionBase } from 'blis-models'
+import { BlisAppBase, EntityBase, EntityMetaData, EntityType, ActionBase } from 'blis-models'
 import './EntityCreatorEditor.css'
 
 const NEW_ENTITY = 'New Entity';
@@ -56,7 +56,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
 
     componentWillReceiveProps(p: Props) {
         // Build entity options based on current applicaiton locale
-        const currentAppLocale = this.props.blisApps.current.locale
+        const currentAppLocale = this.props.app.locale
         const localePreBuiltEntities = PreBuiltEntities
             .find(obj => obj.locale === currentAppLocale)
 
@@ -126,7 +126,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
 
     onClickSubmit = () => {
         const entity = this.convertStateToEntity(this.state)
-        let currentAppId = this.props.blisApps.current.appId;
+        let currentAppId = this.props.app.appId
 
         if (this.state.editing === false) {
             this.props.createEntityAsync(this.props.userKey, entity, currentAppId);
@@ -384,7 +384,6 @@ const mapStateToProps = (state: State, ownProps: any) => {
         userKey: state.user.key,
         entities: state.entities,
         actions: state.actions,
-        blisApps: state.apps
     }
 }
 
@@ -393,6 +392,7 @@ export interface ReceivedProps {
     entity: EntityBase | null,
     handleClose: Function,
     entityTypeFilter: EntityType | null,
+    app: BlisAppBase
     handleOpenDeleteModal: (entityId: string) => void
 }
 

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -3,7 +3,7 @@ import { returntypeof } from 'react-redux-typescript';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { State } from '../../types'
-import { ModelUtils, ExtractResponse, TextVariation, DialogType, EntityType } from 'blis-models'
+import { BlisAppBase, ModelUtils, ExtractResponse, TextVariation, DialogType, EntityType } from 'blis-models'
 import * as OF from 'office-ui-fabric-react';
 import TextVariationCreator from '../TextVariationCreator';
 import ExtractorResponseEditor from '../ExtractorResponseEditor';
@@ -249,7 +249,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
         if (canEdit) {
 
             variationCreator = <TextVariationCreator
-                appId={this.props.appId}
+                appId={this.props.app.appId}
                 sessionId={this.props.sessionId}
                 extractType={this.props.extractType}
                 roundIndex={this.props.roundIndex}
@@ -331,11 +331,13 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                 <div>
                     <div className="blis-dialog-creation-buttons">
                         <EntityCreatorEditor
+                            app={this.props.app}
                             open={this.state.entityModalOpen}
                             entity={null}
                             handleClose={this.entityEditorHandleClose}
                             handleOpenDeleteModal={()=>{}}
-                            entityTypeFilter={EntityType.LUIS}/>
+                            entityTypeFilter={EntityType.LUIS}
+                        />
                     </div>
                     {extractDisplay}
                     {variationCreator}
@@ -392,7 +394,7 @@ const mapStateToProps = (state: State, ownProps: any) => {
 }
 
 export interface ReceivedProps {
-    appId: string,
+    app: BlisAppBase,
     extractType: DialogType,
     sessionId: string,
     roundIndex: number,

--- a/src/components/modals/LogDialogAdmin.tsx
+++ b/src/components/modals/LogDialogAdmin.tsx
@@ -9,7 +9,7 @@ import ActionScorer from './ActionScorer';
 import MemoryTable from './MemoryTable';
 import * as OF from 'office-ui-fabric-react'
 import { Activity } from 'botframework-directlinejs'
-import { TrainExtractorStep, TrainScorerStep, TextVariation, 
+import { BlisAppBase, TrainExtractorStep, TrainScorerStep, TextVariation, 
         Memory, TrainDialog, TrainRound, 
         LogDialog, LogRound, LogScorerStep, 
         ActionBase, EntityBase, ExtractResponse, 
@@ -190,7 +190,7 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
                         <div>
                             {round &&
                                 <EntityExtractor
-                                    appId={this.props.appId}
+                                    app={this.props.app}
                                     extractType={DialogType.LOGDIALOG}
                                     sessionId={this.props.logDialog.logDialogId}
                                     roundIndex={this.state.roundIndex}
@@ -210,7 +210,7 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
                         <div>
                             {action &&
                                 <ActionScorer
-                                    appId={this.props.appId}
+                                    app={this.props.app}
                                     dialogType={DialogType.LOGDIALOG}
                                     sessionId={this.props.logDialog.logDialogId}
                                     autoTeach={false}
@@ -253,7 +253,6 @@ const mapDispatchToProps = (dispatch: any) => {
 }
 const mapStateToProps = (state: State) => {
     return {
-        appId: state.apps.current.appId,
         actions: state.actions,
         entities: state.entities,
         extractResponses: state.teachSessions.extractResponses,
@@ -261,6 +260,7 @@ const mapStateToProps = (state: State) => {
 }
 
 export interface ReceivedProps {
+    app: BlisAppBase
     logDialog: LogDialog
     selectedActivity: Activity
     onSaveChanges: (trainDialog: TrainDialog) => void

--- a/src/components/modals/LogDialogModal.tsx
+++ b/src/components/modals/LogDialogModal.tsx
@@ -131,6 +131,7 @@ class LogDialogModal extends React.Component<Props, ComponentState> {
                             <div className="blis-chatmodal_controls">
                                 <div className="blis-chatmodal_admin-controls">
                                     <LogDialogAdmin
+                                        app={this.props.app}
                                         logDialog={this.props.logDialog}
                                         selectedActivity={this.state.selectedActivity}
                                         onSaveChanges={trainDialog => this.onSaveDialogChanges(trainDialog)}

--- a/src/components/modals/TeachSessionAdmin.tsx
+++ b/src/components/modals/TeachSessionAdmin.tsx
@@ -86,7 +86,7 @@ class TeachSessionAdmin extends React.Component<Props, {}> {
                         <div>
                             {(mode === DialogMode.Extractor || autoTeachWithRound) &&
                                 <EntityExtractor
-                                    appId={this.props.app.appId}
+                                    app={this.props.app}
                                     extractType={DialogType.TEACH}
                                     sessionId={this.props.teachSession.current.teachId}
                                     roundIndex={null}
@@ -105,7 +105,7 @@ class TeachSessionAdmin extends React.Component<Props, {}> {
                         <div>
                             {(mode === DialogMode.Scorer || autoTeachWithRound) &&
                                 <ActionScorer
-                                    appId={this.props.app.appId}
+                                    app={this.props.app}
                                     dialogType={DialogType.TEACH}
                                     sessionId={this.props.teachSession.current.teachId}
                                     autoTeach={this.props.teachSession.autoTeach}

--- a/src/components/modals/TrainDialogAdmin.tsx
+++ b/src/components/modals/TrainDialogAdmin.tsx
@@ -12,7 +12,7 @@ import ActionScorer from './ActionScorer';
 import MemoryTable from './MemoryTable';
 import { Activity } from 'botframework-directlinejs'
 import * as OF from 'office-ui-fabric-react';
-import { ActionBase, TrainDialog, TrainRound, ScoreReason, ScoredAction,
+import { ActionBase, BlisAppBase, TrainDialog, TrainRound, ScoreReason, ScoredAction,
     TrainScorerStep, Memory, UnscoredAction, ScoreResponse,
     TextVariation, ExtractResponse, DialogType } from 'blis-models'
 
@@ -104,7 +104,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
         }  
         // Otherwise just save with new text variations, remaining rounds are ok
         else {
-            this.props.editTrainDialogAsync(this.props.user.key, updatedTrainDialog, this.props.appId);
+            this.props.editTrainDialogAsync(this.props.user.key, updatedTrainDialog, this.props.app.appId);
             this.props.clearExtractResponses();
         }
     }    
@@ -143,7 +143,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
 
     onClickSaveCheckYes() {
         // Submit saved extractions
-        this.props.editTrainDialogAsync(this.props.user.key, this.state.saveTrainDialog, this.props.appId);
+        this.props.editTrainDialogAsync(this.props.user.key, this.state.saveTrainDialog, this.props.app.appId);
         this.props.clearExtractResponses();
 
         this.setState({
@@ -269,7 +269,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
                         <div>
                             {renderData.round ?
                                 <EntityExtractor
-                                    appId={this.props.appId}
+                                    app={this.props.app}
                                     extractType={DialogType.TRAINDIALOG}
                                     sessionId={this.props.trainDialog.trainDialogId}
                                     roundIndex={this.state.roundIndex}
@@ -289,7 +289,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
                         <div className="blis-dialog-admin-title">Action</div>
                         <div>
                                 <ActionScorer
-                                    appId={this.props.appId}
+                                    app={this.props.app}
                                     dialogType={DialogType.TRAINDIALOG}
                                     sessionId={this.props.trainDialog.trainDialogId}
                                     autoTeach={false}
@@ -334,7 +334,6 @@ const mapDispatchToProps = (dispatch: any) => {
 const mapStateToProps = (state: State) => {
     return {
         user: state.user,
-        appId: state.apps.current.appId,
         actions: state.actions,
         entities: state.entities,
         extractResponses: state.teachSessions.extractResponses
@@ -351,6 +350,7 @@ interface ComponentState {
 
 export interface ReceivedProps {
     trainDialog: TrainDialog,
+    app: BlisAppBase
     selectedActivity: Activity
 }
 

--- a/src/components/modals/TrainDialogWindow.tsx
+++ b/src/components/modals/TrainDialogWindow.tsx
@@ -134,6 +134,7 @@ class TrainDialogWindow extends React.Component<Props, ComponentState> {
                         <div className="blis-chatmodal_controls">
                             <div className="blis-chatmodal_admin-controls">
                                 <TrainDialogAdmin
+                                    app={this.props.app}
                                     trainDialog={this.props.trainDialog}
                                     selectedActivity={this.state.selectedActivity}
                                 />

--- a/src/reducers/appsReducer.ts
+++ b/src/reducers/appsReducer.ts
@@ -5,8 +5,7 @@ import { Reducer } from 'redux'
 import { replace } from '../util'
 
 const initialState: AppState = {
-    all: [],
-    current: null
+    all: []
 };
 
 const appsReducer: Reducer<AppState> = (state = initialState, action: ActionObject): AppState => {
@@ -18,14 +17,11 @@ const appsReducer: Reducer<AppState> = (state = initialState, action: ActionObje
         case AT.CREATE_BLIS_APPLICATION_FULFILLED:
             return { ...state, all: [...state.all, action.blisApp] }
         case AT.SET_CURRENT_BLIS_APP_FULFILLED:
-            return { ...state, current: action.app };
+            return { ...state };
         case AT.DELETE_BLIS_APPLICATION_FULFILLED:
             return { ...state, all: state.all.filter(app => app.appId !== action.blisAppGUID) };
         case AT.EDIT_BLIS_APPLICATION_FULFILLED:
-            return {
-                all: replace(state.all, action.blisApp, app => app.appId),
-                current: action.blisApp
-            }
+            return { ...state, all: replace(state.all, action.blisApp, app => app.appId) }
         default:
             return state;
     }

--- a/src/routes/Apps/App/Actions.tsx
+++ b/src/routes/Apps/App/Actions.tsx
@@ -172,6 +172,7 @@ class Actions extends React.Component<Props, ComponentState> {
                     })}
                 />
                 <ActionCreatorEditor
+                    app={this.props.app}
                     open={this.state.isActionEditorModalOpen}
                     blisAction={this.state.actionSelected}
                     handleClose={this.onClickCloseActionEditor}

--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -283,6 +283,7 @@ class Entities extends React.Component<Props, ComponentState> {
                         componentRef={component => this.newEntityButton = component}
                     />
                     <EntityCreatorEditor
+                        app={this.props.app}
                         open={this.state.createEditModalOpen}
                         entity={this.state.entitySelected}
                         handleClose={this.handleCloseCreateModal}

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -96,29 +96,29 @@ class Settings extends React.Component<Props, ComponentState> {
         this.onClickDiscard = this.onClickDiscard.bind(this)
     }
     componentWillMount() {
-        let current: BlisAppBase = this.props.blisApps.current
+        let app = this.props.app
         this.setState({
-            localeVal: current.locale,
-            appIdVal: current.appId,
-            appNameVal: current.appName,
-            luisKeyVal: current.luisKey,
-            botFrameworkAppsVal: current.metadata.botFrameworkApps,
+            localeVal: app.locale,
+            appIdVal: app.appId,
+            appNameVal: app.appName,
+            luisKeyVal: app.luisKey,
+            botFrameworkAppsVal: app.metadata.botFrameworkApps,
             newBotVal: ""
         })
     }
     componentDidUpdate() {
-        let current: BlisAppBase = this.props.blisApps.current
-        if (this.state.edited == false && (this.state.localeVal !== current.locale ||
-            this.state.appIdVal !== current.appId ||
-            this.state.appNameVal !== current.appName ||
-            this.state.luisKeyVal !== current.luisKey ||
-            this.state.botFrameworkAppsVal !== current.metadata.botFrameworkApps)) {
+        let app = this.props.app
+        if (this.state.edited == false && (this.state.localeVal !== app.locale ||
+            this.state.appIdVal !== app.appId ||
+            this.state.appNameVal !== app.appName ||
+            this.state.luisKeyVal !== app.luisKey ||
+            this.state.botFrameworkAppsVal !== app.metadata.botFrameworkApps)) {
             this.setState({
-                localeVal: current.locale,
-                appIdVal: current.appId,
-                appNameVal: current.appName,
-                luisKeyVal: current.luisKey,
-                botFrameworkAppsVal: current.metadata.botFrameworkApps
+                localeVal: app.locale,
+                appIdVal: app.appId,
+                appNameVal: app.appName,
+                luisKeyVal: app.luisKey,
+                botFrameworkAppsVal: app.metadata.botFrameworkApps
             })
         }
     }
@@ -155,35 +155,34 @@ class Settings extends React.Component<Props, ComponentState> {
         )
     }
     onClickDiscard() {
-        let current: BlisAppBase = this.props.blisApps.current
+        let app = this.props.app
         this.setState({
-            localeVal: current.locale,
-            appIdVal: current.appId,
-            appNameVal: current.appName,
-            luisKeyVal: current.luisKey,
-            botFrameworkAppsVal: current.metadata.botFrameworkApps,
+            localeVal: app.locale,
+            appIdVal: app.appId,
+            appNameVal: app.appName,
+            luisKeyVal: app.luisKey,
+            botFrameworkAppsVal: app.metadata.botFrameworkApps,
             edited: false,
             newBotVal: ""
         })
     }
     onClickSave() {
-        let current: BlisAppBase = this.props.blisApps.current;
-        let meta: BlisAppMetaData = new BlisAppMetaData({
-            botFrameworkApps: this.state.botFrameworkAppsVal
-        })
-        let appToAdd = new BlisAppBase({
+        let app = this.props.app
+        let modifiedApp = new BlisAppBase({
             appName: this.state.appNameVal,
-            appId: current.appId,
+            appId: app.appId,
             luisKey: this.state.luisKeyVal,
-            locale: current.locale,
-            metadata: meta
+            locale: app.locale,
+            metadata: new BlisAppMetaData({
+                botFrameworkApps: this.state.botFrameworkAppsVal
+            })
         })
-        this.props.editBLISApplicationAsync(this.props.userKey, appToAdd);
+        this.props.editBLISApplicationAsync(this.props.userKey, modifiedApp);
         this.setState({
-            localeVal: current.locale,
-            appIdVal: current.appId,
-            appNameVal: current.appName,
-            luisKeyVal: current.luisKey,
+            localeVal: app.locale,
+            appIdVal: app.appId,
+            appNameVal: app.appName,
+            luisKeyVal: app.luisKey,
             edited: false,
             newBotVal: ""
         })
@@ -200,7 +199,7 @@ class Settings extends React.Component<Props, ComponentState> {
         }
 
         // Check that name isn't in use
-        let foundApp = this.props.blisApps.all.find(a => (a.appName == value && a.appId != this.props.app.appId));
+        let foundApp = this.props.apps.find(a => (a.appName == value && a.appId != this.props.app.appId));
         if (foundApp) {
             return intl.formatMessage(messages.fieldErrorDistinct)
         }
@@ -341,7 +340,7 @@ const mapDispatchToProps = (dispatch: any) => {
 const mapStateToProps = (state: State) => {
     return {
         userKey: state.user.key,
-        blisApps: state.apps
+        apps: state.apps.all
     }
 }
 

--- a/src/routes/Apps/AppsIndex.tsx
+++ b/src/routes/Apps/AppsIndex.tsx
@@ -57,6 +57,7 @@ class AppsIndex extends React.Component<Props, ComponentState> {
                     app={this.state.selectedApp}
                 />
                 : <AppsList
+                    apps={this.props.apps}
                     onCreateApp={this.onCreateApp}
                     onSelectedAppChanged={app => this.onSelectedAppChanged(app)}
                     onClickDeleteApp={app => this.onClickDeleteApp(app)}
@@ -82,6 +83,7 @@ const mapDispatchToProps = (dispatch: any) => {
 
 const mapStateToProps = (state: State) => {
     return {
+        apps: state.apps.all,
         display: state.display,
         user: state.user
     }

--- a/src/routes/Apps/AppsList.tsx
+++ b/src/routes/Apps/AppsList.tsx
@@ -160,7 +160,7 @@ class AppsList extends React.Component<Props, ComponentState> {
     }
 
     getSortedApplications(): BlisAppBase[] {
-        let sortedApps = this.props.apps.all || [];
+        let sortedApps = this.props.apps
 
         if (this.state.sortColumn) {
             // Sort the items.
@@ -241,11 +241,11 @@ const mapDispatchToProps = (dispatch: any) => {
 }
 const mapStateToProps = (state: State) => {
     return {
-        apps: state.apps
     }
 }
 
 export interface ReceivedProps {
+    apps: BlisAppBase[]
     onCreateApp: (app: BlisAppBase) => void
     onSelectedAppChanged: (app: BlisAppBase) => void
     onClickDeleteApp: (app: BlisAppBase) => void

--- a/src/types/StateTypes.ts
+++ b/src/types/StateTypes.ts
@@ -22,8 +22,7 @@ export type LogDialogState = {
     all: LogDialog[]
 }
 export type AppState = {
-    all: BlisAppBase[],
-    current: BlisAppBase
+    all: BlisAppBase[]
 }
 export type BotState = {
     botInfo: BotInfo


### PR DESCRIPTION
I had this old branch before hackathon forgot to merge it back in to master.  It was intended to be more preparation to move towards app page routing such as `/apps/app1/entities` instead of everything being on the same `/home` route, but was too risky at the time.

Changing to props isn't much of functional change.  The more significant change is to lift knowledge about current app out of these components and not let them dispatch actions which need app directly. Then we can remove the need to pass current app down that many layers.
This type of information should only be known by a container component.

Also, there looks like we have modals being nested very deeply within other components which makes this difficult.
