### PR TITLE
Rename visible text using 'Apps' or 'Applications' to 'Models'

### DIFF
--- a/src/components/ToolTips.tsx
+++ b/src/components/ToolTips.tsx
@@ -337,7 +337,7 @@ export function GetTip(tipType: string) {
                     <p>There are two different keys for LUIS. The <b>Authoring</b> key and the <b>Subscription</b> key.</p>
                     
                     <h4>Why does Conversation Learner need my Authoring key?</h4>
-                    <p>When building and training your bot, the LUIS_AUTHORING_KEY is by Conversation Learner to manage your LUIS account on your behalf.  As you make changes to your Conversation Learner app such as adding entities and labeling entities during training the Conversation Learner service creates the associated LUIS apps with matching entities and utterance phrases.</p>
+                    <p>When building and training your bot, the LUIS_AUTHORING_KEY is by Conversation Learner to manage your LUIS account on your behalf.  As you make changes to your Conversation Learner model such as adding entities and labeling entities during training the Conversation Learner service creates the associated LUIS apps with matching entities and utterance phrases.</p>
 
                     <h4>What does Conversation Learner need my subscription key?</h4>
                     <p>When you publish your bot, you want to set the LUIS_SUBSCRIPTION_KEY.  When set, the Subscription Key (rather than the Authoring Key) is used by Conversation Learner to get predictions from LUIS.  Using the Subscription Key avoids using up the quota for your Authoring key (which would block further usage of Conversation Learner).</p>
@@ -353,7 +353,7 @@ export function GetTip(tipType: string) {
                         <li>Sign in if you are not already</li>
                         <li>Click on your name in the top-right corner to open the dropdown menu</li>
                         <li>Select 'settings' from the menu</li>
-                        <li>Copy the "Authoring Key" and use it as the LUIS_AUTHORING_KEY value for your app</li>
+                        <li>Copy the "Authoring Key" and use it as the LUIS_AUTHORING_KEY value for your model</li>
                     </ol>
 
                     <img src="https://blisstorage.blob.core.windows.net/uiimages/authoringkey.gif"/>
@@ -363,7 +363,7 @@ export function GetTip(tipType: string) {
                     <p>There are two different keys for LUIS. The <b>Authoring</b> key and the <b>Subscription</b> key.</p>
                     
                     <h4>Why does Conversation Learner need my Authoring key?</h4>
-                    <p>When building and training your bot, the LUIS_AUTHORING_KEY is by Conversation Learner to manage your LUIS account on your behalf.  As you make changes to your Conversation Learner app such as adding entities and labeling entities during training the Conversation Learner service creates the associated LUIS apps with matching entities and utterance phrases.</p>
+                    <p>When building and training your bot, the LUIS_AUTHORING_KEY is by Conversation Learner to manage your LUIS account on your behalf.  As you make changes to your Conversation Learner model such as adding entities and labeling entities during training the Conversation Learner service creates the associated LUIS apps with matching entities and utterance phrases.</p>
 
                     <h4>What does Conversation Learner need my Subscription key?</h4>
                     <p>When you publish your bot, you want to set the LUIS_SUBSCRIPTION_KEY.  When set, the Subscription Key (rather than the Authoring Key) is used by Conversation Learner to get predictions from LUIS.  Using the Subscription Key avoids using up the quota for your Authoring key (which would block further usage of Conversation Learner).</p>
@@ -383,14 +383,14 @@ export function GetTip(tipType: string) {
 
                     <h2>Find / Set your LUIS Subscription key:</h2>
                     <ol>
-                        <li>Click on the "Go to LUIS" button in the Conversation Learner UI.  This will take you to the LUIS application associated with you app.</li>
+                        <li>Click on the "Go to LUIS" button in the Conversation Learner UI.  This will take you to the LUIS application associated with you model.</li>
                         <li>In your LUIS' apps "Publish Tab", click on "Add Key"
                             <img src="https://blisstorage.blob.core.windows.net/uiimages/addkey.PNG" width="50%"  />
                         </li>
                         <li>If you don't yet have an Azure Suscription key you'll need to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/luis/azureibizasubscription" target="_blank">Create One</a></li>
-                        <li>Then select the subscription and add the key to your LUIS app</li>
+                        <li>Then select the subscription and add the key to your LUIS model</li>
                             <img src="https://blisstorage.blob.core.windows.net/uiimages/assignkey.PNG" width="50%"/>
-                        <li>Click the Key String to copy the key value and use it as the LUIS_SUBSCRIPTION_KEY value for your app
+                        <li>Click the Key String to copy the key value and use it as the LUIS_SUBSCRIPTION_KEY value for your model
                             <br/>
                             <img src="https://blisstorage.blob.core.windows.net/uiimages/getkey.PNG" width="75%"/>
                         </li>

--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -25,7 +25,7 @@ const messages = defineMessages({
     },
     fieldErrorAlphanumeric: {
         id: FM.APPCREATOR_FIELDERROR_ALPHANUMERIC,
-        defaultMessage: 'Application name may only contain alphanumeric characters'
+        defaultMessage: 'Model name may only contain alphanumeric characters'
     },
     fieldErrorDistinct: {
         id: FM.APPCREATOR_FIELDERROR_DISTINCT,
@@ -125,7 +125,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
     // TODO: Refactor to use default form submission instead of manually listening for keys
     // Also has benefit of native browser validation for required fields
     onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
-        // On enter attempt to create the app if required fields are set
+        // On enter attempt to create the model if required fields are set
         // Not on import as explicit button press is required to pick the file
         if (this.props.creatorType !== AppCreatorType.IMPORT && event.keyCode === 13 && this.state.appNameVal) {
             this.onClickCreate();
@@ -176,19 +176,19 @@ class AppCreator extends React.Component<Props, ComponentState> {
                 return (
                     <FormattedMessage
                         id={FM.APPCREATOR_TITLE}
-                        defaultMessage="Create a Conversation Learner App"
+                        defaultMessage="Create a Conversation Learner Model"
                     />)
             case AppCreatorType.IMPORT:
                 return (
                 <FormattedMessage
                     id={FM.APPCREATOR_IMPORT_TITLE}
-                    defaultMessage="Import a Conversation Learner App"
+                    defaultMessage="Import a Conversation Learner Model"
                 />)
             case AppCreatorType.COPY:
                 return (
                     <FormattedMessage
                         id={FM.APPCREATOR_COPY_TITLE}
-                        defaultMessage="Copy a Conversation Learner App"
+                        defaultMessage="Copy a Conversation Learner Model"
                     />)
             default:
                 return null;
@@ -199,7 +199,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
         return (this.props.creatorType !== AppCreatorType.NEW) ?
             intl.formatMessage({
                 id: FM.APPCREATOR_FIELDS_IMPORT_NAME_LABEL,
-                defaultMessage: "New App Name"
+                defaultMessage: "New Model Name"
             })
         :
             intl.formatMessage({
@@ -231,7 +231,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                         label={this.getLabel(intl)}
                         placeholder={intl.formatMessage({
                             id: FM.APPCREATOR_FIELDS_NAME_PLACEHOLDER,
-                            defaultMessage: "Application Name..."
+                            defaultMessage: "Model Name..."
                         })}
                         onKeyDown={key => this.onKeyDown(key)}
                         value={this.state.appNameVal}

--- a/src/components/modals/EntityCreatorEditor.tsx
+++ b/src/components/modals/EntityCreatorEditor.tsx
@@ -113,7 +113,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
 
     componentWillReceiveProps(nextProps: Props) {
         if (nextProps.open !== this.props.open) {
-            // Build entity options based on current application locale
+            // Build entity options based on current model locale
             const currentAppLocale = nextProps.app.locale
             const localePreBuiltOptions = PreBuiltEntities
                 .find(entitiesList => entitiesList.locale === currentAppLocale).preBuiltEntities

--- a/src/components/modals/PackageCreator.tsx
+++ b/src/components/modals/PackageCreator.tsx
@@ -68,7 +68,7 @@ class PackageCreator extends React.Component<Props, ComponentState> {
     // TODO: Refactor to use default form submission instead of manually listening for keys
     // Also has benefit of native browser validation for required fields
     onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
-        // On enter attempt to create the app if required fields are set
+        // On enter attempt to create the model if required fields are set
         if (event.keyCode === 13 && this.state.tagNameVal) {
             this.onClickCreate();
         }

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -59,7 +59,7 @@ export enum FM {
     ACTIONSCORER_COLUMNS_TYPE = 'ActionScorer.columns.type',
 
     // App
-    APP_HEADER_MYAPPS = 'App.header.home',
+    APP_HEADER_MODELS = 'App.header.home',
     APP_HEADER_ABOUT = 'App.header.about',
     APP_HEADER_DOCS = 'App.header.docs',
     APP_HEADER_SUPPORT = 'App.header.support',
@@ -438,7 +438,7 @@ export default {
         [FM.PROFILE_SETTINGS_SDK_PORT_WARNING]: 'Only change this if you know what you are doing.  This value must match the PORT that your SDK is listening on.',
         [FM.SUPPORT_TITLE]: 'Support',
         [FM.NOMATCH_TITLE]: 'That page was not found.',
-        [FM.NOMATCH_HOME]: 'My Apps',
+        [FM.NOMATCH_HOME]: 'My Models',
         [FM.PAGE_COMINGSOON]: 'Coming soon...',
 
         // Actions
@@ -449,7 +449,7 @@ export default {
         [FM.ACTIONS_CONFIRMCANCELMODALTITLE]: 'Are you sure you want to delete this action?',
 
         // App
-        [FM.APP_HEADER_MYAPPS]: 'My Apps',
+        [FM.APP_HEADER_MODELS]: 'My Models',
         [FM.APP_HEADER_ABOUT]: 'About',
         [FM.APP_HEADER_DOCS]: 'Docs',
         [FM.APP_HEADER_SUPPORT]: 'Support',
@@ -466,12 +466,12 @@ export default {
         [FM.APP_TRAINING_STATUS_EXPIRED]: 'Polling was stopped before training status was finalized. Please Refresh',
 
         // Apps List
-        [FM.APPSLIST_SUBTITLE]: 'Create and manage your Conversation Learner applications',
-        [FM.APPSLIST_CREATEBUTTONARIADESCRIPTION]: 'Create a New Application',
-        [FM.APPSLIST_CREATEBUTTONTEXT]: 'New App',
-        [FM.APPSLIST_IMPORTAPP_BUTTONARIADESCRIPTION]: 'Import Application',
-        [FM.APPSLIST_IMPORTAPP_BUTTONTEXT]: 'Import App',
-        [FM.APPSLIST_IMPORTTUTORIALS_BUTTONARIADESCRIPTION]: 'Import Tutorials Applications',
+        [FM.APPSLIST_SUBTITLE]: 'Create and manage your Conversation Learner models',
+        [FM.APPSLIST_CREATEBUTTONARIADESCRIPTION]: 'Create a New Model',
+        [FM.APPSLIST_CREATEBUTTONTEXT]: 'New Model',
+        [FM.APPSLIST_IMPORTAPP_BUTTONARIADESCRIPTION]: 'Import Model',
+        [FM.APPSLIST_IMPORTAPP_BUTTONTEXT]: 'Import Model',
+        [FM.APPSLIST_IMPORTTUTORIALS_BUTTONARIADESCRIPTION]: 'Import Tutorials Models',
         [FM.APPSLIST_IMPORTTUTORIALS_BUTTONTEXT]: 'Import Tutorials',
         [FM.APPSLIST_CONFIRMCANCELMODALTITLE]: 'Are you sure you want to delete this application? {appName}',
         [FM.APPSLIST_COLUMN_NAME]: 'Name',
@@ -491,7 +491,7 @@ export default {
 
         // Dashboard
         [FM.DASHBOARD_TITLE]: 'Overview',
-        [FM.DASHBOARD_SUBTITLE]: `Notifications about this application`,
+        [FM.DASHBOARD_SUBTITLE]: `Notifications about this model`,
 
         // Entities
         [FM.ENTITIES_TITLE]: 'Entities',
@@ -520,7 +520,7 @@ export default {
         [FM.LOGDIALOGADMIN_CONFIRMTITLE]: 'This will attempt to replay the Log Dialog against the bot and convert it into a new Train Dialog',
 
         // ReplayErrorList
-        [FM.REPLAYERROR_LOGDIALOG_VALIDATION_TITLE]: 'Application definition has changed',
+        [FM.REPLAYERROR_LOGDIALOG_VALIDATION_TITLE]: 'Model definition has changed',
         [FM.REPLAYERROR_LOGDIALOG_VALIDATION_MESSAGE]: 'This Log Dialog was created with a earlier version of the application.  The following incomptibilities were found:',
         [FM.REPLAYERROR_CONVERT_TITLE]: 'Unable to convert to Train Dialog',
         [FM.REPLAYERROR_FAILMESSAGE]: 'The following issues occurred when attempting to replay the dialog',
@@ -535,20 +535,20 @@ export default {
         // Settings
         [FM.SETTINGS_TITLE]: 'Settings',
         [FM.SETTINGS_SUBTITLE]: 'Control your application version tags and other application configuration',
-        [FM.SETTINGS_COPYBUTTONARIALDESCRIPTION]: 'Copy App',
+        [FM.SETTINGS_COPYBUTTONARIALDESCRIPTION]: 'Copy Model',
         [FM.SETTINGS_COPYBUTTONTEXT]: 'Copy',
-        [FM.SETTINGS_EXPORTBUTTONARIALDESCRIPTION]: 'Export App to File',
+        [FM.SETTINGS_EXPORTBUTTONARIALDESCRIPTION]: 'Export Model to File',
         [FM.SETTINGS_EXPORTBUTTONTEXT]: 'Export',
         [FM.SETTINGS_FIELDERROR_REQUIREDVALUE]: 'Required Value',
-        [FM.SETTINGS_FIELDERROR_ALPHANUMERIC]: 'Application name may only contain alphanumeric characters',
+        [FM.SETTINGS_FIELDERROR_ALPHANUMERIC]: 'Model name may only contain alphanumeric characters',
         [FM.SETTINGS_FIELDERROR_DISTINCT]: 'Name is already in use.',
         [FM.SETTINGS_FIELDS_NAMELABEL]: 'Name',
-        [FM.SETTINGS_FILEDS_APPIDLABEL]: 'App ID',
+        [FM.SETTINGS_FILEDS_APPIDLABEL]: 'Model ID',
         [FM.SETTINGS_FIELDS_MARKDOWNLABEL]: 'Markdown',
         [FM.SETTINGS_FIELDS_VIDEOLABEL]: 'Video',
         [FM.SETTINGS_PASSWORDHIDDEN]: 'Show',
         [FM.SETTINGS_PASSWORDVISIBLE]: 'Hide',
-        [FM.SETTINGS_BOTFRAMEWORKAPPIDFIELDLABEL]: 'Application ID',
+        [FM.SETTINGS_BOTFRAMEWORKAPPIDFIELDLABEL]: 'Model ID',
         [FM.SETTINGS_BOTFRAMEWORKADDBOTBUTTONTEXT]: 'Add',
         [FM.SETTINGS_BOTFRAMEWORKLUISKEY_AUTHORING_LABEL]: 'LUIS Authoring Key',
         [FM.SETTINGS_BOTFRAMEWORKLUISKEY_AUTHORING_PLACEHOLDER]: 'Authoring Key...',
@@ -690,14 +690,14 @@ export default {
 
         // AppCreator
         [FM.APPCREATOR_FIELDERROR_REQUIREDVALUE]: 'Required Value',
-        [FM.APPCREATOR_FIELDERROR_ALPHANUMERIC]: 'Application name may only contain alphanumeric characters',
+        [FM.APPCREATOR_FIELDERROR_ALPHANUMERIC]: 'Model name may only contain alphanumeric characters',
         [FM.APPCREATOR_FIELDERROR_DISTINCT]: 'Name is already in use.',
-        [FM.APPCREATOR_TITLE]: 'Create a Conversation Learner App',
-        [FM.APPCREATOR_COPY_TITLE]: 'Copy a Conversation Learner App',
-        [FM.APPCREATOR_IMPORT_TITLE]: 'Import a Conversation Learner App',
+        [FM.APPCREATOR_TITLE]: 'Create a Conversation Learner Model',
+        [FM.APPCREATOR_COPY_TITLE]: 'Copy a Conversation Learner Model',
+        [FM.APPCREATOR_IMPORT_TITLE]: 'Import a Conversation Learner Model',
         [FM.APPCREATOR_FIELDS_NAME_LABEL]: 'Name',
-        [FM.APPCREATOR_FIELDS_IMPORT_NAME_LABEL]: 'New App Name',
-        [FM.APPCREATOR_FIELDS_NAME_PLACEHOLDER]: 'Application Name...',
+        [FM.APPCREATOR_FIELDS_IMPORT_NAME_LABEL]: 'New Model Name',
+        [FM.APPCREATOR_FIELDS_NAME_PLACEHOLDER]: 'Model Name...',
         [FM.APPCREATOR_FIELDS_LOCALE_LABEL]: 'Locale',
         [FM.APPCREATOR_COPYBUTTON_ARIADESCRIPTION]: 'Copy',
         [FM.APPCREATOR_COPYBUTTON_TEXT]: 'Copy',
@@ -709,8 +709,8 @@ export default {
         [FM.APPCREATOR_CANCELBUTTON_TEXT]: 'Cancel',
 
         // DemoImporter
-        [FM.DEMOIMPORT_TITLE]: 'Import Demo Applications',
-        [FM.DEMOIMPORT_BUTTON_ARIADESCRIPTION]: 'Import Demo Applications',
+        [FM.DEMOIMPORT_TITLE]: 'Import Demo Models',
+        [FM.DEMOIMPORT_BUTTON_ARIADESCRIPTION]: 'Import Demo Models',
         [FM.DEMOIMPORT_BUTTON_TEXT]: 'Import',
 
         // ChatSessionModal
@@ -856,7 +856,7 @@ export default {
         [FM.PAGE_COMINGSOON]: '출시 예정 ...',
 
         // App
-        [FM.APP_HEADER_MYAPPS]: '집',
+        [FM.APP_HEADER_MODELS]: '집',
         [FM.APP_HEADER_ABOUT]: '약',
         [FM.APP_HEADER_DOCS]: '선적 서류 비치',
         [FM.APP_HEADER_SUPPORT]: '지원하다',

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -82,8 +82,8 @@ class App extends React.Component<Props, ComponentState> {
               </span>
               <NavLink to="/home">
                 <FormattedMessage
-                  id={FM.APP_HEADER_MYAPPS}
-                  defaultMessage="My Apps"
+                  id={FM.APP_HEADER_MODELS}
+                  defaultMessage="My Models"
                 />
               </NavLink>
               <a href="https://labs.cognitive.microsoft.com/en-us/project-conversation-learner" target="_blank">Documentation</a>

--- a/src/routes/Apps/App/Dashboard.tsx
+++ b/src/routes/Apps/App/Dashboard.tsx
@@ -30,7 +30,7 @@ class Dashboard extends React.Component<Props, {}> {
                 <span className={FontClassNames.mediumPlus}>
                     <FormattedMessage
                         id={FM.DASHBOARD_SUBTITLE}
-                        defaultMessage="Notifications about this application..."
+                        defaultMessage="Notifications about this model..."
                     />
                 </span>
                 {this.props.validationErrors.length > 0 && 

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -57,7 +57,7 @@ class Index extends React.Component<Props, ComponentState> {
     }
 
     componentWillMount() {
-        // If we're loading Index due to page refresh where app is not in router state
+        // If we're loading Index due to page refresh where model is not in router state
         // force back to /home route to mimic old behavior and allow user to login again
         const { location, history } = this.props
         const app: AppBase | null = location.state && location.state.app
@@ -212,7 +212,7 @@ class Index extends React.Component<Props, ComponentState> {
                         </div>
                         <div className="cl-nav_section">
                             <NavLink className="cl-nav-link" exact={true} to="/home">
-                                <Icon iconName="Back" /><span>My Apps</span>
+                                <Icon iconName="Back" /><span>My Models</span>
                             </NavLink>
                         </div>
                     </div>

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -31,7 +31,7 @@ const messages = defineMessages({
     },
     fieldErrorAlphanumeric: {
         id: FM.SETTINGS_FIELDERROR_ALPHANUMERIC,
-        defaultMessage: 'Application name may only contain alphanumeric characters'
+        defaultMessage: 'Model name may only contain alphanumeric characters'
     },
     fieldErrorDistinct: {
         id: FM.SETTINGS_FIELDERROR_DISTINCT,
@@ -47,7 +47,7 @@ const messages = defineMessages({
     },
     botFrameworkAppIdFieldLabel: {
         id: FM.SETTINGS_BOTFRAMEWORKAPPIDFIELDLABEL,
-        defaultMessage: 'Application ID'
+        defaultMessage: 'Model ID'
     },
     botFrameworkAddBotButtonText: {
         id: FM.SETTINGS_BOTFRAMEWORKADDBOTBUTTONTEXT,
@@ -319,7 +319,7 @@ class Settings extends React.Component<Props, ComponentState> {
                 saveAs(blob, `${this.props.app.appName}.cl`);
             })
             .catch(error => {
-                console.warn(`Error when attempting export application `, error)
+                console.warn(`Error when attempting export model `, error)
             })
     }
 
@@ -333,7 +333,7 @@ class Settings extends React.Component<Props, ComponentState> {
                 })
             })
             .catch(error => {
-                console.warn(`Error when attempting export application `, error)
+                console.warn(`Error when attempting export model `, error)
             })
     }
 
@@ -367,7 +367,7 @@ class Settings extends React.Component<Props, ComponentState> {
                 <span className={OF.FontClassNames.mediumPlus}>
                     <FormattedMessage
                         id={FM.SETTINGS_SUBTITLE}
-                        defaultMessage="Control your application version tags and other application configuration"
+                        defaultMessage="Control your model version tags and other model configuration"
                     />
                 </span>
                 <div className="cl-settings-fields">
@@ -386,7 +386,7 @@ class Settings extends React.Component<Props, ComponentState> {
                             onClick={this.onExport}
                             ariaDescription={intl.formatMessage({
                                 id: FM.SETTINGS_EXPORTBUTTONARIALDESCRIPTION,
-                                defaultMessage: 'Export Application to a file'
+                                defaultMessage: 'Export Model to a file'
                             })}
                             text={intl.formatMessage({
                                 id: FM.SETTINGS_EXPORTBUTTONTEXT,
@@ -397,7 +397,7 @@ class Settings extends React.Component<Props, ComponentState> {
                             onClick={this.onCopy}
                             ariaDescription={intl.formatMessage({
                                 id: FM.SETTINGS_COPYBUTTONARIALDESCRIPTION,
-                                defaultMessage: 'Copy Application'
+                                defaultMessage: 'Copy Model'
                             })}
                             text={intl.formatMessage({
                                 id: FM.SETTINGS_COPYBUTTONTEXT,

--- a/src/routes/Apps/AppsIndex.tsx
+++ b/src/routes/Apps/AppsIndex.tsx
@@ -31,7 +31,7 @@ class AppsIndex extends React.Component<Props, ComponentState> {
         const { history } = this.props
         if (history.location.pathname !== '/home') {
             // TODO: There seems to be bug where the router state is not cleared sychronously here
-            // Thus when refreshing on non home page such as entities list for an app, this will force redirect to home
+            // Thus when refreshing on non home page such as entities list for an model, this will force redirect to home
             // howver, the other component at the entities page still runs component will mount with old router state.
             // Perhaps we need to use componentDidMount to inspect router state in children?
             history.replace('/home', null)
@@ -60,7 +60,7 @@ class AppsIndex extends React.Component<Props, ComponentState> {
         if (appFromLocationState) {
             const app = this.props.apps.find(a => a.appId === appFromLocationState.appId)
             if (!app) {
-                console.warn(`Attempted to find selected app in list of apps: ${this.state.selectedApp.appId} but it could not be found.`)
+                console.warn(`Attempted to find selected model in list of models: ${this.state.selectedApp.appId} but it could not be found.`)
                 return
             }
 

--- a/src/routes/Apps/AppsList.tsx
+++ b/src/routes/Apps/AppsList.tsx
@@ -289,22 +289,22 @@ class AppsList extends React.Component<Props, ComponentState> {
                         onClick={this.onClickCreateNewApp}
                         ariaDescription={this.props.intl.formatMessage({
                             id: FM.APPSLIST_CREATEBUTTONARIADESCRIPTION,
-                            defaultMessage: 'Create a New Application'
+                            defaultMessage: 'Create a New Model'
                         })}
                         text={this.props.intl.formatMessage({
                             id: FM.APPSLIST_CREATEBUTTONTEXT,
-                            defaultMessage: 'New App'
+                            defaultMessage: 'New Model'
                         })}
                     />
                     <OF.DefaultButton
                         onClick={this.onClickImportApp}
                         ariaDescription={this.props.intl.formatMessage({
                             id: FM.APPSLIST_IMPORTAPP_BUTTONARIADESCRIPTION,
-                            defaultMessage: 'Import Applicaiton'
+                            defaultMessage: 'Import Model'
                         })}
                         text={this.props.intl.formatMessage({
                             id: FM.APPSLIST_IMPORTAPP_BUTTONTEXT,
-                            defaultMessage: 'Import Application'
+                            defaultMessage: 'Import Model'
                         })}
                     />
                     {this.props.user.id !== CL_DEMO_ID &&
@@ -341,7 +341,7 @@ class AppsList extends React.Component<Props, ComponentState> {
                     onConfirm={this.onConfirmDeleteApp}
                     title={this.props.intl.formatMessage({
                         id: FM.APPSLIST_CONFIRMCANCELMODALTITLE,
-                        defaultMessage: 'Are you sure you want to delete this application? {appName}'
+                        defaultMessage: 'Are you sure you want to delete this model? {appName}'
                     }, {
                         appName: this.state.appToDelete ? this.state.appToDelete.appName : ''
                     })}

--- a/src/routes/NoMatch.tsx
+++ b/src/routes/NoMatch.tsx
@@ -20,7 +20,7 @@ const component = () => (
             <NavLink to="/">
                 <FormattedMessage
                     id={FM.NOMATCH_HOME}
-                    defaultMessage="My Apps"
+                    defaultMessage="My Models"
                 />
             </NavLink>
         </div>


### PR DESCRIPTION
The term application has a lot of other meaning and sounds like the root logical container for a system.  However, multiple CL 'application' could have been used in a single bot which is also an "application".  The term model is more appropriate semantically.  You are training conversation models for different task based domains and may use one or more of them within your Application / Bot.