### PR TITLE
Disable locale selection in AppCreator

### DIFF
--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -183,6 +183,8 @@ class AppCreator extends React.Component<Props, ComponentState> {
                         defaultSelectedKey={this.state.localeVal}
                         options={this.state.localeOptions}
                         onChanged={this.localeChanged}
+                        disabled={true}
+                        /* Disabled until trainer can support more than english */
                     />
                 </div>
                 <div className='cl-modal_footer'>


### PR DESCRIPTION
This effectively forces 'en-US' local, but still informs user that app has a locale and we will support more in future.