### PR TITLE
[Bug] Fix issue with entity picker showing wrong highlighted characters due to extra index increment (off-by-one)

### DIFF
--- a/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
@@ -161,12 +161,7 @@ export default class EntityPickerContainer extends React.Component<Props, State>
             ? this.defaultMatchedOptions
             : this.fuse.search<FuseResult<IOption>>(normalizedSearchText)
                 .filter((_, i) => i < this.props.maxDisplayedOptions)
-                .map(result => {
-                    // TODO: For some reason the Fuse.io library returns the end index before the last character instead of after
-                    // I opened issue here for explanation: https://github.com/krisk/Fuse/issues/212
-                    const indices = result.matches[0].indices.map<[number, number]>(([start, end]) => [start, end + 1])
-                    return convertMatchedTextIntoMatchedOption(result.item.name, indices, result.item)
-                })
+                .map(result => convertMatchedTextIntoMatchedOption(result.item.name, result.matches[0].indices, result.item))
 
         this.setState(prevState => ({
             searchText,

--- a/src/components/ExtractorResponseEditor/utilities.ts
+++ b/src/components/ExtractorResponseEditor/utilities.ts
@@ -155,10 +155,8 @@ export const convertEntitiesAndTextToEditorValue = (text: string, customEntities
 
 export const convertMatchedTextIntoMatchedOption = <T>(text: string, matches: [number, number][], original: T): models.MatchedOption<T> => {
     const matchedStrings = matches.reduce<models.ISegement[]>((segements, [startIndex, originalEndIndex]) => {
-        // if (startIndex === endIndex) {
-        //     return segements
-        // }
-
+        // TODO: For some reason the Fuse.io library returns the end index before the last character instead of after
+        // I opened issue here for explanation: https://github.com/krisk/Fuse/issues/212
         let endIndex = originalEndIndex + 1
         const segementIndexWhereEntityBelongs = segements.findIndex(seg => seg.startIndex <= startIndex && endIndex <= seg.endIndex)
         const prevSegements = segements.slice(0, segementIndexWhereEntityBelongs)


### PR DESCRIPTION
I think i added code to fix this issue for payload editor and forgot it was also used by the entity picker.  This normalizes use across app.