### PR TITLE
[Bug]: Only call getRangeAt(0) if rangeCount > 0

### DIFF
--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -104,7 +104,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
         // From what I can tell slate's is always accurate to display.  If the selection was updated programmatically via slate API it will be reflected within Slates selection
         // and as soon as user interacts to change DOM selection, it will update both
         // Note: Cannot test for selection.isCollapsed here, because we need the menu to open when the user clicks a word
-        if (!selection) {
+        if (!selection && selection.rangeCount > 0) {
             return hideMenu
         }
 


### PR DESCRIPTION
From what I understand the browser asynchronously updates the selection object and so there are scenarios where the rangeCount is not updated by the time we query it.  We previously were blindly calling getRangeAt(0) but there were no ranges.  This is like trying to access element on array which is empty.  We now check the length first.

https://developer.mozilla.org/en-US/docs/Web/API/Selection/getRangeAt

Fixes VSTS#1333