### PR TITLE
Default to last used LUIS key when creating new apps

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -189,10 +189,34 @@ i[data-icon-name="Delete"]:hover, i[data-icon-name="Edit"]:hover{
 }
 
 .blis-modal.blis-modal--small{
-  width: 40%;
+  width: 50%;
   /* TODO: Remove padding here, it should be the content inside that decides padding, otherwise all modals should have padding */
   padding: 1em;
 }
+@media (max-width: 600px) {
+  .blis-modal.blis-modal--small {
+    width: 80%;
+  }
+}
+
+@media (min-width: 601px) and (max-width: 800px) {
+  .blis-modal.blis-modal--small {
+    width: 70%;
+  }
+}
+
+@media (min-width: 801px) and (max-width: 1200px) {
+  .blis-modal.blis-modal--small {
+    width: 60%;
+  }
+}
+
+@media (min-width: 1400px) {
+  .blis-modal.blis-modal--small {
+    width: 40%;
+  }
+}
+
 .blis-modal.blis-modal--border {
   border: 2px solid #004b50;
 }

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -248,8 +248,8 @@ class Settings extends React.Component<Props, ComponentState> {
         this.setState((prevState: ComponentState) => ({
             isPasswordVisible: !prevState.isPasswordVisible,
             passwordShowHideText: !prevState.isPasswordVisible
-                ? this.props.intl.formatMessage(messages.passwordHidden)
-                : this.props.intl.formatMessage(messages.passwordVisible)
+                ? this.props.intl.formatMessage(messages.passwordVisible)
+                : this.props.intl.formatMessage(messages.passwordHidden)
         }))
     }
 


### PR DESCRIPTION
Currently we have awkward spot in UX where user intends to create an app and opens the window to be reminded they need a LUIS key to continue.  They have to close the window and open an app settings page, copy paste then re-open the window which is annoying and avoidable

Now we automatically save the LUIS key of last app created and re-use it as default on new apps\

Also fix bug on settings page where Show/Hide button was 1 state behind due to bad boolean logic