### PR TITLE
Allow users to view most up to date payload when selecting actions with toggle for original text.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "autobind",
         "be",
         "conversationlearner",
+        "deserialize",
         "inlines",
         "returntypeof",
         "segoe",

--- a/CredScanSuppression.json
+++ b/CredScanSuppression.json
@@ -3,7 +3,7 @@
     "suppressions": [
         {
             "hash": "kZ+rjPLaOLBxWM2LQRjVNamHs7mSPJm29Mrxn4wsSys=",
-            "_justification": "This is secret is for the public blob storage URL for retreiving locales which contains SAS (Secure Access Signature)"
+            "_justification": "This is secret is for the public blob storage URL for retrieving locales which contains SAS (Secure Access Signature)"
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@conversationlearner/models": {
-      "version": "0.157.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.157.0.tgz",
-      "integrity": "sha1-RsiC2ndQdDELAUZMWeWBUG2Txbc="
+      "version": "0.158.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.158.0.tgz",
+      "integrity": "sha1-GxapOS5iB4dqOotvbkSiQ0rCWlQ="
     },
     "@conversationlearner/webchat": {
       "version": "0.105.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "private": true,
   "dependencies": {
-    "@conversationlearner/models": "0.157.0",
+    "@conversationlearner/models": "0.158.0",
     "@conversationlearner/webchat": "0.105.0",
     "adaptivecards": "1.0.0",
     "axios": "^0.16.2",

--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -223,7 +223,7 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                         cardAction={cardAction}
                         entities={component.props.entities}
                         memories={null}
-                        onClickViewCard={() => {}}
+                        onClickViewCard={() => component.onClickViewCard(action)}
                     />
                 }
 

--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -112,7 +112,7 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
             const entityMap = Util.getDefaultEntityMap(this.props.entities)
             template = this.props.botInfo.templates.find((t) => t.name === cardAction.templateName);
             // TODO: This is hack to make adaptive card viewer accept action arguments with pre-rendered values
-            renderedActionArguments = cardAction.renderArguments(entityMap)
+            renderedActionArguments = cardAction.renderArguments(entityMap, { preserveOptionalNodeWrappingCharacters: true })
                 .filter(aa => !Util.isNullOrWhiteSpace(aa.value))
         }
 

--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -340,6 +340,6 @@ interface IRenderableColumn extends OF.IColumn {
 
 interface ComponentState {
     columns: IRenderableColumn[]
-    sortColumn: IRenderableColumn,
+    sortColumn: IRenderableColumn
     cardViewerAction: ActionBase
 }

--- a/src/components/ExtractorResponseEditor/utilities.ts
+++ b/src/components/ExtractorResponseEditor/utilities.ts
@@ -563,7 +563,7 @@ export const convertGenericEntityToPredictedEntity = (entities: EntityBase[]) =>
         endCharIndex: ge.endIndex - 1,
         entityText: text,
         resolution: {},
-        builtinType: entity.entityType,
+        builtinType: undefined,
         score: 0
     }
 }

--- a/src/components/TextPayloadRenderer.css
+++ b/src/components/TextPayloadRenderer.css
@@ -1,0 +1,5 @@
+.cl-textpayload {
+    display: grid;
+    grid-template: auto / 1fr min-content;
+    grid-gap: 1em;
+}

--- a/src/components/TextPayloadRenderer.tsx
+++ b/src/components/TextPayloadRenderer.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import * as OF from 'office-ui-fabric-react'
+import './TextPayloadRenderer.css'
+
+interface Props {
+    original: string
+    currentMemory: string
+}
+
+interface State {
+    isOriginalVisible: boolean
+}
+
+export default class Component extends React.Component<Props, State> {
+    state = {
+        isOriginalVisible: false
+    }
+
+    onChangedVisible = () => {
+        this.setState(prevState => ({
+            isOriginalVisible: !prevState.isOriginalVisible
+        }))
+    }
+
+    render() {
+        return <div className={`${OF.FontClassNames.mediumPlus} cl-textpayload`}>
+            <div className="cl-textpayload__string">{this.state.isOriginalVisible
+                ? this.props.original
+                : this.props.currentMemory
+            }</div>
+            {this.props.currentMemory !== this.props.original
+                && <div>
+                <OF.Toggle
+                    checked={this.state.isOriginalVisible}
+                    onChanged={this.onChangedVisible}
+                />
+            </div>}
+        </div>
+    }
+}

--- a/src/components/actionPayloadRenderers/ApiPayloadRenderer.css
+++ b/src/components/actionPayloadRenderers/ApiPayloadRenderer.css
@@ -3,3 +3,13 @@
     grid-template: auto / 1fr min-content;
     grid-gap: 1em;
 }
+
+.cl-api-payload__arguments {
+    display: grid;
+    grid-template: auto / min-content 1fr;
+    grid-gap: 0 0.5em;
+}
+
+.cl-api-payload__arguments div:nth-child(2n - 1) {
+    white-space: nowrap;
+}

--- a/src/components/actionPayloadRenderers/ApiPayloadRenderer.css
+++ b/src/components/actionPayloadRenderers/ApiPayloadRenderer.css
@@ -1,0 +1,5 @@
+.cl-api-payload {
+    display: grid;
+    grid-template: auto / 1fr min-content;
+    grid-gap: 1em;
+}

