### PR TITLE
1343 Remove datetime pre-built entity (deprecated; use datetimeV2 ins…

### DIFF
--- a/src/types/PreBuiltEntities.ts
+++ b/src/types/PreBuiltEntities.ts
@@ -27,7 +27,7 @@ export const PreBuiltEntities: LocalePreBuilts[] = [
 	{
 		locale: "en-us",
 		preBuiltEntities: [
-			PreBuilts.DatetimeV2, PreBuilts.Datetime, PreBuilts.Number, PreBuilts.Ordinal,
+			PreBuilts.DatetimeV2, PreBuilts.Number, PreBuilts.Ordinal,
 			PreBuilts.Percentage, PreBuilts.Temperature, PreBuilts.Dimension, PreBuilts.Money, PreBuilts.Age,
 			PreBuilts.Geography, PreBuilts.Encyclopedia, PreBuilts.URL, PreBuilts.Email, PreBuilts.Phone_number
 		]


### PR DESCRIPTION
…tead)

Looks like only some of the languages are fully migrated in LUIS.  FR for example now has DateTimeV2, Italian has Datetime.  As we are currently only supporting English, I'm just updating that.  We can update the others when we add those languages (as we'll have to do that anyway to see what state they are in)