### PR TITLE
Update log dialog warning message to inform user they can create after training completes.

### DIFF
--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -378,7 +378,7 @@ export default {
         [FM.LOGDIALOGS_SUBTITLE]: 'Use this tool to test the current versions of your application, to check if you are progressing on the right track...',
         [FM.LOGDIALOGS_CREATEBUTTONTITLE]: 'New Chat Session',
         [FM.LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION]: 'Create a New Chat Session',
-        [FM.LOGDIALOGS_SESSIONCREATIONWARNING_TITLE]: 'You may not create chat session at this time. Please try again later.',
+        [FM.LOGDIALOGS_SESSIONCREATIONWARNING_TITLE]: 'You may not create chat session at this time. Please try again after training as completed.',
         [FM.LOGDIALOGS_SESSIONCREATIONWARNING_PRIMARYBUTTON]: 'Ok',
         [FM.LOGDIALOGS_FIRSTINPUT]: 'First Input',
         [FM.LOGDIALOGS_LASTINPUT]: 'Last Input',

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -284,7 +284,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                         type: OF.DialogType.normal,
                         title: this.props.intl.formatMessage({
                             id: FM.LOGDIALOGS_SESSIONCREATIONWARNING_TITLE,
-                            defaultMessage: 'You may not create chat session at this time. Please try again later.'
+                            defaultMessage: 'You may not create chat session at this time. Please try again after training as completed.'
                         })
                     }}
                     onDismiss={() => this.onClickWarningWindowOk()}


### PR DESCRIPTION
This is more helpful than 'later' and now we have training status so they can see when it's completed.