### PR TITLE
 fix: allow negative entity creation in single call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -420,9 +420,9 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.167.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.167.0.tgz",
-      "integrity": "sha512-UNfFHjKIjBXT6hEEw0uCHMOYfOkbsyYk8UdoHKqBOPsXlPzJM7bfZMwwrJw7JIinuNmbW1fnaO5e/6+VLKr2WA=="
+      "version": "0.167.1",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.167.1.tgz",
+      "integrity": "sha512-bNMDD1io7DraWu1/MPA8/5FxbqGbCTRFmtmNQbc0LV1URP231GtbEx4dyJeSyk8JHa1geGzip7kT6wW6zWWQ0w=="
     },
     "@conversationlearner/webchat": {
       "version": "0.105.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "private": true,
   "dependencies": {
-    "@conversationlearner/models": "0.167.0",
+    "@conversationlearner/models": "0.167.1",
     "@conversationlearner/webchat": "0.105.0",
     "@types/file-saver": "^1.3.0",
     "adaptivecards": "1.0.0",

--- a/src/actions/createActions.ts
+++ b/src/actions/createActions.ts
@@ -92,33 +92,19 @@ export const createEntityThunkAsync = (appId: string, entity: EntityBase) => {
         const clClient = ClientFactory.getInstance(AT.CREATE_ENTITY_ASYNC)
 
         try {
-            let posEntity = await clClient.entitiesCreate(appId, entity);
-            
-            // If it's a negatable entity
-            if (posEntity.isNegatible) {
-                // Create negative entity with ref to positive entity
-                let negEntity = {
-                    ...entity, 
-                    entityName: `~${entity.entityName}`,
-                    positiveId: posEntity.entityId
-                }
-                // Remove pos entityId from negative entity
-                delete negEntity.entityId;
-
-                negEntity = await clClient.entitiesCreate(appId, negEntity);
-                dispatch(createEntityFulfilled(negEntity));
-
-                // Update positive entity with ref to negative entity
-                posEntity.negativeId = negEntity.entityId;
-                posEntity = await clClient.entitiesUpdate(appId, posEntity);
-            }
+            const posEntity = await clClient.entitiesCreate(appId, entity);
             dispatch(createEntityFulfilled(posEntity));
+
+            if (posEntity.negativeId) {
+                // Need to load negative entity in order to load it into memory
+                const negEntity = await clClient.entity(appId, posEntity.negativeId)
+                dispatch(createEntityFulfilled(negEntity));
+            }
+            
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId));
-            return true;
         } catch (e) {
             const error = e as Error
             dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.CREATE_ENTITY_ASYNC))
-            return false;
         }
     }
 }

--- a/src/actions/createActions.ts
+++ b/src/actions/createActions.ts
@@ -97,7 +97,7 @@ export const createEntityThunkAsync = (appId: string, entity: EntityBase) => {
 
             if (posEntity.negativeId) {
                 // Need to load negative entity in order to load it into memory
-                const negEntity = await clClient.entity(appId, posEntity.negativeId)
+                const negEntity = await clClient.entitiesGetById(appId, posEntity.negativeId)
                 dispatch(createEntityFulfilled(negEntity));
             }
             

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -171,6 +171,12 @@ export default class ClClient {
             .then(response => response.data)
     }
 
+    entity(appId: string, entityId: string): Promise<models.EntityBase> {
+        return this.send<models.EntityBase>({
+            url: `${this.baseUrl}/app/${appId}/entities/${entityId}`
+        }).then(response => response.data)
+    }
+
     entities(appId: string): Promise<models.EntityBase[]> {
         return this.send<models.EntityList>({
             url: `${this.baseUrl}/app/${appId}/entities`

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -171,9 +171,9 @@ export default class ClClient {
             .then(response => response.data)
     }
 
-    entity(appId: string, entityId: string): Promise<models.EntityBase> {
+    entitiesGetById(appId: string, entityId: string): Promise<models.EntityBase> {
         return this.send<models.EntityBase>({
-            url: `${this.baseUrl}/app/${appId}/entities/${entityId}`
+            url: `${this.baseUrl}/app/${appId}/entity/${entityId}`
         }).then(response => response.data)
     }
 
@@ -184,14 +184,16 @@ export default class ClClient {
     }
 
     entitiesCreate(appId: string, entity: models.EntityBase): Promise<models.EntityBase> {
-        return this.send<string>({
+        return this.send<models.ChangeEntityResponse>({
             method: 'post',
             url: `${this.baseUrl}/app/${appId}/entity`,
             data: entity
         }).then(response => {
-                entity.entityId = response.data
-                return entity
-            })
+            const changeEntityResponse = response.data
+            entity.entityId = changeEntityResponse.entityId
+            entity.negativeId = changeEntityResponse.negativeEntityId
+            return entity
+        })
     }
 
     entitiesDelete(appId: string, entityId: string): Promise<models.DeleteEditResponse> {


### PR DESCRIPTION
Previous this required 3 steps:
1. Create positive entity
2. Create negative entity using positive entity id
3. Update positive entity with negative entity id

Now we can do all of this with one call:
1. Create entity (if negatable is true, implicitly create negative entity as well)

We still have to fetch the negative entity since we need representation of it in memory though.