### PR TITLE
Add default sort column to applications list to make it easier to find apps

### DIFF
--- a/src/routes/Apps/AppsList.tsx
+++ b/src/routes/Apps/AppsList.tsx
@@ -84,12 +84,20 @@ const ifStringReturnLowerCase = (s: string | number) => {
 }
 
 class AppsList extends React.Component<Props, ComponentState> {
-    state: ComponentState = {
-        isAppCreateModalOpen: false,
-        isConfirmDeleteAppModalOpen: false,
-        appToDelete: null,
-        columns: getColumns(this.props.intl),
-        sortColumn: null
+    constructor(props: Props) {
+        super(props)
+
+        const columns = getColumns(this.props.intl)
+        const defaultSortColumn = columns.find(c => c.key === "appName")
+        defaultSortColumn.isSorted = true
+        
+        this.state = {
+            isAppCreateModalOpen: false,
+            isConfirmDeleteAppModalOpen: false,
+            appToDelete: null,
+            columns,
+            sortColumn: defaultSortColumn
+        }
     }
 
     onConfirmDeleteModal() {


### PR DESCRIPTION
I'm not sure what the sort order is from the server, perhaps just however they were returned from the database so probably created time but it was difficult to scan through the list to find a particular application.  This sorts them alphabetically by application name