### PR TITLE
[Bug]: Fix ExtractorResponseEditor not removing event listner when unmounted

### DIFF
--- a/src/components/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor.tsx
@@ -89,6 +89,7 @@ interface ComponentState {
 }
 
 class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
+    boundOnGlobalClick: () => void
     constructor(p: any) {
         super(p);
         this.state = {
@@ -150,11 +151,12 @@ class ExtractorResponseEditor extends React.Component<Props, ComponentState> {
     }
     componentDidMount() {
         this.setInitialValues(this.props)
-        document.addEventListener('click', this.onGlobalClick.bind(this), false);
+        this.boundOnGlobalClick = this.onGlobalClick.bind(this)
+        document.addEventListener('click', this.boundOnGlobalClick, false)
     }
 
     componentWillUnmount() {
-        document.removeEventListener('click', this.onGlobalClick.bind(this), false);
+        document.removeEventListener('click', this.boundOnGlobalClick, false)
     }
     setInitialValues(props: Props) {
         this.setState({


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2856501/32343461-bba7d328-bfc0-11e7-9334-04a1a2c18334.png)

removeEventHandler should be given reference the same function that was given to addEventListener