### PR TITLE
[Bug] Error when opening card action which less arguments than variables

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -218,11 +218,22 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                     let actionPayload = JSON.parse(action.payload) as ActionPayload;
                     if (actionType === ActionTypes.API_LOCAL) {
                         selectedApiOptionKey = actionPayload.payload;
+                        for (let actionArgument of actionPayload.arguments) {
+                            slateValuesMap[actionArgument.parameter] = createSlateValue(actionArgument.value)
+                        }
                     } else if (actionType === ActionTypes.CARD) {
                         selectedCardOptionKey = actionPayload.payload;
-                    }
-                    for (let actionArgument of actionPayload.arguments) {
-                        slateValuesMap[actionArgument.parameter] = createSlateValue(actionArgument.value)
+                        const template = this.props.botInfo.templates.find(t => t.name === selectedCardOptionKey)
+                        if (!template) {
+                            throw new Error(`Could not find template with name: ${selectedCardOptionKey}`)
+                        }
+
+                        // For each template variable initialize to the associated argument value or default to empty string
+                        for (let cardTemplateVariable of template.variables) {
+                            const argument = actionPayload.arguments.find(a => a.parameter === cardTemplateVariable.key)
+                            const initialValue = argument ? argument.value : ''
+                            slateValuesMap[cardTemplateVariable.key] = createSlateValue(initialValue)
+                        }
                     }
                 }
 


### PR DESCRIPTION
There is coupling across templates and actions.  The actions reference the template by name was assuming there was an argument for each variable however, we were only saving arguments which are non-empty.

Fix was to initialize from the template which always has all the variables needed.  It still seems like there is a larger issue here.  Perhaps actions should always save all arguments and avoid to avoid requiring the template.