### PR TITLE
Add tooltip delay (default medium) to prevent flashing of white box as mouse moves across headers

### DIFF
--- a/src/components/ToolTips.tsx
+++ b/src/components/ToolTips.tsx
@@ -36,7 +36,7 @@ export function onRenderDetailsHeader(detailsHeaderProps: OF.IDetailsHeaderProps
                                     let ttHP = {...tooltipHostProps};
                                     ttHP.tooltipProps =  {
                                         onRenderContent: () => { return tip },
-                                        delay: OF.TooltipDelay.zero,
+                                        delay: OF.TooltipDelay.medium,
                                         directionalHint: OF.DirectionalHint.topCenter
                                     };
                                     return <OF.TooltipHost {...ttHP} />

--- a/src/components/modals/EntityCreatorEditor.tsx
+++ b/src/components/modals/EntityCreatorEditor.tsx
@@ -308,7 +308,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                             tooltipProps={{
                                 onRenderContent: () => { return GetTip(TipType.ENTITY_PROGAMMATIC) }
                             }}
-                            delay={OF.TooltipDelay.zero}
+                            delay={OF.TooltipDelay.medium}
                             directionalHint={OF.DirectionalHint.bottomCenter}
                         >
                             <span className="ms-fontColor-themeTertiary">
@@ -339,7 +339,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                             tooltipProps={{
                                 onRenderContent: () => { return GetTip(TipType.ENTITY_MULTIVALUE) }
                             }}
-                            delay={OF.TooltipDelay.zero}
+                            delay={OF.TooltipDelay.medium}
                             directionalHint={OF.DirectionalHint.bottomCenter}
                         >
                             <span className="ms-fontColor-themeTertiary">
@@ -370,7 +370,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                             tooltipProps={{
                                 onRenderContent: () => { return GetTip(TipType.ENTITY_NEGATABLE) }
                             }}
-                            delay={OF.TooltipDelay.zero}
+                            delay={OF.TooltipDelay.medium}
                             directionalHint={OF.DirectionalHint.bottomCenter}
                         >
                             <span className="ms-fontColor-themeTertiary">


### PR DESCRIPTION
With 0 delay there were cases where user didn't intend for tooltip to show and it was becoming distracting.