--- a/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
@@ -35,7 +35,7 @@ export default class Component extends React.Component<Props, State> {
     }
 
     render() {
-        
+
         const pairedArguments = this.props.substitutedArguments === null
             ? {
                 argumentPairs: this.props.originalArguments.map(oa => ({
@@ -45,41 +45,45 @@ export default class Component extends React.Component<Props, State> {
                 argumentsDiffer: false
             }
             : this.props.originalArguments.reduce<ICombinedActionArguments>((combined, originalArgument) => {
-            const matchingSubstitutedArgument = this.props.substitutedArguments.find(sa => sa.parameter ===  originalArgument.parameter)
-            combined.argumentPairs.push({
-                original: originalArgument,
-                substituted: matchingSubstitutedArgument
-            })
+                const matchingSubstitutedArgument = this.props.substitutedArguments.find(sa => sa.parameter === originalArgument.parameter)
+                combined.argumentPairs.push({
+                    original: originalArgument,
+                    substituted: matchingSubstitutedArgument
+                })
 
-            // If any of the arguments are different, set to true
-            combined.argumentsDiffer = combined.argumentsDiffer || (originalArgument.value !== matchingSubstitutedArgument.value)
+                // If any of the arguments are different, set to true
+                combined.argumentsDiffer = combined.argumentsDiffer || (originalArgument.value !== matchingSubstitutedArgument.value)
 
-            return combined
-        }, {
-            argumentPairs: [],
-            argumentsDiffer: false
-        })
+                return combined
+            }, {
+                    argumentPairs: [],
+                    argumentsDiffer: false
+                })
 
         const showToggle = pairedArguments.argumentsDiffer
 
         return <div className="cl-api-payload">
-            <div className="cl-api-payload__string">
+            <div>
                 <div className={OF.FontClassNames.mediumPlus}>{this.props.name}(memoryManager{pairedArguments.argumentPairs.length !== 0 && `, ${pairedArguments.argumentPairs.map(a => a.original.parameter).join(', ')}`})</div>
-                <div>
-                    {pairedArguments.argumentPairs.length !== 0 && pairedArguments.argumentPairs.map((argument, i) =>
-                        <div className="ms-ListItem-primaryText" key={i}>{`${argument.original.parameter}: ${(this.props.substitutedArguments === null || this.state.isOriginalVisible)
-                            ? argument.original.value
-                            : argument.substituted.value}`
-                        }</div>)}
+                <div className="cl-api-payload__arguments ms-ListItem-primaryText">
+                    {pairedArguments.argumentPairs.length !== 0
+                    && pairedArguments.argumentPairs.map((argument, i) =>
+                        <React.Fragment key={i}>
+                            <div>{argument.original.parameter}:</div>
+                            <div>{`${(this.props.substitutedArguments === null || this.state.isOriginalVisible)
+                                ? argument.original.value
+                                : argument.substituted.value}`
+                            }</div>
+                        </React.Fragment>)}
                 </div>
             </div>
             {showToggle
                 && <div>
-                <OF.Toggle
-                    checked={this.state.isOriginalVisible}
-                    onChanged={this.onChangedVisible}
-                />
-            </div>}
+                    <OF.Toggle
+                        checked={this.state.isOriginalVisible}
+                        onChanged={this.onChangedVisible}
+                    />
+                </div>}
         </div>
     }
 }

--- a/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import * as OF from 'office-ui-fabric-react'
+import './TextPayloadRenderer.css'
+import { RenderedActionArgument } from '@conversationlearner/models';
+
+
+interface ICombinedActionArgument {
+    original: RenderedActionArgument
+    substituted: RenderedActionArgument
+}
+
+interface ICombinedActionArguments {
+    argumentPairs: ICombinedActionArgument[]
+    argumentsDiffer: boolean
+}
+
+interface Props {
+    name: string
+    originalArguments: RenderedActionArgument[]
+    substitutedArguments: RenderedActionArgument[]
+}
+
+interface State {
+    isOriginalVisible: boolean
+}
+
+export default class Component extends React.Component<Props, State> {
+    state = {
+        isOriginalVisible: false
+    }
+
+    onChangedVisible = () => {
+        this.setState(prevState => ({
+            isOriginalVisible: !prevState.isOriginalVisible
+        }))
+    }
+
+    render() {
+        const pairedArguments = this.props.originalArguments.reduce<ICombinedActionArguments>((combined, originalArgument) => {
+            const matchingSubstitutedArgument = this.props.substitutedArguments.find(sa => sa.parameter ===  originalArgument.parameter)
+            combined.argumentPairs.push({
+                original: originalArgument,
+                substituted: matchingSubstitutedArgument
+            })
+
+            // If any of the arguments are different, set to true
+            combined.argumentsDiffer = combined.argumentsDiffer || (originalArgument.value !== matchingSubstitutedArgument.value)
+
+            return combined
+        }, {
+            argumentPairs: [],
+            argumentsDiffer: false
+        })
+
+        const showToggle = pairedArguments.argumentsDiffer
+
+        return <div className={`${OF.FontClassNames.mediumPlus} cl-apipayload`}>
+            <div className="cl-apipayload__string">
+                <div className={OF.FontClassNames.mediumPlus}>{this.props.name}(memoryManager{pairedArguments.argumentPairs.length !== 0 && `, ${pairedArguments.argumentPairs.map(a => a.original.parameter).join(', ')}`})</div>
+                <div>
+                    {pairedArguments.argumentPairs.length !== 0 && pairedArguments.argumentPairs.map((argument, i) =>
+                        <div className="ms-ListItem-primaryText" key={i}>{`${argument.original.parameter}: ${this.state.isOriginalVisible
+                            ? argument.original.value
+                            : argument.substituted.value}`
+                        }</div>)}
+                </div>
+            }</div>
+            {showToggle
+                && <div>
+                <OF.Toggle
+                    checked={this.state.isOriginalVisible}
+                    onChanged={this.onChangedVisible}
+                />
+            </div>}
+        </div>
+    }
+}

