### PR TITLE
Remove uncompleted inline nodes after inserting closing character

### DIFF
--- a/src/components/modals/ActionPayloadEditor/MentionPlugin.tsx
+++ b/src/components/modals/ActionPayloadEditor/MentionPlugin.tsx
@@ -63,11 +63,14 @@ export default function mentionPlugin(inputOptions: Partial<IOptions> = {}) {
             }
 
             if (isWithinMentionNode) {
-                const isNodeCompleted = change.value.inlines.last().data.get('completed')
+                const lastInlineNode = change.value.inlines.last()
+                const isNodeCompleted = lastInlineNode.data.get('completed')
                 if (!isNodeCompleted && event.key === options.closingCharacter) {
                     event.preventDefault()
 
                     change
+                        .removeNodeByKey(lastInlineNode.key)
+                        .insertText(lastInlineNode.text)
                         .collapseToStartOfNextText()
                         .insertText(options.closingCharacter)
 


### PR DESCRIPTION
This will prevent UI from attempting to substitute entity names into inline nodes which were incomplete (don't have entity ids) and crashing the UI

Alternative would be to change the entity substitution code to ignore inline nodes which are imcomplete but I think this is better fix to root issue.

Fixes VSTS#1175