### PR TITLE
Use x-memory-key header instead of key query param to avoid conflict with APIM param parsing

### DIFF
--- a/src/services/blisClient.ts
+++ b/src/services/blisClient.ts
@@ -48,19 +48,14 @@ export default class BlisClient {
     }
 
     send<T = any>(config: AxiosRequestConfig) {
-
         if (this.forceError) {
             return Promise.reject(new Error("Injected Error"));
         }
 
         const memoryKey = this.getMemoryKey()
-        const joinCharacter = /\?/g.test(config.url) ? '&' : '?'
-        const urlWithKey = `${config.url}${joinCharacter}key=${memoryKey}`
-
         const finalConfig = {
             ...this.defaultConfig,
-            ...config,
-            url: urlWithKey
+            ...config
         }
 
         finalConfig.headers.Authorization = `Bearer ${this.getAccessToken()}`


### PR DESCRIPTION
The SDK was using query from UI and forwarding on to server which is good, but the UI was sending a generic `key` query param for the memory key which conflicted with the key param APIM looks for subscription key.

Moved memory key to header which is likely better suited anyways since it can hopefully be removed all together and won't confuse users about our REST api