### PR TITLE
[Bug]: Add guards around checking tagName of possibly null parent node/element of selection anchorNode.

### DIFF
--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -171,7 +171,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
             if (selectionParentElement == null) {
                 console.warn(`selectionParentElement is null or undefined. Value: ${value.document.text}`)
             }
-            if (selectionParentElement.tagName ===  "BUTTON")
+            else if (selectionParentElement.tagName ===  "BUTTON")
             {
                 shouldExpandSelection = false
             }


### PR DESCRIPTION
Fixes VSTS#1314