### PR TITLE
Get EntityExtractor working more reliably

### DIFF
--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditorContainer.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditorContainer.tsx
@@ -20,7 +20,19 @@ interface Props {
  */
 class ExtractorResponseEditorContainer extends React.Component<Props, {}> {
     onChangeCustomEntities = (customEntities: IGenericEntity<IGenericEntityData<PredictedEntity>>[]) => {
-        const preBuiltPredictedEntities = this.props.extractorResponse.predictedEntities.filter(e => e.builtinType !== "LUIS")
+        // TODO: Need to find out why entities sometimes come back with builtinType populated and other times have entitType populated
+        // This should be normalized so we can only check one property here.
+        const preBuiltPredictedEntities = this.props.extractorResponse.predictedEntities.filter(e => {
+            if (e.builtinType) {
+                console.warn(`ExtractorResponseEditorContainer#onChangeCustomEntities When filtering prebuilts out of predicted entities encountered entity with builtinType defined`)
+            }
+
+            // TODO: Should not have to cast to any. After re-model all entities should have type available
+            const entityType = (e as any).entityType
+            return (typeof entityType === "string" && entityType !== "LUIS")
+                || (typeof e.builtinType === "string" && e.builtinType !== "LUIS")
+        })
+
         const newExtractResponse = {
             ...this.props.extractorResponse,
             predictedEntities: [...preBuiltPredictedEntities, ...customEntities.map(convertGenericEntityToPredictedEntity)]

--- a/src/components/ExtractorResponseEditor/utilities.ts
+++ b/src/components/ExtractorResponseEditor/utilities.ts
@@ -301,14 +301,20 @@ export const convertGenericEntityToPredictedEntity = (ge: models.IGenericEntity<
     // Such as the case where we're editing the extract response and adding a new entity
     const option = ge.data.option
     const text = (ge as any).text || (ge.data as any).text || ''
+
+    if (option.type !== "LUIS") {
+        console.warn(`convertGenericEntityToPredictedEntity option selected as option type other than LUIS, this will most likely cause an error`)
+    }
+
     return {
         startCharIndex: ge.startIndex,
         endCharIndex: ge.endIndex - 1,
         entityId: option.id,
         entityName: option.name,
         entityText: text,
+        entityType: option.type,
         resolution: {},
-        builtinType: option.type
+        builtinType: undefined
     }
 }
 


### PR DESCRIPTION
- When filtering predicted entities it now looks at entityType first an builtinType as fallback
- When adding entities it now sets entityType to option.type instead of of builtin since you could never custom assign builtinType