### PR TITLE
[Bug]: Require entities should not have strike through

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -284,7 +284,7 @@ html {
 }
 
 .ms-TagItem-text--highlight {
-  background-color: var(--color-tag-highlight);
+  background-color: var(--color-themeLighter);
 }
 
 .ms-TagItem-close {

--- a/src/components/BlisTagPicker.css
+++ b/src/components/BlisTagPicker.css
@@ -10,6 +10,7 @@
 .blis-tagpicker .ms-BasePicker-text.ms-BasePicker-text--static {
     border-right: none;
     min-width: 0;
+    flex-wrap: nowrap;
 }
 .blis-tagpicker .ms-BasePicker-text:not(.ms-BasePicker-text--static) {
     border-left: none;

--- a/src/components/BlisTagPicker.tsx
+++ b/src/components/BlisTagPicker.tsx
@@ -1,32 +1,38 @@
 import * as React from 'react';
 import * as OF from 'office-ui-fabric-react'
 import HelpIcon from './HelpIcon'
-import { TipType } from '../components/ToolTips';
+import { TipType } from '../components/ToolTips'
 import './BlisTagPicker.css'
 
+/**
+ * It would be better to take in render functions or components instead of declarative options such as highlight or strike through which are not flexible
+ * Also, this has overlap with the BlisTagItem component which could be used here.
+ */
 export interface IBlisTagPickerProps extends OF.ITagPickerProps {
-    label: string,
+    label: string
     tipType: TipType
     nonRemovableTags: OF.ITag[]
+    nonRemoveableHighlight?: boolean
+    nonRemoveableStrikethrough?: boolean
 }
 export const component = (props: IBlisTagPickerProps) => {
-    const { nonRemovableTags, ...tagPickerProps } = props
+    const { nonRemovableTags, nonRemoveableHighlight = true, nonRemoveableStrikethrough = true, ...tagPickerProps } = props
     return (
         <div>
             <OF.Label>{props.label}
-                <HelpIcon tipType={props.tipType}/>
+                <HelpIcon tipType={props.tipType} />
             </OF.Label>
             <div className="blis-tagpicker">
                 <div className="ms-BasePicker-text ms-BasePicker-text--static pickerText_4c4c5cb3" role="list">
                     {nonRemovableTags.map(tag => (
-                        <div className="ms-TagItem ms-TagItem-text--highlight" tabIndex={0} key={tag.key}>
-                            <span className="ms-TagItem-text ms-TagItem-text--strike" aria-label="name">{tag.name}</span>
+                        <div className={`ms-TagItem ${nonRemoveableHighlight ? 'ms-TagItem-text--highlight' : ''}`} tabIndex={0} key={tag.key}>
+                            <span className={`ms-TagItem-text ${nonRemoveableStrikethrough ? 'ms-TagItem-text--strike' : ''}`} aria-label={tag.name}>{tag.name}</span>
                         </div>
                     ))}
                 </div>
                 <OF.TagPicker {...tagPickerProps} />
             </div>
-            </div>
+        </div>
     )
 }
 

--- a/src/components/modals/ActionCreatorEditor.css
+++ b/src/components/modals/ActionCreatorEditor.css
@@ -1,0 +1,6 @@
+.blis-action-creator--expected-entities .ms-TagItem-text--highlight {
+    background-color: var(--color-successBackground);
+}
+.blis-action-creator--blocking-entities .ms-BasePicker-text--static .ms-TagItem-text--highlight {
+    background-color: var(--color-successBackground);
+}

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -51,7 +51,7 @@ const getSuggestedTags = (filterText: string, allTags: OF.ITag[], tagsToExclude:
     if (filterText.length === 0) {
         return availableTags
     }
-    
+
     return availableTags
         .filter(tag => tag.name.toLowerCase().startsWith(filterText.toLowerCase()))
 }
@@ -352,7 +352,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         const isPayloadValid = actionTypeOption.key === ActionTypes.API_LOCAL
             ? true
             : this.state.mentionEditorState.getCurrentContent().hasText()
-            
+
         this.setState({
             isPayloadValid,
             selectedActionTypeOptionKey: actionTypeOption.key
@@ -377,7 +377,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
     onRenderExpectedTag = (props: IBlisPickerItemProps<OF.ITag>): JSX.Element => {
         const renderProps = { ...props }
         renderProps.highlight = true
-        return <BlisTagItem{...renderProps}>{props.item.name}</BlisTagItem>
+        return <BlisTagItem key={props.index} {...renderProps}>{props.item.name}</BlisTagItem>
     }
 
     onChangeExpectedEntityTags = (tags: OF.ITag[]) => {
@@ -406,11 +406,11 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         const locked = this.state.requiredEntityTagsFromPayload.some(t => t.key === props.key)
 
         // Strickout and lock/highlight if also the suggested entity
-        renderProps.strike = true
+        renderProps.strike = false
         renderProps.locked = locked
         renderProps.highlight = locked
 
-        return <BlisTagItem {...renderProps}>{props.item.name}</BlisTagItem>
+        return <BlisTagItem key={props.index} {...renderProps}>{props.item.name}</BlisTagItem>
     }
 
     onResolveNegativeEntityTags(filterText: string, selectedTags: OF.ITag[]): OF.ITag[] {
@@ -436,7 +436,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         renderProps.locked = suggestedEntityKey === props.key
         renderProps.highlight = suggestedEntityKey === props.key
 
-        return <BlisTagItem {...renderProps}>{props.item.name}</BlisTagItem>
+        return <BlisTagItem key={props.index} {...renderProps}>{props.item.name}</BlisTagItem>
     }
 
     onChangeMentionEditor = (editorState: EditorState) => {
@@ -510,7 +510,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                         <div className={(this.state.isPayloadValid ? '' : 'editor--error')}>
                             <div>
                                 <ActionPayloadEditor
-                                    label={this.state.selectedActionTypeOptionKey === ActionTypes.API_LOCAL ? 
+                                    label={this.state.selectedActionTypeOptionKey === ActionTypes.API_LOCAL ?
                                         'Arguments (Comma Separated)' : 'Response...'}
                                     allSuggestions={getMentionsAvailableForPayload}
                                     editorState={this.state.mentionEditorState}
@@ -518,7 +518,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                     placeholder={this.state.selectedActionTypeOptionKey === ActionTypes.API_LOCAL ? "Arguments..." : "Phrase..."}
                                     onChange={this.onChangeMentionEditor}
                                     disabled={isPayloadDisabled}
-                                    tipType={this.state.selectedActionTypeOptionKey === ActionTypes.API_LOCAL ? 
+                                    tipType={this.state.selectedActionTypeOptionKey === ActionTypes.API_LOCAL ?
                                         ToolTip.TipType.ACTION_ARGUMENTS : ToolTip.TipType.ACTION_RESPONSE_TEXT}
                                 />
                             </div>
@@ -529,8 +529,8 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                     </p>
                                 </div>)}
                         </div>
-       
-                        <div>
+
+                        <div className="blis-action-creator--expected-entities">
                             <TC.TagPicker
                                 label="Expected Entity in Response..."
                                 onResolveSuggestions={(text, tags) => this.onResolveExpectedEntityTags(text, tags)}
@@ -547,9 +547,10 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                 tipType={ToolTip.TipType.ACTION_SUGGESTED}
                             />
                         </div>
-                        <div>
+                        <div className="blis-action-creator--required-entities">
                             <BlisTagPicker
                                 nonRemovableTags={this.state.requiredEntityTagsFromPayload}
+                                nonRemoveableStrikethrough={false}
                                 label="Required Entities"
                                 onResolveSuggestions={(text, tags) => this.onResolveRequiredEntityTags(text, tags)}
                                 onRenderItem={this.onRenderRequiredEntityTag}
@@ -566,7 +567,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                             />
                         </div>
 
-                        <div>
+                        <div className="blis-action-creator--blocking-entities">
                             <BlisTagPicker
                                 nonRemovableTags={this.state.expectedEntityTags}
                                 label="Blocking Entities"

--- a/src/components/modals/ActionPayloadEditor/ActionPayloadEditor.css
+++ b/src/components/modals/ActionPayloadEditor/ActionPayloadEditor.css
@@ -34,7 +34,7 @@
 .draftJsMentionPlugin__mention__29BEd,
 .draftJsMentionPlugin__mention__29BEd:visited {
     display: inline-block;
-    background: var(--color-tag-highlight);
+    background: var(--color-themeLighter);
     padding-left: 2px;
     padding-right: 2px;
     border-radius: 2px;
@@ -45,7 +45,7 @@
   
 .draftJsMentionPlugin__mention__29BEd:hover,
 .draftJsMentionPlugin__mention__29BEd:focus {
-    background: var(--color-tag-highlight);
+    background: var(--color-themeLighter);
     outline: 0; /* reset for :focus */
 }
 
@@ -62,7 +62,7 @@
 }
   
 .draftJsMentionPlugin__mentionSuggestionsEntryFocused__3LcTd {
-    background-color: var(--color-tag-highlight);
+    background-color: var(--color-themeLighter);
 }
   
 .draftJsMentionPlugin__mentionSuggestionsEntryText__3Jobq {

--- a/src/components/modals/BlisTagItem.tsx
+++ b/src/components/modals/BlisTagItem.tsx
@@ -8,20 +8,22 @@ export interface IBlisPickerItemProps<T> extends IPickerItemProps<T> {
 }
 export const BlisTagItem = (props: IBlisPickerItemProps<ITag>) => (
     <div
-      className={`ms-TagItem ${props.highlight && 'ms-TagItem-text--highlight'}`}
-      key={ props.index }
-      data-selection-index={ props.index }
-      data-is-focusable={ !props.disabled && true }
+        className={`ms-TagItem ${props.highlight ? 'ms-TagItem-text--highlight' : ''}`}
+        data-selection-index={props.index}
+        data-is-focusable={!props.disabled && true}
     >
-      <span 
-          className={`ms-TagItem-text ${props.strike && 'ms-TagItem-text--strike'}`} 
-          aria-label={ props.children }>{ props.children }</span>
-      { !props.disabled && !props.locked &&
-        <span className={'ms-TagItem-close'} onClick={ props.onRemoveItem }>
-          <Icon iconName='Cancel' />
+        <span
+            className={`ms-TagItem-text ${props.strike ? 'ms-TagItem-text--strike' : ''}`}
+            aria-label={props.children}
+        >
+            {props.children}
         </span>
-      }
+        {!props.disabled && !props.locked &&
+            <span className={'ms-TagItem-close'} onClick={props.onRemoveItem}>
+                <Icon iconName='Cancel' />
+            </span>
+        }
     </div>
-  );
+);
 
-  export default BlisTagItem;
+export default BlisTagItem;

--- a/src/routes/App.css
+++ b/src/routes/App.css
@@ -63,7 +63,6 @@
     --color-botchat-grey: #dbdee1;
     --color-wc-user: #3a96dd;
     --color-wc-bot: #eceff1;
-    --color-tag-highlight: #deecf9;
     --gutter-width: 100px;
     --nav-link-padding: 1.5em 2em;
 }


### PR DESCRIPTION
- Adds two new props to BlisTagPicker to control highlight and strike through
- Also uses different color (light green from Office UI) for expected / blocking to show this is separate tag association