### PR TITLE
[Bug]: Fix login message id

### DIFF
--- a/src/components/modals/UserLogin.tsx
+++ b/src/components/modals/UserLogin.tsx
@@ -87,11 +87,11 @@ class UserLogin extends React.Component<Props, ComponentState> {
                         onKeyDown={this.onKeyDown}
                         onChanged={this.onChangedName}
                         label={this.props.intl.formatMessage({
-                            id: FM.USERLOGIN_PASSWORDFIELDLABEL,
+                            id: FM.USERLOGIN_USERNAMEFIELDLABEL,
                             defaultMessage: "Name"
                         })}
                         placeholder={this.props.intl.formatMessage({
-                            id: FM.USERLOGIN_PASSWORDFIELDPLACEHOLDER,
+                            id: FM.USERLOGIN_USERNAMEFIELDPLACEHOLDER,
                             defaultMessage: "User Name..."
                         })}
                         value={this.state.userName}


### PR DESCRIPTION
The password message id was used for the username field's label and placeholder message id causing the login prompt to ask for password twice. Bug introduced with the commit which changed message ids to enums: 58b61d78. This updates them to use correct id.