### PR TITLE
Make medium modals (Action and Entity) responsive so they are less space constrained on small screens (Laptop)

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -106,9 +106,36 @@ html {
 
 .blis-modal.blis-modal--medium{
   width: 60%;
-  height: 60%;
+  height: 70%;
   /* TODO: Remove padding here, it should be the content inside that decides padding, otherwise all modals should have padding */
   padding: 1em;
+}
+@media (max-width: 600px) {
+  .blis-modal.blis-modal--medium {
+    width: 90%;
+  }
+}
+@media (max-height: 700px) {
+  .blis-modal.blis-modal--medium {
+    height: 90%;
+  }
+}
+
+@media (min-width: 601px) and (max-width: 1200px) {
+  .blis-modal.blis-modal--medium {
+    width: 75%;
+  }
+}
+@media (min-height: 701px) and (max-height: 800px) {
+  .blis-modal.blis-modal--medium {
+    height: 80%;
+  }
+}
+
+@media (min-width: 1201px) {
+  .blis-modal.blis-modal--medium {
+    width: 50%;
+  }
 }
 
 .blis-modal.blis-modal--small{


### PR DESCRIPTION
Noticed Adam was having difficulty constantly scrolling up and down the modal.  His screen was standard laptop and we should support that too instead of only FHD resolution.  Updates CSS to scale the modal  size so the actual usable space of stays relatively the same regardless of screen size.