### PR TITLE
Update to use concrete actions types from latest blis-models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -804,9 +804,9 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
     "blis-models": {
-      "version": "0.128.0",
-      "resolved": "http://bbnpm.azurewebsites.net/blis-models/-/blis-models-0.128.0.tgz",
-      "integrity": "sha512-CZy2fGl9o3OCHpxDZA3fdPK0XDzKu0DYsmLQFm/mqkgSStIZG1MP/uv0vO9vB3fqhMTsmHrR8zJeBEZDSWOvlw=="
+      "version": "0.129.0",
+      "resolved": "http://bbnpm.azurewebsites.net/blis-models/-/blis-models-0.129.0.tgz",
+      "integrity": "sha512-SC0LV50rbAKsM8HGiofrbJRveNowh42TiOrMQm4pjmMftumRVMEMLiMqkVjbmV23MRhfFp7T8iXBwKga5UMEeg=="
     },
     "blis-webchat": {
       "version": "0.100.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "adaptivecards": "^1.0.0-beta9",
     "axios": "^0.16.2",
-    "blis-models": "0.128.0",
+    "blis-models": "0.129.0",
     "blis-webchat": "^0.100.2",
     "botframework-directlinejs": "^0.9.12",
     "draft-js": "^0.10.4",

--- a/src/routes/Apps/App/Dashboard.tsx
+++ b/src/routes/Apps/App/Dashboard.tsx
@@ -12,7 +12,6 @@ import * as ReactMarkdown from 'react-markdown'
 class Dashboard extends React.Component<Props, {}> {
 
     render() {
-        let key = 0;
         return (
             <div className="blis-page">
                 <span className={FontClassNames.xxLarge}>
@@ -30,9 +29,11 @@ class Dashboard extends React.Component<Props, {}> {
                 {this.props.validationErrors.length > 0 && 
                 (
                     <div className="blis-errorpanel" >
-                        <div className={FontClassNames.medium}></div>
-                        {this.props.validationErrors.map((message: any) => { 
-                                return message.length === 0 ? <br key={key++}></br> : <div key={key++} className={FontClassNames.medium}>{message}</div>;
+                        <div className={FontClassNames.medium}>Please ensure that your bot code is the correct version and running the expected file.</div>
+                        {this.props.validationErrors.map((message: any, i) => { 
+                                return message.length === 0
+                                    ? <br key={i}></br>
+                                    : <div key={i} className={FontClassNames.medium}>{message}</div>
                             })
                         }
                     </div>

--- a/src/types/StateTypes.ts
+++ b/src/types/StateTypes.ts
@@ -6,7 +6,7 @@ import {
     ActionBase,
     TrainDialog, LogDialog, Teach, Session,
     Memory, UIScoreInput, ScoreInput, ExtractResponse, ScoreResponse
-} from 'blis-models';
+} from 'blis-models'
 import { ErrorType } from '../types/const'
 import { AT } from '../types/ActionTypes'
 import { TipType } from '../components/ToolTips'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",


### PR DESCRIPTION
- Remove dependency on serializer from within blis-ui (Although it's still kept here for testing due to the issue mentioned in the other PR which introduced it)

Larger picture, the GetPayload method was the most problematic because it doesn't return the same thing for all objects and was being used in unintended ways which make it hard to reason about.  Really the method should be removed, but i will hold off on that until good solution arises.

The method is doing two things: encapsulating logic of parsing payload as well as having knowledge about what "payload" means for a specific column in the UI (E.g. for text it means everything, for api and card it means only the name / templateName) and this was the issue. 

The UI has two separate use cases:
1. For each action in list display infor about it (ActionDetailsList, ActionScorer) and in this scenario it was nice to have single method to do everything
2. For each distinct action type display something different or do something different
Action validation errors display, SDK take*action, etc.

The new concrete types allow bests of both in most places.
