### PR TITLE
[Bug] Fix bug with entity properties being reset while user is attempting to use modal since properties are updating in background

### DIFF
--- a/src/components/modals/EntityCreatorEditor.tsx
+++ b/src/components/modals/EntityCreatorEditor.tsx
@@ -108,8 +108,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
 
         // If we are not opening the window, stop
         // The code below is only for initializtion when opening modal
-        if (this.props.open === true) {
-            console.log(`stop early since modal is already open`)
+        if (!(this.props.open === false && nextProps.open === true)) {
             return
         }
 


### PR DESCRIPTION
This adds check to only performs initialization if the modal is being opened.

Details about bug:
If you create and entity and then quickly open the entity editor to create another and start typing the entity name it would be reset as you type which was very annoying.  This was because we were resetting the initial state of the modal whenever props updated.  The props were not updating previously, but now that we have the polling of training status the app was getting updated.

