### PR TITLE
Update app creation to default training status to Completed

### DIFF
--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -5,10 +5,10 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Modal } from 'office-ui-fabric-react/lib/Modal';
 import { PrimaryButton, DefaultButton, Dropdown, IDropdownOption, TextField, Label } from 'office-ui-fabric-react';
-import { BlisAppBase, BlisAppMetaData } from 'blis-models'
 import { State } from '../../types'
 import { FM } from '../../react-intl-messages'
 import { injectIntl, InjectedIntlProps, defineMessages, FormattedMessage } from 'react-intl'
+import { AppInput } from '../../types/models';
 
 const messages = defineMessages({
     fieldErrorRequired: {
@@ -96,14 +96,14 @@ class AppCreator extends React.Component<Props, ComponentState> {
     }
 
     onClickCreate() {
-        const appToAdd = new BlisAppBase({
+        const appToAdd: AppInput = {
             appName: this.state.appNameVal,
             luisKey: this.state.luisKeyVal,
             locale: this.state.localeVal,
-            metadata: new BlisAppMetaData({
+            metadata: {
                 botFrameworkApps: []
-            })
-        })
+            }
+        }
 
         this.resetState()
         this.props.onSubmit(appToAdd)
@@ -249,7 +249,7 @@ const mapStateToProps = (state: State) => {
 
 export interface ReceivedProps {
     open: boolean
-    onSubmit: (app: BlisAppBase) => void
+    onSubmit: (app: AppInput) => void
     onCancel: () => void
 }
 

--- a/src/services/blisClient.ts
+++ b/src/services/blisClient.ts
@@ -1,5 +1,6 @@
 import * as models from 'blis-models'
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
+import { AppInput } from '../types/models';
 
 interface TypedAxiosResponse<T> extends AxiosResponse {
     data: T
@@ -87,14 +88,22 @@ export default class BlisClient {
             .then(response => response.data)
     }
 
-    appsCreate(userId: string, app: models.BlisAppBase): Promise<models.BlisAppBase> {
+    appsCreate(userId: string, appInput: AppInput): Promise<models.BlisAppBase> {
         return this.send<string>({
             method: 'post',
             url: `${this.baseUrl}/app?userId=${userId}`,
-            data: app
+            data: appInput
         }).then(response => {
-            app.appId = response.data
-            return app
+            // TODO: Fix API to return full object instead of faking it
+            // Alternative is to send another request for app
+            return {
+                ...appInput,
+                appId: response.data,
+                datetime: new Date(),
+                trainingFailureMessage: null,
+                trainingStatus: models.TrainingStatusCode.Completed,
+                latestPackageId: 0
+            }
         })
     }
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,5 +1,12 @@
-import { BlisAppBase } from "blis-models"
+import { BlisAppBase, BlisAppMetaData } from "blis-models"
 
 export interface App extends BlisAppBase {
     didPollingExpire: boolean
+}
+
+export interface AppInput {
+    appName: string
+    luisKey: string
+    locale: string
+    metadata: BlisAppMetaData
 }


### PR DESCRIPTION
Previously new apps had no training status given becuase it wasn't allowed to be sent to the server and it wasn't returned. This meant the TrainingStatus indicator defaulted to Unknown which could be misleading to the users.  This will change it to default to Completed which is the expected neutral state.