### PR TITLE
[Bug]: Use document.text.length instead of isEmpty which seems to have bug in this version of slate.

### DIFF
--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -91,7 +91,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
         }
 
         const { value } = this.state
-        if (value.isEmpty) {
+        if (value.document.text.length === 0) {
             return hideMenu
         }
 


### PR DESCRIPTION
I think maybe I had developed the ExtractResponse editor using a newer version of slate which didn't have the bug with `isEmpty`.  I had to revert to older version of Slate to fix issue with the ActionPayloadEditor and I think that introduced bug with `isEmpty`