### PR TITLE
fix: delete entity in single call

### DIFF
--- a/src/actions/deleteActions.ts
+++ b/src/actions/deleteActions.ts
@@ -30,21 +30,14 @@ export const deleteApplicationFulfilled = (appId: string): ActionObject => {
 // ---------------------
 // Entity
 // ---------------------
-export const deleteEntityThunkAsync = (appId: string, entityId: string, reverseEntityId?: string) => {
+export const deleteEntityThunkAsync = (appId: string, entityId: string) => {
     return async (dispatch: Dispatch<any>) => {
         dispatch(deleteEntityAsync(appId, entityId))
         const clClient = ClientFactory.getInstance(AT.DELETE_ENTITY_ASYNC)
 
         try {
-            let deleteReverseResponse = null;
             const deleteEditResponse = await clClient.entitiesDelete(appId, entityId);
             dispatch(deleteEntityFulfilled(entityId));
-
-            // If it's a negatable entity
-            if (reverseEntityId) {
-                deleteReverseResponse = await clClient.entitiesDelete(appId, reverseEntityId);
-                dispatch(deleteEntityFulfilled(reverseEntityId));
-            }
 
             // If any actions were modified, reload them
             if (deleteEditResponse.actionIds && deleteEditResponse.actionIds.length > 0) {
@@ -52,8 +45,7 @@ export const deleteEntityThunkAsync = (appId: string, entityId: string, reverseE
             }
 
             // If any train dialogs were modified fetch train dialogs 
-            if ((deleteEditResponse.trainDialogIds && deleteEditResponse.trainDialogIds.length > 0) ||
-                (deleteReverseResponse && deleteReverseResponse.trainDialogIds && deleteReverseResponse.trainDialogIds.length > 0)) {
+            if (deleteEditResponse.trainDialogIds && deleteEditResponse.trainDialogIds.length > 0) {
                 dispatch(fetchAllTrainDialogsAsync(appId));
             }
 

--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -131,8 +131,7 @@ class Entities extends React.Component<Props, ComponentState> {
 
     @autobind
     handleDelete(entityId: string) {
-        let entityToDelete = this.props.entities.find(entity => entity.entityId === entityId)
-        this.props.deleteEntityThunkAsync(this.props.app.appId, entityId, entityToDelete.negativeId)
+        this.props.deleteEntityThunkAsync(this.props.app.appId, entityId)
         this.setState({
             createEditModalOpen: false
         })


### PR DESCRIPTION
I had fixed entity creation to be single call, but this will also address the delete.

Entities with associated negative entities will be created and deleted as pairs now.