### PR TITLE
Add application name to delete message to help prevent accidents.

### DIFF
--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -456,7 +456,7 @@ export default {
         [FM.APPSLIST_CREATEBUTTONTEXT]: 'New App',
         [FM.APPSLIST_IMPORTBUTTONARIADESCRIPTION]: 'Import Tutorials Applications',
         [FM.APPSLIST_IMPORTBUTTONTEXT]: 'Import Tutorials',
-        [FM.APPSLIST_CONFIRMCANCELMODALTITLE]: 'Are you sure you want to delete this application?',
+        [FM.APPSLIST_CONFIRMCANCELMODALTITLE]: 'Are you sure you want to delete this application? {appName}',
         [FM.APPSLIST_COLUMN_NAME]: 'Name',
         [FM.APPSLIST_COLUMNS_LOCALE]: 'Locale',
         [FM.APPSLIST_COLUMNS_LINKEDBOTS]: 'Linked Bots',

--- a/src/routes/Apps/AppsList.tsx
+++ b/src/routes/Apps/AppsList.tsx
@@ -319,7 +319,9 @@ class AppsList extends React.Component<Props, ComponentState> {
                     onConfirm={this.onConfirmDeleteApp}
                     title={this.props.intl.formatMessage({
                         id: FM.APPSLIST_CONFIRMCANCELMODALTITLE,
-                        defaultMessage: 'Are you sure you want to delete this application?'
+                        defaultMessage: 'Are you sure you want to delete this application? {appName}'
+                    }, {
+                        appName: this.state.appToDelete ? this.state.appToDelete.appName : ''
                     })}
                 />
                 <TutorialImporter


### PR DESCRIPTION
If you accidentally click the trash icon in the wrong row, you don't know until the wrong app disappears.

This helps by adding the application name you clicked to the message.