### PR TITLE
[Bug]: Restore deleteLogDialog epic which will fix conversion of log dialog to train dialog

### DIFF
--- a/src/actions/deleteActions.ts
+++ b/src/actions/deleteActions.ts
@@ -155,7 +155,7 @@ export const deleteLogDialogAsync = (appId: string, logDialogId: string): Action
     }
 }
 
-export const deleteLogDialogFulFilled = (logDialogId: string): ActionObject => {
+export const deleteLogDialogFulfilled = (logDialogId: string): ActionObject => {
     return {
         type: AT.DELETE_LOG_DIALOG_FULFILLED,
         logDialogId
@@ -174,7 +174,7 @@ export const deleteLogDialogThunkAsync = (appId: string, logDialogId: string) =>
 
         try {
             await blisClient.logDialogsDelete(appId, logDialogId)
-            dispatch(deleteLogDialogFulFilled(logDialogId))
+            dispatch(deleteLogDialogFulfilled(logDialogId))
         }
         catch (e) {
             const error = e as Error

--- a/src/epics/apiHelpers.ts
+++ b/src/epics/apiHelpers.ts
@@ -214,7 +214,7 @@ export const deleteBlisAction = (key: string, appId: string, action: ActionBase)
 export const deleteLogDialog = (appId: string, logDialogId: string): Observable<ActionObject> => {
   return Rx.Observable.create((obs: Rx.Observer<ActionObject>) => blisClient.logDialogsDelete(appId, logDialogId)
     .then(() => {
-      obs.next(actions.delete.deleteLogDialogFulFilled(logDialogId));
+      obs.next(actions.delete.deleteLogDialogFulfilled(logDialogId));
       obs.complete();
     })
     .catch(err => handleError(obs, err, AT.DELETE_LOG_DIALOG_ASYNC)));

--- a/src/epics/deleteEpics.ts
+++ b/src/epics/deleteEpics.ts
@@ -3,7 +3,7 @@ import * as Rx from 'rxjs';
 import { ActionsObservable, Epic } from 'redux-observable'
 import { State, ActionObject } from '../types'
 import { AT } from '../types/ActionTypes'
-import { deleteBlisApp, deleteBlisEntity, deleteBlisAction, deleteChatSession, deleteTeachSession } from "./apiHelpers";
+import { deleteBlisApp, deleteBlisEntity, deleteBlisAction, deleteChatSession, deleteTeachSession, deleteLogDialog } from "./apiHelpers";
 
 const assertNever = () => { throw Error(`Should not reach here`) }
 
@@ -57,6 +57,15 @@ export const deleteTeachEpic: Epic<ActionObject, State> = (action$: ActionsObser
         .flatMap(action =>
             (action.type === AT.DELETE_TEACH_SESSION_ASYNC)
                 ? deleteTeachSession(action.key, action.currentAppId, action.teachSession, action.save)
+                : assertNever()
+        )
+}
+
+export const deleteLogDialogEpic: Epic<ActionObject, State> = (action$: ActionsObservable<ActionObject>): Rx.Observable<ActionObject> => {
+    return action$.ofType(AT.DELETE_LOG_DIALOG_ASYNC)
+        .flatMap(action =>
+            (action.type === AT.DELETE_LOG_DIALOG_ASYNC)
+                ? deleteLogDialog(action.appId, action.logDialogId)
                 : assertNever()
         )
 }

--- a/src/reducers/displayReducer.ts
+++ b/src/reducers/displayReducer.ts
@@ -70,6 +70,8 @@ const displayReducer: Reducer<DisplayState> = (state = initialState, action: Act
         case AT.FETCH_CHAT_SESSIONS_ASYNC:
         case AT.FETCH_ENTITIES_ASYNC:
         case AT.FETCH_TEACH_SESSIONS_ASYNC:
+        case AT.FETCH_TRAIN_DIALOGS_ASYNC:
+        case AT.FETCH_LOG_DIALOGS_ASYNC:
 
         case AT.RUN_EXTRACTOR_ASYNC:
         case AT.GET_SCORES_ASYNC:
@@ -105,6 +107,8 @@ const displayReducer: Reducer<DisplayState> = (state = initialState, action: Act
         case AT.FETCH_CHAT_SESSIONS_FULFILLED:
         case AT.FETCH_ENTITIES_FULFILLED:
         case AT.FETCH_TEACH_SESSIONS_FULFILLED:
+        case AT.FETCH_TRAIN_DIALOGS_FULFILLED:
+        case AT.FETCH_LOG_DIALOGS_FULFILLED:
 
         case AT.RUN_EXTRACTOR_FULFILLED:
         case AT.GET_SCORES_FULFILLED:


### PR DESCRIPTION
When I converted the normal deletion scenario to use thunk pattern I had removed the epic becuase I thought it was no longer needed and but it was still needed to catch the action from this alternate code path.

I think this loose coupling here is a good thing and bad thing, it was allowing good small atomic async operations to be re-used by various callers, but there isn't anything that couples them together in a type safe way since it's only observing action types.

I think first step is to get rid of apiHelpers use of rxjs and then second phase is to finalize on async pattern. 