### PR TITLE
 ci: update circle CI config to build sample and run e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,12 @@ jobs:
       - run: cd ../cl-samples && npm run build
 
       # Run sample
-      - run: cd ../cl-samples && npm start &
+      - run: cd ../cl-samples && npm start
+            background: true
 
       # Run UI
-      - run: npm start &
+      - run: npm start
+            background: true
 
       # Run UI e2e tests
       - run: npm run cypress -- run --browser chrome --record --key $CYPRESS_RECORD_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run: cd ../cl-samples && npm run build
 
       # Run sample
-      - run: cd cl-samples && npm start &
+      - run: cd ../cl-samples && npm start &
 
       # Run UI
       - run: npm start &

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,20 @@ jobs:
 
       - run: npm run test
       - run: npm run cibuild
+
+      # Clone, install, and build sample application
       - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop cl-samples
-      - run: cd cl-samples
-      - run: npm ci
-      - run: npm run build
-      - run: cd ..
+      - run: cd cl-samples && npm ci
+      - run: cd cl-samples && npm run build
+
+      # Run sample
+      - run: cd cl-samples && npm start &
+
+      # Run UI
+      - run: npm start &
+
+      # Run UI e2e tests
+      - run: npm run cypress -- run --browser chrome
       
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,14 @@ jobs:
       - run: cd ../cl-samples && npm run build
 
       # Run sample
-      - run: cd ../cl-samples && npm start
-            background: true
+      - run: 
+          command: cd ../cl-samples && npx fornpm start
+          background: true
 
       # Run UI
-      - run: npm start
-            background: true
+      - run: 
+          command: npm start
+          background: true
 
       # Run UI e2e tests
       - run: npm run cypress -- run --browser chrome --record --key $CYPRESS_RECORD_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Run sample
       - run: 
-          command: cd ../cl-samples && npx fornpm start
+          command: cd ../cl-samples && npm start
           background: true
 
       # Run UI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,11 @@ jobs:
 
       - run: npm run test
       - run: npm run cibuild
+      - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop cl-samples
+      - run: cd cl-samples
+      - run: npm ci
+      - run: npm run build
+      - run: cd ..
       
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ jobs:
       - run: npm run cibuild
 
       # Clone, install, and build sample application
-      - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop cl-samples
-      - run: cd cl-samples && npm ci
-      - run: cd cl-samples && npm run build
+      - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop ../cl-samples
+      - run: cd ../cl-samples && npm ci
+      - run: cd ../cl-samples && npm run build
 
       # Run sample
       - run: cd cl-samples && npm start &

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cypress/base:8
+      - image: cypress/browsers:chrome65-ff57
         environment:
           ## this enables colors in the output
           TERM: xterm
@@ -40,7 +40,10 @@ jobs:
       - run: npm start &
 
       # Run UI e2e tests
-      - run: npm run cypress -- run --browser chrome
+      - run: npm run cypress -- run --browser chrome --record --key $CYPRESS_RECORD_KEY
+
+      - store_test_results:
+          path: results
       
 workflows:
   version: 2


### PR DESCRIPTION
Example of Cypress dashboard output for test run:
https://dashboard.cypress.io/#/projects/so64kq/runs/8/specs

Currently the tests only pass with Chrome, but Cypress recording only works with electron which means we don't have recordings yet.  I'm still trying to find out why they're broken on Electron.