### PR TITLE
1133: When editing the last system turn in a train dialog, a warning …

### DIFF
--- a/src/components/ToolTips.tsx
+++ b/src/components/ToolTips.tsx
@@ -96,19 +96,18 @@ export function Wrap(content: JSX.Element, tooltip: string, directionalHint: OF.
 }
 
 let apiCodeSample =
-    `blisdk.APICallback("Multiply", async (memoryManager, argArray) =>
-{
-    try {
-        var num1 = parseInt(argArray[0]);
-        var num2 = parseInt(argArray[1]);
-        var product = num1*num2;
-        return product.toString();
-    }
-    catch (err)
-    {
-        return "Invalid number";
-    }
-})`;
+    `Blis.AddAPICallback("Multiply", async (memoryManager: ClientMemoryManager, num1string: string, num2string: string) => {
+
+        // convert base and exponent to ints
+        var num1int = parseInt(num1string);
+        var num2int = parseInt(num2string);
+    
+        // compute product
+        var result = num1int * num2int;
+    
+        // return result as message
+        return num1int.toString() + " * " + num2int.toString() + " = " + result.toString();
+    })`;
 
 let memoryManagerSample =
     `async RememberEntityAsync(entityName : string, value : string) 

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -37,9 +37,10 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             isResizable: true,
             render: (action, component, index) => {
                 if (component.props.canEdit) {
-                    let buttonText = (component.props.dialogType !== DialogType.TEACH && index === 0) ? "Selected" : "Select";
+                    const selected = (component.props.dialogType !== DialogType.TEACH && index === 0);
+                    let buttonText = selected ? 'Selected' : 'Select';
                     let isAvailable = component.isUnscoredActionAvailable(action as UnscoredAction);
-                    if (!isAvailable) {
+                    if (!isAvailable || selected) {
                         return (
                             <PrimaryButton
                                 disabled={true}

--- a/src/components/modals/TrainDialogAdmin.tsx
+++ b/src/components/modals/TrainDialogAdmin.tsx
@@ -96,6 +96,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
             newRounds[roundIndex].scorerSteps = [];
             updatedTrainDialog = { ...updatedTrainDialog, rounds: rounds };
 
+            // LARS??
             // Save prompt will be shown to user
             this.setState({
                 saveTrainDialog: updatedTrainDialog,
@@ -148,22 +149,29 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
         newRounds[this.state.roundIndex] = newRound;
         let updatedTrainDialog = { ...this.props.trainDialog, rounds: newRounds };
 
-        // Save prompt will be shown to user
-        this.setState({
-            saveTrainDialog: updatedTrainDialog,
-            saveSliceRound: this.state.roundIndex,
-            saveExtractChanged: false
-        });
+        if (this.props.trainDialog.rounds.length !== newRounds.length) {
+            // Truncation prompt will be shown to user
+            this.setState({
+                saveTrainDialog: updatedTrainDialog,
+                saveSliceRound: this.state.roundIndex,
+                saveExtractChanged: false
+            });
+        } else {
+            this.editTrainDialog(updatedTrainDialog, this.state.roundIndex, false);
+        }
     }
 
     onClickSaveCheckYes() {
+        this.editTrainDialog(this.state.saveTrainDialog, this.state.saveSliceRound, false);
+    }
 
+    editTrainDialog(sourceDialog: TrainDialog, sliceRound: number, extractChanged: boolean) {
         let trainDialog: TrainDialog = {
             trainDialogId: undefined,
             version: undefined,
             packageCreationId: undefined,
             packageDeletionId: undefined,
-            rounds: this.state.saveTrainDialog.rounds,
+            rounds: sourceDialog.rounds,
             definitions: {
                 entities: this.props.entities,
                 actions: this.props.actions,
@@ -171,7 +179,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
             }
         }
 
-        this.props.onEdit(this.state.saveTrainDialog.trainDialogId, trainDialog, this.state.saveExtractChanged);
+        this.props.onEdit(sourceDialog.trainDialogId, trainDialog, extractChanged);
          
         this.props.clearExtractResponses();
 
@@ -179,9 +187,10 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
             saveTrainDialog: null,
             saveSliceRound: 0,
             saveExtractChanged: false,
-            roundIndex: this.state.saveSliceRound
+            roundIndex: sliceRound
         });
     }
+
     onClickSaveCheckNo() {
         // Reset the entity extractor
         this.setState({ saveTrainDialog: null, saveSliceRound: 0 });


### PR DESCRIPTION
…message isn't needed

Updated tooltip for API callback
Disable clicking "selected" button in action scorer as it's a no-op