### PR TITLE
When pre-built entity type is selected force name and check multi-value

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -619,7 +619,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                         <div>
                             <TC.Checkbox
                                 label="Wait for Response?"
-                                defaultChecked={true}
+                                checked={this.state.isTerminal}
                                 onChange={() => this.onChangeWaitCheckbox()}
                                 style={{ marginTop: '1em', display: 'inline-block' }}
                                 disabled={this.state.isEditing}

--- a/src/components/tipComponents/CheckboxWithTip.tsx
+++ b/src/components/tipComponents/CheckboxWithTip.tsx
@@ -5,7 +5,6 @@ import HelpIcon from '../HelpIcon'
 import * as OF from 'office-ui-fabric-react';
 
 class CheckboxWithTip extends OF.BaseComponent<ICheckboxWithTipProps, OF.ICheckboxState> {
-
     constructor(props: ICheckboxWithTipProps) {
         super(props)
     }
@@ -14,7 +13,7 @@ class CheckboxWithTip extends OF.BaseComponent<ICheckboxWithTipProps, OF.ICheckb
             <div>
                 <OF.Checkbox
                     className="blis-tip"
-                    defaultChecked={this.props.defaultChecked}
+                    checked={this.props.checked}
                     onChange={this.props.onChange}
                     style={{ marginTop: '1em', display: 'inline-block' }}
                     disabled={this.props.disabled}


### PR DESCRIPTION
- Bug fix where entity type did not show up when editing entity since it had been filtered out
- Bug fix when closing modal after editing entity becuase state.editing was set to true while props.entity was null due to short-circuiting componentWillReceiveProps