### PR TITLE
1344: When reviewing a train dialog, hide the "score" column

### DIFF
--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -30,8 +30,8 @@ interface IRenderableColumn extends OF.IColumn {
     render: (x: ScoredBase, component: ActionScorer, index: number) => React.ReactNode
 }
 
-function getColumns(intl: InjectedIntl): IRenderableColumn[] {
-    return [
+function getColumns(intl: InjectedIntl, hideScore: boolean): IRenderableColumn[] {
+    let columns = [
         {
             key: 'select',
             name: '',
@@ -176,7 +176,12 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             isResizable: true,
             render: action => action.actionType
         },
-    ]
+    ] as IRenderableColumn[]
+
+    if (hideScore) {
+        columns = columns.filter(c => c.key !== 'actionScore')
+    }
+    return columns
 }
 
 interface ComponentState {
@@ -194,7 +199,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
     constructor(p: Props) {
         super(p);
 
-        const columns = getColumns(this.props.intl)
+        const columns = getColumns(this.props.intl, this.props.hideScore)
         this.state = {
             actionModalOpen: false,
             columns,
@@ -693,6 +698,7 @@ export interface ReceivedProps {
     scoreInput: ScoreInput,
     memories: Memory[],
     canEdit: boolean
+    hideScore: boolean,
     onActionSelected: (trainScorerStep: TrainScorerStep) => void,
 }
 

--- a/src/components/modals/LogDialogAdmin.tsx
+++ b/src/components/modals/LogDialogAdmin.tsx
@@ -291,6 +291,7 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
                                 app={this.props.app}
                                 editingPackageId={this.props.editingPackageId}
                                 canEdit={this.props.canEdit}
+                                hideScore={false}
                                 dialogType={DialogType.LOGDIALOG}
                                 sessionId={this.props.logDialog.logDialogId}
                                 autoTeach={false}

--- a/src/components/modals/TeachSessionAdmin.tsx
+++ b/src/components/modals/TeachSessionAdmin.tsx
@@ -214,6 +214,7 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
                                 app={this.props.app}
                                 editingPackageId={this.props.editingPackageId}
                                 canEdit={true}
+                                hideScore={false}
                                 dialogType={DialogType.TEACH}
                                 sessionId={this.props.teachSession.current.teachId}
                                 autoTeach={this.props.teachSession.autoTeach}

--- a/src/components/modals/TrainDialogAdmin.tsx
+++ b/src/components/modals/TrainDialogAdmin.tsx
@@ -424,6 +424,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
                                 app={this.props.app}
                                 editingPackageId={this.props.editingPackageId}
                                 canEdit={this.props.canEdit}
+                                hideScore={true}
                                 dialogType={DialogType.TRAINDIALOG}
                                 sessionId={this.props.trainDialog.trainDialogId}
                                 autoTeach={false}

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -129,6 +129,9 @@ class Index extends React.Component<Props, ComponentState> {
     }
     render() {
         const { match, location, intl } = this.props
+
+        if (!location.state) return null;
+
         const app: AppBase = location.state.app
         const editPackageId = this.state.packageId
         const tag = (editPackageId === app.devPackageId) ? 


### PR DESCRIPTION
Prevent null ref exception when right-click open in new window.  (Selected app still lost, but will fix that later)

#553 