--- a/src/components/actionPayloadRenderers/ApiPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRendererContainer.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { ApiAction, EntityBase, Memory } from '@conversationlearner/models'
+import * as Util from '../../util'
+import ApiPayloadRenderer from './ApiPayloadRenderer'
+
+interface Props {
+    apiAction: ApiAction
+    entities: EntityBase[]
+    memories: Memory[] | null
+}
+
+export default class Component extends React.Component<Props, {}> {
+    render() {
+        const { apiAction, entities, memories } = this.props
+        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
+        const defaultEntityMap = Util.getDefaultEntityMap(entities)
+        const argumentStringsUsingEntityNames = apiAction.renderArguments(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
+        const argumentStringsUsingCurrentMemory = apiAction.renderArguments(currentEntityMap, { fallbackToOriginal: true })
+
+        return <ApiPayloadRenderer
+            name={apiAction.name}
+            originalArguments={argumentStringsUsingEntityNames}
+            substitutedArguments={argumentStringsUsingCurrentMemory}
+        />
+    }
+}

--- a/src/components/actionPayloadRenderers/ApiPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRendererContainer.tsx
@@ -12,9 +12,18 @@ interface Props {
 export default class Component extends React.Component<Props, {}> {
     render() {
         const { apiAction, entities, memories } = this.props
-        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
         const defaultEntityMap = Util.getDefaultEntityMap(entities)
         const argumentStringsUsingEntityNames = apiAction.renderArguments(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
+        
+        if (memories === null) {
+            return <ApiPayloadRenderer
+                name={apiAction.name}
+                originalArguments={argumentStringsUsingEntityNames}
+                substitutedArguments={null}
+            />
+        }
+
+        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
         const argumentStringsUsingCurrentMemory = apiAction.renderArguments(currentEntityMap, { fallbackToOriginal: true })
 
         return <ApiPayloadRenderer

--- a/src/components/actionPayloadRenderers/ApiPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRendererContainer.tsx
@@ -13,23 +13,15 @@ export default class Component extends React.Component<Props, {}> {
     render() {
         const { apiAction, entities, memories } = this.props
         const defaultEntityMap = Util.getDefaultEntityMap(entities)
-        const argumentStringsUsingEntityNames = apiAction.renderArguments(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
-        
-        if (memories === null) {
-            return <ApiPayloadRenderer
-                name={apiAction.name}
-                originalArguments={argumentStringsUsingEntityNames}
-                substitutedArguments={null}
-            />
-        }
-
-        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
-        const argumentStringsUsingCurrentMemory = apiAction.renderArguments(currentEntityMap, { fallbackToOriginal: true })
+        const argumentsUsingEntityNames = apiAction.renderArguments(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
+        const argumentsUsingCurrentMemory = memories === null
+            ? null
+            : apiAction.renderArguments(Util.createEntityMapFromMemories(entities, memories), { fallbackToOriginal: true })
 
         return <ApiPayloadRenderer
             name={apiAction.name}
-            originalArguments={argumentStringsUsingEntityNames}
-            substitutedArguments={argumentStringsUsingCurrentMemory}
+            originalArguments={argumentsUsingEntityNames}
+            substitutedArguments={argumentsUsingCurrentMemory}
         />
     }
 }

--- a/src/components/actionPayloadRenderers/CardPayloadRenderer.css
+++ b/src/components/actionPayloadRenderers/CardPayloadRenderer.css
@@ -1,0 +1,5 @@
+.cl-card-payload {
+    display: grid;
+    grid-template: auto / 1fr min-content;
+    grid-gap: 1em;
+}

--- a/src/components/actionPayloadRenderers/CardPayloadRenderer.css
+++ b/src/components/actionPayloadRenderers/CardPayloadRenderer.css
@@ -3,3 +3,13 @@
     grid-template: auto / 1fr min-content;
     grid-gap: 1em;
 }
+
+.cl-card-payload__arguments {
+    display: grid;
+    grid-template: auto / min-content 1fr;
+    grid-gap: 0 0.5em;
+}
+
+.cl-card-payload__arguments div:nth-child(2n - 1) {
+    white-space: nowrap;
+}

--- a/src/components/actionPayloadRenderers/CardPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/CardPayloadRenderer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as OF from 'office-ui-fabric-react'
-import './ApiPayloadRenderer.css'
+import './CardPayloadRenderer.css'
 import { RenderedActionArgument } from '@conversationlearner/models'
 
 interface ICombinedActionArgument {
@@ -14,7 +14,9 @@ interface ICombinedActionArguments {
 }
 
 interface Props {
+    isValidationError: boolean
     name: string
+    onClickViewCard: () => void
     originalArguments: RenderedActionArgument[]
     substitutedArguments: RenderedActionArgument[] | null
 }
@@ -35,7 +37,6 @@ export default class Component extends React.Component<Props, State> {
     }
 
     render() {
-        
         const pairedArguments = this.props.substitutedArguments === null
             ? {
                 argumentPairs: this.props.originalArguments.map(oa => ({
@@ -45,26 +46,26 @@ export default class Component extends React.Component<Props, State> {
                 argumentsDiffer: false
             }
             : this.props.originalArguments.reduce<ICombinedActionArguments>((combined, originalArgument) => {
-            const matchingSubstitutedArgument = this.props.substitutedArguments.find(sa => sa.parameter ===  originalArgument.parameter)
-            combined.argumentPairs.push({
-                original: originalArgument,
-                substituted: matchingSubstitutedArgument
-            })
+                const matchingSubstitutedArgument = this.props.substitutedArguments.find(sa => sa.parameter === originalArgument.parameter)
+                combined.argumentPairs.push({
+                    original: originalArgument,
+                    substituted: matchingSubstitutedArgument
+                })
 
-            // If any of the arguments are different, set to true
-            combined.argumentsDiffer = combined.argumentsDiffer || (originalArgument.value !== matchingSubstitutedArgument.value)
+                // If any of the arguments are different, set to true
+                combined.argumentsDiffer = combined.argumentsDiffer || (originalArgument.value !== matchingSubstitutedArgument.value)
 
-            return combined
-        }, {
-            argumentPairs: [],
-            argumentsDiffer: false
-        })
+                return combined
+            }, {
+                    argumentPairs: [],
+                    argumentsDiffer: false
+                })
 
         const showToggle = pairedArguments.argumentsDiffer
 
-        return <div className="cl-api-payload">
-            <div className="cl-api-payload__string">
-                <div className={OF.FontClassNames.mediumPlus}>{this.props.name}(memoryManager{pairedArguments.argumentPairs.length !== 0 && `, ${pairedArguments.argumentPairs.map(a => a.original.parameter).join(', ')}`})</div>
+        return <div className="cl-card-payload">
+            <div className="cl-card-payload__string">
+                <div className={OF.FontClassNames.mediumPlus}>{this.props.name}</div>
                 <div>
                     {pairedArguments.argumentPairs.length !== 0 && pairedArguments.argumentPairs.map((argument, i) =>
                         <div className="ms-ListItem-primaryText" key={i}>{`${argument.original.parameter}: ${(this.props.substitutedArguments === null || this.state.isOriginalVisible)
@@ -73,13 +74,21 @@ export default class Component extends React.Component<Props, State> {
                         }</div>)}
                 </div>
             </div>
-            {showToggle
-                && <div>
-                <OF.Toggle
-                    checked={this.state.isOriginalVisible}
-                    onChanged={this.onChangedVisible}
+            <div>
+                {showToggle
+                    && <OF.Toggle
+                        checked={this.state.isOriginalVisible}
+                        onChanged={this.onChangedVisible}
+                    />}
+                <OF.PrimaryButton
+                    disabled={this.props.isValidationError}
+                    className="cl-button--viewCard"
+                    onClick={() => this.props.onClickViewCard()}
+                    ariaDescription="ViewCard"
+                    text=""
+                    iconProps={{ iconName: 'RedEye' }}
                 />
-            </div>}
+            </div>
         </div>
     }
 }

--- a/src/components/actionPayloadRenderers/CardPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/CardPayloadRenderer.tsx
@@ -16,7 +16,7 @@ interface ICombinedActionArguments {
 interface Props {
     isValidationError: boolean
     name: string
-    onClickViewCard: () => void
+    onClickViewCard: (showOriginal: boolean) => void
     originalArguments: RenderedActionArgument[]
     substitutedArguments: RenderedActionArgument[] | null
 }
@@ -64,14 +64,18 @@ export default class Component extends React.Component<Props, State> {
         const showToggle = pairedArguments.argumentsDiffer
 
         return <div className="cl-card-payload">
-            <div className="cl-card-payload__string">
+            <div>
                 <div className={OF.FontClassNames.mediumPlus}>{this.props.name}</div>
-                <div>
-                    {pairedArguments.argumentPairs.length !== 0 && pairedArguments.argumentPairs.map((argument, i) =>
-                        <div className="ms-ListItem-primaryText" key={i}>{`${argument.original.parameter}: ${(this.props.substitutedArguments === null || this.state.isOriginalVisible)
-                            ? argument.original.value
-                            : argument.substituted.value}`
-                        }</div>)}
+                <div className="cl-card-payload__arguments ms-ListItem-primaryText">
+                    {pairedArguments.argumentPairs.length !== 0
+                    && pairedArguments.argumentPairs.map((argument, i) =>
+                        <React.Fragment key={i}>
+                            <div>{argument.original.parameter}:</div>
+                            <div>{`${(this.props.substitutedArguments === null || this.state.isOriginalVisible)
+                                ? argument.original.value
+                                : argument.substituted.value}`
+                            }</div>
+                        </React.Fragment>)}
                 </div>
             </div>
             <div>
@@ -83,7 +87,7 @@ export default class Component extends React.Component<Props, State> {
                 <OF.PrimaryButton
                     disabled={this.props.isValidationError}
                     className="cl-button--viewCard"
-                    onClick={() => this.props.onClickViewCard()}
+                    onClick={() => this.props.onClickViewCard(this.state.isOriginalVisible)}
                     ariaDescription="ViewCard"
                     text=""
                     iconProps={{ iconName: 'RedEye' }}

--- a/src/components/actionPayloadRenderers/CardPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/CardPayloadRendererContainer.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { CardAction, EntityBase, Memory } from '@conversationlearner/models'
+import * as Util from '../../util'
+import CardPayloadRenderer from './CardPayloadRenderer'
+
+interface Props {
+    isValidationError: boolean
+    cardAction: CardAction
+    entities: EntityBase[]
+    memories: Memory[] | null
+    onClickViewCard: (cardAction: CardAction) => void
+}
+
+export default class Component extends React.Component<Props, {}> {
+    onClickViewCard = () => {
+        this.props.onClickViewCard(this.props.cardAction)
+    }
+
+    render() {
+        const { cardAction, entities, memories } = this.props
+        const defaultEntityMap = Util.getDefaultEntityMap(entities)
+        const argumentStringsUsingEntityNames = cardAction.renderArguments(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
+        
+        if (memories === null) {
+            return <CardPayloadRenderer
+                isValidationError={this.props.isValidationError}
+                name={cardAction.templateName}
+                originalArguments={argumentStringsUsingEntityNames}
+                substitutedArguments={null}
+                onClickViewCard={this.onClickViewCard}
+            />
+        }
+
+        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
+        const argumentStringsUsingCurrentMemory = cardAction.renderArguments(currentEntityMap, { fallbackToOriginal: true })
+
+        return <CardPayloadRenderer
+            isValidationError={this.props.isValidationError}
+            name={cardAction.templateName}
+            originalArguments={argumentStringsUsingEntityNames}
+            substitutedArguments={argumentStringsUsingCurrentMemory}
+            onClickViewCard={this.onClickViewCard}
+        />
+    }
+}

--- a/src/components/actionPayloadRenderers/CardPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/CardPayloadRendererContainer.tsx
@@ -8,37 +8,27 @@ interface Props {
     cardAction: CardAction
     entities: EntityBase[]
     memories: Memory[] | null
-    onClickViewCard: (cardAction: CardAction) => void
+    onClickViewCard: (cardAction: CardAction, showOriginal: boolean) => void
 }
 
 export default class Component extends React.Component<Props, {}> {
-    onClickViewCard = () => {
-        this.props.onClickViewCard(this.props.cardAction)
+    onClickViewCard = (showOriginal: boolean) => {
+        this.props.onClickViewCard(this.props.cardAction, showOriginal)
     }
 
     render() {
         const { cardAction, entities, memories } = this.props
         const defaultEntityMap = Util.getDefaultEntityMap(entities)
-        const argumentStringsUsingEntityNames = cardAction.renderArguments(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
-        
-        if (memories === null) {
-            return <CardPayloadRenderer
-                isValidationError={this.props.isValidationError}
-                name={cardAction.templateName}
-                originalArguments={argumentStringsUsingEntityNames}
-                substitutedArguments={null}
-                onClickViewCard={this.onClickViewCard}
-            />
-        }
-
-        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
-        const argumentStringsUsingCurrentMemory = cardAction.renderArguments(currentEntityMap, { fallbackToOriginal: true })
+        const argumentsUsingEntityNames = cardAction.renderArguments(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
+        const argumentUsingCurrentMemory = memories === null
+            ? null
+            : cardAction.renderArguments(Util.createEntityMapFromMemories(entities, memories), { fallbackToOriginal: true })
 
         return <CardPayloadRenderer
             isValidationError={this.props.isValidationError}
             name={cardAction.templateName}
-            originalArguments={argumentStringsUsingEntityNames}
-            substitutedArguments={argumentStringsUsingCurrentMemory}
+            originalArguments={argumentsUsingEntityNames}
+            substitutedArguments={argumentUsingCurrentMemory}
             onClickViewCard={this.onClickViewCard}
         />
     }

--- a/src/components/actionPayloadRenderers/TextPayloadRenderer.css
+++ b/src/components/actionPayloadRenderers/TextPayloadRenderer.css
@@ -1,4 +1,4 @@
-.cl-textpayload {
+.cl-text-payload {
     display: grid;
     grid-template: auto / 1fr min-content;
     grid-gap: 1em;

--- a/src/components/actionPayloadRenderers/TextPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/TextPayloadRenderer.tsx
@@ -23,13 +23,14 @@ export default class Component extends React.Component<Props, State> {
     }
 
     render() {
-        return <div className={`${OF.FontClassNames.mediumPlus} cl-textpayload`}>
-            <div className="cl-textpayload__string">{this.state.isOriginalVisible
+        const showToggle = this.props.currentMemory !== this.props.original
+
+        return <div className={`${OF.FontClassNames.mediumPlus} cl-text-payload`}>
+            <div className="cl-text-payload__string">{this.state.isOriginalVisible
                 ? this.props.original
                 : this.props.currentMemory
             }</div>
-            {this.props.currentMemory !== this.props.original
-                && <div>
+            {showToggle && <div>
                 <OF.Toggle
                     checked={this.state.isOriginalVisible}
                     onChanged={this.onChangedVisible}

--- a/src/components/actionPayloadRenderers/TextPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/TextPayloadRenderer.tsx
@@ -4,7 +4,7 @@ import './TextPayloadRenderer.css'
 
 interface Props {
     original: string
-    currentMemory: string
+    currentMemory: string | null
 }
 
 interface State {
@@ -23,10 +23,10 @@ export default class Component extends React.Component<Props, State> {
     }
 
     render() {
-        const showToggle = this.props.currentMemory !== this.props.original
+        const showToggle = this.props.currentMemory !== null && this.props.currentMemory !== this.props.original
 
         return <div className={`${OF.FontClassNames.mediumPlus} cl-text-payload`}>
-            <div className="cl-text-payload__string">{this.state.isOriginalVisible
+            <div className="cl-text-payload__string">{(this.props.currentMemory === null || this.state.isOriginalVisible)
                 ? this.props.original
                 : this.props.currentMemory
             }</div>

--- a/src/components/actionPayloadRenderers/TextPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/TextPayloadRendererContainer.tsx
@@ -16,16 +16,9 @@ export default class Component extends React.Component<Props, {}> {
         const { entities, memories, textAction } = this.props
         const defaultEntityMap = Util.getDefaultEntityMap(entities)
         const renderStringUsingEntityNames = textAction.renderValue(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
-
-        if (memories === null) {
-            return <TextPayloadRenderer
-                original={renderStringUsingEntityNames}
-                currentMemory={null}
-            />
-        }
-
-        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
-        const renderStringUsingCurrentMemory = textAction.renderValue(currentEntityMap, { fallbackToOriginal: true })
+        const renderStringUsingCurrentMemory = memories === null
+            ? null
+            : textAction.renderValue(Util.createEntityMapFromMemories(entities, memories), { fallbackToOriginal: true })
 
         return <TextPayloadRenderer
             original={renderStringUsingEntityNames}

--- a/src/components/actionPayloadRenderers/TextPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/TextPayloadRendererContainer.tsx
@@ -6,15 +6,25 @@ import TextPayloadRenderer from './TextPayloadRenderer'
 interface Props {
     textAction: TextAction
     entities: EntityBase[]
+    // TODO: Find better alternative than null
+    // When memories is null it's assumed parent doesn't have access to it and intends to fallback to the entity names
     memories: Memory[] | null
 }
 
 export default class Component extends React.Component<Props, {}> {
     render() {
         const { entities, memories, textAction } = this.props
-        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
         const defaultEntityMap = Util.getDefaultEntityMap(entities)
         const renderStringUsingEntityNames = textAction.renderValue(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
+
+        if (memories === null) {
+            return <TextPayloadRenderer
+                original={renderStringUsingEntityNames}
+                currentMemory={null}
+            />
+        }
+
+        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
         const renderStringUsingCurrentMemory = textAction.renderValue(currentEntityMap, { fallbackToOriginal: true })
 
         return <TextPayloadRenderer

--- a/src/components/actionPayloadRenderers/TextPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/TextPayloadRendererContainer.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { TextAction, EntityBase, Memory } from '@conversationlearner/models'
+import * as Util from '../../util'
+import TextPayloadRenderer from './TextPayloadRenderer'
+
+interface Props {
+    textAction: TextAction
+    entities: EntityBase[]
+    memories: Memory[] | null
+}
+
+export default class Component extends React.Component<Props, {}> {
+    render() {
+        const { entities, memories, textAction } = this.props
+        const currentEntityMap = Util.createEntityMapFromMemories(entities, memories)
+        const defaultEntityMap = Util.getDefaultEntityMap(entities)
+        const renderStringUsingEntityNames = textAction.renderValue(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
+        const renderStringUsingCurrentMemory = textAction.renderValue(currentEntityMap, { fallbackToOriginal: true })
+
+        return <TextPayloadRenderer
+            original={renderStringUsingEntityNames}
+            currentMemory={renderStringUsingCurrentMemory}
+        />
+    }
+}

--- a/src/components/actionPayloadRenderers/index.ts
+++ b/src/components/actionPayloadRenderers/index.ts
@@ -1,7 +1,9 @@
 import TextPayloadRendererContainer from './TextPayloadRendererContainer'
 import ApiPayloadRendererContainer from './ApiPayloadRendererContainer'
+import CardPayloadRendererContainer from './CardPayloadRendererContainer'
 
 export {
     ApiPayloadRendererContainer,
+    CardPayloadRendererContainer,
     TextPayloadRendererContainer
 }

--- a/src/components/actionPayloadRenderers/index.ts
+++ b/src/components/actionPayloadRenderers/index.ts
@@ -1,0 +1,7 @@
+import TextPayloadRendererContainer from './TextPayloadRendererContainer'
+import ApiPayloadRendererContainer from './ApiPayloadRendererContainer'
+
+export {
+    ApiPayloadRendererContainer,
+    TextPayloadRendererContainer
+}

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -418,13 +418,17 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
             }))
     }
 
-    // TODO: Investigate alternative to get around need to use EntityIdSerializer directly is to construct mock CardAction and call .renderArguments()
+    /**
+     * Pre-render slate values for display in card template
+     */
     getRenderedActionArguments(slateValuesMap: { [slot: string]: ActionPayloadEditor.SlateValue }, entities: EntityBase[]): RenderedActionArgument[] {
         return Object.entries(slateValuesMap)
             .filter(([parameter, value]) => value.document.text.length > 0)
             .map<RenderedActionArgument>(([parameter, value]) => ({
                 parameter,
-                value: Plain.serialize(value)// ActionPayloadEditor.EntityIdSerializer.serialize(value, entityValueMap)
+                // TODO: Investigate alternative to get around need to use EntityIdSerializer directly is to construct mock CardAction and call .renderArguments()
+                // ActionPayloadEditor.EntityIdSerializer.serialize(value, entityValueMap)
+                value: Plain.serialize(value)
             }))
     }
 

--- a/src/components/modals/ActionPayloadEditor/index.ts
+++ b/src/components/modals/ActionPayloadEditor/index.ts
@@ -6,7 +6,6 @@ import Editor, { SlateValue } from './PayloadEditor'
 import { defaultOptions } from './MentionPlugin'
 import initialValue from './value'
 import { getEntitiesFromValue } from './utilities'
-import EntityIdSerializer from './slateSerializer'
 import SlateTransformer from './slateTransformer'
 import { IOption } from './models'
 
@@ -19,7 +18,6 @@ export {
     triggerCharacter, 
     SlateValue,
     Editor,
-    EntityIdSerializer,
     IOption,
     initialValue,
     Utilities

--- a/src/components/modals/ActionPayloadEditor/slateSerializer.test.ts
+++ b/src/components/modals/ActionPayloadEditor/slateSerializer.test.ts
@@ -130,7 +130,7 @@ describe('EntityIdSerializer', () => {
             .value
 
         const plainString = Plain.serialize(testValue)
-        const entityIdString = EntityIdSerializer.serialize(testValue, emptyMap, true)
+        const entityIdString = EntityIdSerializer.serialize(testValue, emptyMap, { fallbackToOriginal: true })
 
         expect(plainString).toEqual(`some text to start $entityName some other text`)
         expect(entityIdString).toEqual(`some text to start $entityName some other text`)
@@ -214,6 +214,13 @@ describe('EntityIdSerializer', () => {
             [entities[0].id, 'Custom Entity 1 Value']
         ]))
 
+        const partialStringWithBrackets = EntityIdSerializer.serialize(testValue, new Map<string, string>([
+            [entities[0].id, 'Custom Entity 1 Value'],
+            [entities[1].id, 'Custom Entity 2 Value']
+        ]), {
+            preserveOptionalNodeWrappingCharacters: true
+        })
+
         test(`given slate value with custom optional inline nodes without matching value in map are removed`, () => {
             expect(plainString).toEqual(`some text to start $entityName1 some other text [some stuff $entityName2 ending optional node ]ending text`)
             expect(partialString).toEqual(`some text to start Custom Entity 1 Value some other text ending text`)
@@ -221,6 +228,10 @@ describe('EntityIdSerializer', () => {
         
         test('given slate value with custom optional inline nodes with matching value in map are preserved', () => {
             expect(entityIdString).toEqual(`some text to start Custom Entity 1 Value some other text some stuff Custom Entity 2 Value ending optional node ending text`)
+        })
+
+        test('given slate value with custom optional inline nodes with matching value in map are preserved', () => {
+            expect(partialStringWithBrackets).toEqual(`some text to start Custom Entity 1 Value some other text [some stuff Custom Entity 2 Value ending optional node ]ending text`)
         })
     })
 })

--- a/src/components/modals/ActionPayloadEditor/slateTransformer.ts
+++ b/src/components/modals/ActionPayloadEditor/slateTransformer.ts
@@ -37,7 +37,7 @@ function updateNodeOptionNames(node: any, options: IOption[], newName?: string) 
         // 1. Update option name
         option.name = matchingOption.name
 
-        // 2. Update 
+        // 2. Update child text nodes which also contain entity name
         node.nodes.map((n: any) => updateNodeOptionNames(n, options, matchingOption.name))
         return node
     } else if (node.kind === 'text') {

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -10,7 +10,7 @@ import { State } from '../../types'
 import {
     AppBase, TrainScorerStep, Memory, ScoredBase, ScoreInput, ScoreResponse,
     ActionBase, ScoredAction, UnscoredAction, ScoreReason, DialogType, ActionTypes,
-    Template, DialogMode, RenderedActionArgument, CardAction, TextAction
+    Template, DialogMode, RenderedActionArgument, CardAction, TextAction, ApiAction
 } from '@conversationlearner/models'
 import { createActionThunkAsync } from '../../actions/createActions'
 import { toggleAutoTeach } from '../../actions/teachActions'
@@ -100,13 +100,12 @@ function getColumns(intl: InjectedIntl, hideScore: boolean): IRenderableColumn[]
                     />
                 }
                 else if (action.actionType === ActionTypes.API_LOCAL) {
-                    return "test"
-                    // const apiAction = new ApiAction(action)
-                    // return "test" <ActionPayloadRenderers.ApiPayloadRendererContainer
-                    //     apiAction={apiAction}
-                    //     entities={component.props.entities}
-                    //     memories={component.props.memories}
-                    // />
+                    const apiAction = new ApiAction(action)
+                    return <ActionPayloadRenderers.ApiPayloadRendererContainer
+                        apiAction={apiAction}
+                        entities={component.props.entities}
+                        memories={component.props.memories}
+                    />
                 }
                 else if (action.actionType === ActionTypes.CARD) {
                     const cardAction = new CardAction(action)

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -22,7 +22,6 @@ import { injectIntl, InjectedIntl, InjectedIntlProps } from 'react-intl'
 import { FM } from '../../react-intl-messages'
 import * as Util from '../../util'
 import AdaptiveCardViewer from './AdaptiveCardViewer/AdaptiveCardViewer'
-import TextPayloadRenderer from '../TextPayloadRenderer'
 
 const ACTION_BUTTON = 'action_button';
 const MISSING_ACTION = 'missing_action';
@@ -81,7 +80,7 @@ function getColumns(intl: InjectedIntl, hideScore: boolean): IRenderableColumn[]
             isMultiline: true,
             isResizable: true,
             render: (action: ActionBase, component) => {
-                const currentEntityMap = Util.createEntityMapFromMemories(component.props.entities, component.props.memories)
+                // const currentEntityMap = Util.createEntityMapFromMemories(component.props.entities, component.props.memories)
                 const defaultEntityMap = Util.getDefaultEntityMap(component.props.entities)
                 const args = ActionBase.GetActionArguments(action)
                     .map(aa => ({ key: aa.parameter, value: aa.renderValue(defaultEntityMap) }))
@@ -89,10 +88,7 @@ function getColumns(intl: InjectedIntl, hideScore: boolean): IRenderableColumn[]
 
                 if (action.actionType === ActionTypes.TEXT) {
                     const textAction = new TextAction(action)
-                    return <TextPayloadRenderer
-                        original={textAction.renderValue(defaultEntityMap)}
-                        currentMemory={textAction.renderValue(currentEntityMap)}
-                    />
+                    return <div>{textAction.renderValue(defaultEntityMap)}</div>
                 }
                 else if (action.actionType === ActionTypes.API_LOCAL) {
                     const apiAction = new ApiAction(action)

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -81,15 +81,7 @@ function getColumns(intl: InjectedIntl, hideScore: boolean): IRenderableColumn[]
             isMultiline: true,
             isResizable: true,
             render: (action: ActionBase, component) => {
-                const currentEntityMap = Util.createEntityMapFromMemories(component.props.entities, component.props.memories)
                 const defaultEntityMap = Util.getDefaultEntityMap(component.props.entities)
-                const args = ActionBase.GetActionArguments(action)
-                    .map(aa => ({
-                        parameter: aa.parameter,
-                        original: aa.renderValue(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true }),
-                        currentMemory: aa.renderValue(currentEntityMap, { fallbackToOriginal: true })
-                    }))
-                    .filter(kv => !Util.isNullOrWhiteSpace(kv.original))
                     
                 if (action.actionType === ActionTypes.TEXT) {
                     const textAction = new TextAction(action)
@@ -109,20 +101,13 @@ function getColumns(intl: InjectedIntl, hideScore: boolean): IRenderableColumn[]
                 }
                 else if (action.actionType === ActionTypes.CARD) {
                     const cardAction = new CardAction(action)
-                    return <div>
-                        <OF.PrimaryButton
-                            className="cl-button--viewCard"
-                            onClick={() => component.onClickViewCard(action)}
-                            ariaDescription="View Card"
-                            text=""
-                            iconProps={{ iconName: 'RedEye' }}
-                        />
-
-                        <span className={OF.FontClassNames.mediumPlus}>{cardAction.templateName}</span>
-                        {args.length !== 0 &&
-                            args.map((argument, i) => <div className="ms-ListItem-primaryText" key={i}>{`${argument.parameter}: ${argument.original}`}</div>)
-                        }
-                    </div>
+                    return <ActionPayloadRenderers.CardPayloadRendererContainer
+                        isValidationError={false}
+                        cardAction={cardAction}
+                        entities={component.props.entities}
+                        memories={component.props.memories}
+                        onClickViewCard={() => component.onClickViewCard(action)}
+                    />
                 }
 
                 return <span className={OF.FontClassNames.mediumPlus}>{ActionBase.GetPayload(action, defaultEntityMap)}</span>

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -7,7 +7,7 @@ import { returntypeof } from 'react-redux-typescript';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { State } from '../../types'
-import { AppBase, ModelUtils, ExtractResponse, TextVariation, DialogType, EntityType, EntityBase, UserInput, DialogMode, PredictedEntity } from '@conversationlearner/models'
+import { AppBase, ModelUtils, ExtractResponse, TextVariation, DialogType, EntityType, UserInput, DialogMode } from '@conversationlearner/models'
 import * as OF from 'office-ui-fabric-react';
 import * as ExtractorResponseEditor from '../ExtractorResponseEditor'
 import EntityCreatorEditor from './EntityCreatorEditor';
@@ -21,23 +21,6 @@ import './EntityExtractor.css'
 interface ExtractResponseForDisplay {
     extractResponse: ExtractResponse
     isValid: boolean
-}
-
-const addMissingEntityData = (extractResponse: ExtractResponse, entities: EntityBase[]): ExtractResponse => {
-    const predictedEntities = extractResponse.predictedEntities.map<PredictedEntity>(pe => {
-        const entity = entities.find(e => e.entityId === pe.entityId)
-        const builtinType = entity ? entity.entityType : 'UNKNOWN'
-
-        return {
-            ...pe,
-            builtinType
-        }
-    })
-
-    return {
-        ...extractResponse,
-        predictedEntities
-    }
 }
 
 interface ComponentState {
@@ -158,7 +141,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
 
     // Return merge of extract responses and text variations
     allResponses(): ExtractResponse[] {
-        return [...ModelUtils.ToExtractResponses(this.state.newTextVariations).map(er => addMissingEntityData(er, this.props.entities)), ...this.props.extractResponses]
+        return [...ModelUtils.ToExtractResponses(this.state.newTextVariations), ...this.props.extractResponses]
             .map(e => ({
                 ...e,
                 definitions: {

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -572,7 +572,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                     }
                     for (let ss of round.scorerSteps) {
                         let foundAction = this.props.actions.find(a => a.actionId === ss.labelAction);
-                        // Invalid train dialogs can contain delted actions
+                        // Invalid train dialogs can contain deleted actions
                         if (foundAction) {
                             actionsInTD.push(foundAction);
                         }
@@ -591,8 +591,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 }
                 if (this.state.actionFilter && this.state.actionFilter.key
                     && !actionsInTD.find(a => a.actionId === this.state.actionFilter.key)) {
-                return false;
-            }
+                    return false;
+                }
 
                 let entityNames = entitiesInTD.map(e => e.entityName);
                 let actionPayloads = actionsInTD.map(a => ActionBase.GetPayload(a, getDefaultEntityMap(this.props.entities)));

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,6 +42,16 @@ export function packageReferences(app: models.AppBase): models.PackageReference[
     return [...app.packageVersions || [], {packageId: app.devPackageId, packageVersion: 'Master'}] as models.PackageReference[]
 }
 
+export function createEntityMapFromMemories(entities: models.EntityBase[], memories: models.Memory[]): Map<string, string> {
+    return memories.reduce((map, m) => {
+        const entity = entities.find(e => e.entityName === m.entityName)
+        if (entity) {
+            map.set(entity.entityId, models.memoryValuesAsString(m.entityValues))
+        }
+        return map
+    }, new Map<string, string>())
+}
+
 // TODO: Remove coupling with the start character on ActionPayloadEditor
 export function getDefaultEntityMap(entities: models.EntityBase[]): Map<string, string> {
     return entities.reduce((m, e) => m.set(e.entityId, `$${e.entityName}`), new Map<string, string>())


### PR DESCRIPTION
- Use same component across ActionDetailsList and ActionScorer to ensure consistency
- Allow viewing original form of action without entity substitutions
- Allows viewing partially complete payloads (they have required entity which is missing and disqualified but still want to see substitutions)
- Allows viewing cards in both states

Optional brackets are now correctly shown to indicate optional sections:
![image](https://user-images.githubusercontent.com/2856501/40208596-66290bf0-59ef-11e8-90d3-f88650f80e61.png)

Api payloads show arguments to the user as they would appear in the function so they better understand the relationship:

Showing current memory (notice e1 value 3457 is showing):
![image](https://user-images.githubusercontent.com/2856501/40208636-8dd100d6-59ef-11e8-9a86-2b0f82f5a8b3.png)
Toggle to show original text (notice 3457 is not shown):
![image](https://user-images.githubusercontent.com/2856501/40208650-9c84303a-59ef-11e8-82c5-7d92bf1b7bf9.png)

Card Previews can now show with current memory for better idea of what bot will return:
![image](https://user-images.githubusercontent.com/2856501/40208694-d00ceb18-59ef-11e8-9fab-029ec69ae0f6.png)

