### PR TITLE
ci: setup mocha-multi-reporters to show spec and save junit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ jobs:
       # Run UI e2e tests
       - run: npm run cypress -- run --browser chrome --record --key $CYPRESS_RECORD_KEY
 
+      - store_artifacts:
+          path: results
+          
       - store_test_results:
           path: results
       

--- a/config-mocha-reporter.json
+++ b/config-mocha-reporter.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "results/tests-e2e.xml"
+  }
+}

--- a/config-mocha-reporter.json
+++ b/config-mocha-reporter.json
@@ -1,6 +1,6 @@
 {
   "reporterEnabled": "spec, mocha-junit-reporter",
   "mochaJunitReporterReporterOptions": {
-    "mochaFile": "results/tests-e2e.xml"
+    "mochaFile": "results/junit/test-results.xml"
   }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,7 @@
 {
   "projectId": "so64kq",
+  "reporter": "mocha-multi-reporters",
   "reporterOptions": {
-    "mochaFile": "results/tests-integration.xml"
+    "configFile": "config-mocha-reporter.json"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1895,6 +1895,12 @@
       "resolved": "http://bbnpm.azurewebsites.net/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -2822,6 +2828,12 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "cryptiles": {
       "version": "3.1.2",
@@ -7975,6 +7987,17 @@
       "resolved": "http://bbnpm.azurewebsites.net/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "http://bbnpm.azurewebsites.net/md5.js/-/md5.js-1.3.4.tgz",
@@ -8226,6 +8249,55 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha-junit-reporter": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.17.0.tgz",
+      "integrity": "sha1-LlFJ7UD8XS48px5C21qx/snG2Fw=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "mocha-multi-reporters": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+      "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "lodash": "^4.16.4"
       }
     },
     "moment": {
@@ -14892,6 +14964,12 @@
       "version": "3.0.0",
       "resolved": "http://bbnpm.azurewebsites.net/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-char-classes": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1589,6 +1589,12 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browserify-aes": {
       "version": "1.1.1",
       "resolved": "http://bbnpm.azurewebsites.net/browserify-aes/-/browserify-aes-1.1.1.tgz",
@@ -5745,6 +5751,12 @@
       "resolved": "http://bbnpm.azurewebsites.net/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "http://bbnpm.azurewebsites.net/growly/-/growly-1.3.0.tgz",
@@ -8249,6 +8261,42 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "mocha-junit-reporter": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "execa": "^0.9.0",
     "fs-extra": "^5.0.0",
     "husky": "0.14.3",
+    "mocha": "5.2.0",
     "mocha-junit-reporter": "1.17.0",
     "mocha-multi-reporters": "1.1.7",
     "tslint": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,10 @@
     "analyzeCommits": {
       "preset": "angular",
       "releaseRules": [
-        {"type": "style", "release": "patch"}
+        {
+          "type": "style",
+          "release": "patch"
+        }
       ]
     }
   },
@@ -105,6 +108,8 @@
     "execa": "^0.9.0",
     "fs-extra": "^5.0.0",
     "husky": "0.14.3",
+    "mocha-junit-reporter": "1.17.0",
+    "mocha-multi-reporters": "1.1.7",
     "tslint": "^5.9.1",
     "tslint-config-prettier": "^1.12.0",
     "tslint-config-standard": "^7.0.0",


### PR DESCRIPTION
This allows best of both reports.  Inline spec reports to be uploaded by Cypress with standard test result output saved as artifact to be understood by CI tool