### PR TITLE
[Bug]: Only set state for action if next action is different than previous action

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -195,7 +195,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
             }
 
             // If we are given an action, set edit mode and apply properties
-            if (nextProps.action) {
+            if (nextProps.action && nextProps.action !== this.props.action) {
                 const action = nextProps.action
 
                 const negativeEntityTags = convertEntityIdsToTags(action.negativeEntities.filter(entityId => entityId !== action.suggestedEntity), nextProps.entities)


### PR DESCRIPTION
In the case user opens up action very quickly after creating it as they edit the control it was being reset to the original action because of the training status updates in the background. This fix prevents the unnecessary update.

Having to add these guard statements all over seems like bad sign. Perhaps alternate solution is to only include appId or move training status to separate reducer / object other than App. However, that moves complexity to merging the objects back together when needed since the status does belong to an app