### PR TITLE
fix: add placeholders for empty lists

### DIFF
--- a/src/routes/Apps/App/Actions.tsx
+++ b/src/routes/Apps/App/Actions.tsx
@@ -122,7 +122,8 @@ class Actions extends React.Component<Props, ComponentState> {
 
     render() {
         // TODO: Look to move this up to the set state calls instead of forcing it to be on every render
-        const actions = this.getFilteredActions();
+        const { actions } = this.props
+        const computedActions = this.getFilteredActions()
         return (
             <div className="cl-page">
                 <span className={OF.FontClassNames.xxLarge}>
@@ -156,15 +157,38 @@ class Actions extends React.Component<Props, ComponentState> {
                         componentRef={component => this.newActionButton = component}
                     />
                 </div>
-                <OF.SearchBox
-                    className={OF.FontClassNames.mediumPlus}
-                    onChange={searchString => this.onChangeSearchString(searchString)}
-                    onSearch={searchString => this.onChangeSearchString(searchString)}
-                />
-                <ActionDetailsList
-                    actions={actions}
-                    onSelectAction={this.onSelectAction}
-                />
+                {actions.length === 0
+                    ? <div className="cl-page-placeholder">
+                        <div className="cl-page-placeholder__content">
+                            <div className={`cl-page-placeholder__description ${OF.FontClassNames.xxLarge}`}>Create an Action</div>
+                            <OF.PrimaryButton
+                                iconProps={{
+                                    iconName: "Add"
+                                }}
+                                disabled={this.props.editingPackageId !== this.props.app.devPackageId}
+                                onClick={() => this.onClickOpenActionEditor()}
+                                ariaDescription={this.props.intl.formatMessage({
+                                    id: FM.ACTIONS_CREATEBUTTONARIADESCRIPTION,
+                                    defaultMessage: 'Create a New Action'
+                                })}
+                                text={this.props.intl.formatMessage({
+                                    id: FM.ACTIONS_CREATEBUTTONTITLE,
+                                    defaultMessage: 'New Action'
+                                })}
+                            />
+                        </div>
+                    </div>
+                    : <React.Fragment>
+                        <OF.SearchBox
+                            className={OF.FontClassNames.mediumPlus}
+                            onChange={searchString => this.onChangeSearchString(searchString)}
+                            onSearch={searchString => this.onChangeSearchString(searchString)}
+                        />
+                        <ActionDetailsList
+                            actions={computedActions}
+                            onSelectAction={this.onSelectAction}
+                        />
+                    </React.Fragment>}
 
                 <ActionCreatorEditor
                     app={this.props.app}

--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -219,7 +219,8 @@ class Entities extends React.Component<Props, ComponentState> {
         })
     }
     render() {
-        let entityItems = this.getFilteredAndSortedEntities()
+        const { entities } = this.props
+        const computedEntities = this.getFilteredAndSortedEntities()
 
         return (
             <div className="cl-page">
@@ -235,7 +236,7 @@ class Entities extends React.Component<Props, ComponentState> {
                             id={FM.ENTITIES_SUBTITLE}
                             defaultMessage="Entities hold values from the user or are set by code, and are stored in the bot's memory to track state"
                         />
-                    </span> 
+                    </span>
                     :
                     <span className="cl-errorpanel">Editing is only allowed in Master Tag</span>
                 }
@@ -254,33 +255,56 @@ class Entities extends React.Component<Props, ComponentState> {
                         })}
                         componentRef={component => this.newEntityButton = component}
                     />
-                    <EntityCreatorEditor
-                        app={this.props.app}
-                        editingPackageId={this.props.editingPackageId}
-                        open={this.state.createEditModalOpen}
-                        entity={this.state.entitySelected}
-                        handleClose={this.handleCloseCreateModal}
-                        handleDelete={this.handleDelete}
-                        entityTypeFilter={null}
-                    />
                 </div>
-                <OF.SearchBox
-                    className={OF.FontClassNames.mediumPlus}
-                    onChange={(newValue) => this.onChange(newValue)}
-                    onSearch={(newValue) => this.onChange(newValue)}
-                />
-                <OF.DetailsList
-                    className={OF.FontClassNames.mediumPlus}
-                    items={entityItems}
-                    columns={this.state.columns}
-                    checkboxVisibility={OF.CheckboxVisibility.hidden}
-                    onRenderItemColumn={(entity: EntityBase, i, column: IRenderableColumn) =>
-                        column.render(entity, this)}
-                    onRenderDetailsHeader={(detailsHeaderProps: OF.IDetailsHeaderProps,
-                        defaultRender: OF.IRenderFunction<OF.IDetailsHeaderProps>) =>
-                        onRenderDetailsHeader(detailsHeaderProps, defaultRender)}
-                    onColumnHeaderClick={this.onClickColumnHeader}
-                    onActiveItemChanged={entity => this.onSelectEntity(entity)}
+                {entities.length === 0
+                    ? <div className="cl-page-placeholder">
+                        <div className="cl-page-placeholder__content">
+                            <div className={`cl-page-placeholder__description ${OF.FontClassNames.xxLarge}`}>Create an Entity</div>
+                            <OF.PrimaryButton
+                                iconProps={{
+                                    iconName: "Add"
+                                }}
+                                disabled={this.props.editingPackageId !== this.props.app.devPackageId}
+                                onClick={this.handleOpenCreateModal}
+                                ariaDescription={this.props.intl.formatMessage({
+                                    id: FM.ENTITIES_CREATEBUTTONARIALDESCRIPTION,
+                                    defaultMessage: 'Create a New Entity'
+                                })}
+                                text={this.props.intl.formatMessage({
+                                    id: FM.ENTITIES_CREATEBUTTONTEXT,
+                                    defaultMessage: 'New Entity'
+                                })}
+                            />
+                        </div>
+                    </div>
+                    : <React.Fragment>
+                        <OF.SearchBox
+                            className={OF.FontClassNames.mediumPlus}
+                            onChange={(newValue) => this.onChange(newValue)}
+                            onSearch={(newValue) => this.onChange(newValue)}
+                        />
+                        <OF.DetailsList
+                            className={OF.FontClassNames.mediumPlus}
+                            items={computedEntities}
+                            columns={this.state.columns}
+                            checkboxVisibility={OF.CheckboxVisibility.hidden}
+                            onRenderItemColumn={(entity: EntityBase, i, column: IRenderableColumn) =>
+                                column.render(entity, this)}
+                            onRenderDetailsHeader={(detailsHeaderProps: OF.IDetailsHeaderProps,
+                                defaultRender: OF.IRenderFunction<OF.IDetailsHeaderProps>) =>
+                                onRenderDetailsHeader(detailsHeaderProps, defaultRender)}
+                            onColumnHeaderClick={this.onClickColumnHeader}
+                            onActiveItemChanged={entity => this.onSelectEntity(entity)}
+                        />
+                    </React.Fragment>}
+                <EntityCreatorEditor
+                    app={this.props.app}
+                    editingPackageId={this.props.editingPackageId}
+                    open={this.state.createEditModalOpen}
+                    entity={this.state.entitySelected}
+                    handleClose={this.handleCloseCreateModal}
+                    handleDelete={this.handleDelete}
+                    entityTypeFilter={null}
                 />
             </div>
         );

--- a/src/routes/Apps/App/Index.css
+++ b/src/routes/Apps/App/Index.css
@@ -46,3 +46,15 @@
     margin-top: 3px;
 }
 
+.cl-page-placeholder {
+    min-height: 20em;
+    display: grid;
+    justify-content: center;
+    align-content: center;
+    text-align: center;
+}
+
+.cl-page-placeholder__description {
+    margin-bottom: 1em;
+}
+

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -10,10 +10,11 @@ import * as OF from 'office-ui-fabric-react';
 import { State } from '../../../types'
 import { AppBase, LogDialog, Session, ModelUtils, Teach, TeachWithHistory, TrainDialog, ActionBase, ReplayError, UIScoreInput } from '@conversationlearner/models'
 import { ChatSessionModal, LogDialogModal, TeachSessionModal } from '../../../components/modals'
-import { 
-    createChatSessionThunkAsync, 
+import {
+    createChatSessionThunkAsync,
     createTeachSessionFromHistoryThunkAsync,
-    createTeachSessionFromUndoThunkAsync } from '../../../actions/createActions'
+    createTeachSessionFromUndoThunkAsync
+} from '../../../actions/createActions'
 import { deleteLogDialogThunkAsync } from '../../../actions/deleteActions';
 import { fetchAllLogDialogsAsync, fetchHistoryThunkAsync } from '../../../actions/fetchActions';
 import { setErrorDisplay } from '../../../actions/displayActions';
@@ -51,8 +52,7 @@ function getTagName(logDialog: LogDialog, component: LogDialogs): string {
     if (logDialog.packageId === component.props.app.devPackageId) {
         tagName = 'Master';
     }
-    else 
-    {
+    else {
         let packageVersion = component.props.app.packageVersions.find(pv => pv.packageId === logDialog.packageId);
         if (packageVersion) {
             tagName = packageVersion.packageVersion;
@@ -144,7 +144,7 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             render: logDialog => {
                 let lastInput = getLastInput(logDialog)
                 if (lastInput) {
-                     return <span className={OF.FontClassNames.mediumPlus}>{lastInput}</span>;
+                    return <span className={OF.FontClassNames.mediumPlus}>{lastInput}</span>;
                 }
                 return <OF.Icon iconName="Remove" className="notFoundIcon" />
             },
@@ -205,14 +205,14 @@ interface ComponentState {
     lastAction: ActionBase,
     teachSession: Teach,
     validationErrors: ReplayError[],
-    validationErrorTitleId: string | null, 
+    validationErrorTitleId: string | null,
     validationErrorMessageId: string | null,
 }
 
 class LogDialogs extends React.Component<Props, ComponentState> {
     newChatSessionButton: OF.IButton
     state: ComponentState
-    
+
     constructor(props: Props) {
         super(props)
         let columns = getColumns(this.props.intl);
@@ -244,7 +244,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                     let firstValue = this.state.sortColumn.getSortValue(a, this)
                     let secondValue = this.state.sortColumn.getSortValue(b, this)
                     let compareValue = firstValue.localeCompare(secondValue)
-    
+
                     // If primary sort is the same do secondary sort on another column, to prevent sort jumping around
                     if (compareValue === 0) {
                         let sortColumn2 = ((this.state.sortColumn !== this.state.columns[1]) ? this.state.columns[1] : this.state.columns[2]) as IRenderableColumn
@@ -327,26 +327,26 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     onClickLogDialogItem(logDialog: LogDialog) {
-        
+
         // Convert to trainDialog until schema update change, and pass in app definition too
         let trainDialog = ModelUtils.ToTrainDialog(logDialog, this.props.actions, this.props.entities);
 
         ((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialog, this.props.user.name, this.props.user.id) as any) as Promise<TeachWithHistory>)
-        .then(teachWithHistory => {
-            this.setState({
-                history: teachWithHistory.history,
-                lastAction: teachWithHistory.lastAction,
-                currentLogDialog: logDialog,
-                isLogDialogWindowOpen: true,
-                validationErrors: teachWithHistory.replayErrors,
-                isValidationWarningOpen: teachWithHistory.replayErrors.length > 0,
-                validationErrorTitleId: FM.REPLAYERROR_LOGDIALOG_VALIDATION_TITLE,
-                validationErrorMessageId: FM.REPLAYERROR_LOGDIALOG_VALIDATION_MESSAGE
+            .then(teachWithHistory => {
+                this.setState({
+                    history: teachWithHistory.history,
+                    lastAction: teachWithHistory.lastAction,
+                    currentLogDialog: logDialog,
+                    isLogDialogWindowOpen: true,
+                    validationErrors: teachWithHistory.replayErrors,
+                    isValidationWarningOpen: teachWithHistory.replayErrors.length > 0,
+                    validationErrorTitleId: FM.REPLAYERROR_LOGDIALOG_VALIDATION_TITLE,
+                    validationErrorMessageId: FM.REPLAYERROR_LOGDIALOG_VALIDATION_MESSAGE
+                })
             })
-        })
-        .catch(error => {
-            console.warn(`Error when attempting to create history: `, error)
-        })
+            .catch(error => {
+                console.warn(`Error when attempting to create history: `, error)
+            })
     }
 
     @autobind
@@ -363,7 +363,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     @autobind
-    onDeleteLogDialog() {      
+    onDeleteLogDialog() {
         if (this.state.currentLogDialog) {
             this.props.deleteLogDialogThunkAsync(this.props.user.id, this.props.app, this.state.currentLogDialog.logDialogId, this.props.editingPackageId)
         }
@@ -371,32 +371,32 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     onEditLogDialog(logDialogId: string, newTrainDialog: TrainDialog, newScoreInput: UIScoreInput) {
-        
+
         // Create a new teach session from the train dialog
         ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, newScoreInput) as any) as Promise<TeachWithHistory>)
-        .then(teachWithHistory => {
-            if (teachWithHistory.replayErrors.length === 0) {
-                // Note: Don't clear currentLogDialog so I can update it if I save my edits
-                this.setState({
-                    teachSession: teachWithHistory.teach, 
-                    history: teachWithHistory.history,
-                    lastAction: teachWithHistory.lastAction,
-                    isLogDialogWindowOpen: false,
-                    isTeachDialogModalOpen: true
-                })
-            }
-            else {
-                this.setState({
-                    validationErrors: teachWithHistory.replayErrors,
-                    isValidationWarningOpen: true,
-                    validationErrorTitleId: FM.REPLAYERROR_CONVERT_TITLE,
-                    validationErrorMessageId: FM.REPLAYERROR_FAILMESSAGE
-                })
-            }
-        })
-        .catch(error => {
-            console.warn(`Error when attempting to create teach session from log dialog: `, error)
-        })
+            .then(teachWithHistory => {
+                if (teachWithHistory.replayErrors.length === 0) {
+                    // Note: Don't clear currentLogDialog so I can update it if I save my edits
+                    this.setState({
+                        teachSession: teachWithHistory.teach,
+                        history: teachWithHistory.history,
+                        lastAction: teachWithHistory.lastAction,
+                        isLogDialogWindowOpen: false,
+                        isTeachDialogModalOpen: true
+                    })
+                }
+                else {
+                    this.setState({
+                        validationErrors: teachWithHistory.replayErrors,
+                        isValidationWarningOpen: true,
+                        validationErrorTitleId: FM.REPLAYERROR_CONVERT_TITLE,
+                        validationErrorMessageId: FM.REPLAYERROR_FAILMESSAGE
+                    })
+                }
+            })
+            .catch(error => {
+                console.warn(`Error when attempting to create teach session from log dialog: `, error)
+            })
     }
 
     @autobind
@@ -426,28 +426,28 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         });
 
         ((this.props.createTeachSessionFromUndoThunkAsync(this.props.app.appId, this.state.teachSession, popRound, this.props.user.name, this.props.user.id) as any) as Promise<TeachWithHistory>)
-        .then(teachWithHistory => {
-            if (teachWithHistory.replayErrors.length === 0) {
-                this.setState({
-                    teachSession: teachWithHistory.teach, 
-                    history: teachWithHistory.history,
-                    lastAction: teachWithHistory.lastAction
-                })
-            } else {    
-                this.setState({
-                    validationErrors: teachWithHistory.replayErrors,
-                    isValidationWarningOpen: true,
-                    validationErrorTitleId: FM.REPLAYERROR_UNDO_TITLE,
-                    validationErrorMessageId: FM.REPLAYERROR_FAILMESSAGE
-                })
-            }
-        })
-        .catch(error => {
-            console.warn(`Error when attempting to create teach session from undo: `, error)
-        })
+            .then(teachWithHistory => {
+                if (teachWithHistory.replayErrors.length === 0) {
+                    this.setState({
+                        teachSession: teachWithHistory.teach,
+                        history: teachWithHistory.history,
+                        lastAction: teachWithHistory.lastAction
+                    })
+                } else {
+                    this.setState({
+                        validationErrors: teachWithHistory.replayErrors,
+                        isValidationWarningOpen: true,
+                        validationErrorTitleId: FM.REPLAYERROR_UNDO_TITLE,
+                        validationErrorMessageId: FM.REPLAYERROR_FAILMESSAGE
+                    })
+                }
+            })
+            .catch(error => {
+                console.warn(`Error when attempting to create teach session from undo: `, error)
+            })
     }
 
-    renderLogDialogItems(): LogDialog[] {
+    getFilteredAndSortedDialogs(): LogDialog[] {
         // Don't show log dialogs that have derived TrainDialogs as they've already been edited
         let filteredLogDialogs: LogDialog[] = this.props.logDialogs.filter(l => !l.targetTrainDialogIds || l.targetTrainDialogIds.length === 0);
 
@@ -474,11 +474,12 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     render() {
-        let logDialogItems = this.renderLogDialogItems()
+        const { logDialogs } = this.props
+        const computedLogDialogs = this.getFilteredAndSortedDialogs()
         const currentLogDialog = this.state.currentLogDialog;
         return (
             <div className="cl-page">
-                <div data-testid= "logdialogs-title" className={`cl-dialog-title cl-dialog-title--log ${OF.FontClassNames.xxLarge}`}>
+                <div data-testid="logdialogs-title" className={`cl-dialog-title cl-dialog-title--log ${OF.FontClassNames.xxLarge}`}>
                     <OF.Icon iconName="UserFollowed" />
                     <FormattedMessage
                         id={FM.LOGDIALOGS_TITLE}
@@ -495,7 +496,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                     :
                     <span className="cl-errorpanel">Editing is only allowed in Master Tag</span>
                 }
-                {this.props.app.metadata.isLoggingOn === false && 
+                {this.props.app.metadata.isLoggingOn === false &&
                     <span className="ms-TextField-errorMessage label-error">
                         <FormattedMessage
                             id={FM.LOGDIALOGS_LOGDISABLED}
@@ -506,7 +507,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                 <div>
                     <OF.PrimaryButton
                         data-testid="logdialogs-button-create"
-                        disabled={this.props.editingPackageId !== this.props.app.devPackageId || this.props.invalidBot}                      
+                        disabled={this.props.editingPackageId !== this.props.app.devPackageId || this.props.invalidBot}
                         onClick={this.onClickNewChatSession}
                         ariaDescription={this.props.intl.formatMessage({
                             id: FM.LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION,
@@ -518,38 +519,61 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                         })}
                         componentRef={component => this.newChatSessionButton = component}
                     />
-                    <ChatSessionModal
-                        app={this.props.app}
-                        editingPackageId={this.props.editingPackageId}
-                        open={this.state.isChatSessionWindowOpen}
-                        onClose={this.onCloseChatSessionWindow}
-                    />
                 </div>
-                <OF.SearchBox
-                    data-testid="logdialogs-search-box"
-                    className={OF.FontClassNames.mediumPlus}
-                    onChange={(newValue) => this.onChange(newValue)}
-                    onSearch={(newValue) => this.onChange(newValue)}
-                />
-                <div>
-                    <OF.PrimaryButton
-                        data-testid="logdialogs-button-refresh"
-                        onClick={() => this.onClickSync()}
-                        ariaDescription="Refresh"
-                        text="Refresh"
-                        iconProps={{ iconName: 'Sync' }}
-                    />
-                </div>
-                <OF.DetailsList
-                    data-testid="logdialogs-details-list"
-                    key={this.state.dialogKey}
-                    className={OF.FontClassNames.mediumPlus}
-                    items={logDialogItems}
-                    columns={this.state.columns}
-                    checkboxVisibility={OF.CheckboxVisibility.hidden}
-                    onColumnHeaderClick={this.onClickColumnHeader}
-                    onRenderItemColumn={(logDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(logDialog, this))}
-                    onActiveItemChanged={logDialog => this.onClickLogDialogItem(logDialog)}
+                {logDialogs.length === 0
+                    ? <div className="cl-page-placeholder">
+                        <div className="cl-page-placeholder__content">
+                            <div className={`cl-page-placeholder__description ${OF.FontClassNames.xxLarge}`}>Create a Log Dialog</div>
+                            <OF.PrimaryButton
+                                iconProps={{
+                                    iconName: "Add"
+                                }}
+                                disabled={this.props.editingPackageId !== this.props.app.devPackageId || this.props.invalidBot}
+                                onClick={this.onClickNewChatSession}
+                                ariaDescription={this.props.intl.formatMessage({
+                                    id: FM.LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION,
+                                    defaultMessage: 'Create a New Log Dialog'
+                                })}
+                                text={this.props.intl.formatMessage({
+                                    id: FM.LOGDIALOGS_CREATEBUTTONTITLE,
+                                    defaultMessage: 'New Log Dialog'
+                                })}
+                            />
+                        </div>
+                    </div>
+                    : <React.Fragment>
+                        <OF.SearchBox
+                            data-testid="logdialogs-search-box"
+                            className={OF.FontClassNames.mediumPlus}
+                            onChange={(newValue) => this.onChange(newValue)}
+                            onSearch={(newValue) => this.onChange(newValue)}
+                        />
+                        <div>
+                            <OF.PrimaryButton
+                                data-testid="logdialogs-button-refresh"
+                                onClick={() => this.onClickSync()}
+                                ariaDescription="Refresh"
+                                text="Refresh"
+                                iconProps={{ iconName: 'Sync' }}
+                            />
+                        </div>
+                        <OF.DetailsList
+                            data-testid="logdialogs-details-list"
+                            key={this.state.dialogKey}
+                            className={OF.FontClassNames.mediumPlus}
+                            items={computedLogDialogs}
+                            columns={this.state.columns}
+                            checkboxVisibility={OF.CheckboxVisibility.hidden}
+                            onColumnHeaderClick={this.onClickColumnHeader}
+                            onRenderItemColumn={(logDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(logDialog, this))}
+                            onActiveItemChanged={logDialog => this.onClickLogDialogItem(logDialog)}
+                        />
+                    </React.Fragment>}
+                <ChatSessionModal
+                    app={this.props.app}
+                    editingPackageId={this.props.editingPackageId}
+                    open={this.state.isChatSessionWindowOpen}
+                    onClose={this.onCloseChatSessionWindow}
                 />
                 <LogDialogModal
                     app={this.props.app}
@@ -562,7 +586,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                     logDialog={currentLogDialog}
                     history={this.state.isLogDialogWindowOpen ? this.state.history : null}
                 />
-                <ReplayErrorList  
+                <ReplayErrorList
                     open={this.state.isValidationWarningOpen}
                     onClose={this.onCloseValidationWarning}
                     textItems={this.state.validationErrors}
@@ -570,16 +594,16 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                     formattedMessageId={this.state.validationErrorMessageId}
                 />
                 <TeachSessionModal
-                        app={this.props.app}
-                        editingPackageId={this.props.editingPackageId}
-                        teach={this.props.teachSessions.current}
-                        dialogMode={this.props.teachSessions.mode}
-                        isOpen={this.state.isTeachDialogModalOpen}
-                        onClose={this.onCloseTeachSession} 
-                        onUndo={(popRound) => this.onUndoTeachStep(popRound)}
-                        history={this.state.isTeachDialogModalOpen ? this.state.history : null}
-                        lastAction={this.state.lastAction}
-                        sourceLogDialog={this.state.currentLogDialog}
+                    app={this.props.app}
+                    editingPackageId={this.props.editingPackageId}
+                    teach={this.props.teachSessions.current}
+                    dialogMode={this.props.teachSessions.mode}
+                    isOpen={this.state.isTeachDialogModalOpen}
+                    onClose={this.onCloseTeachSession}
+                    onUndo={(popRound) => this.onUndoTeachStep(popRound)}
+                    history={this.state.isTeachDialogModalOpen ? this.state.history : null}
+                    lastAction={this.state.lastAction}
+                    sourceLogDialog={this.state.currentLogDialog}
                 />
             </div>
         );

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -52,14 +52,14 @@ function textClassName(trainDialog: TrainDialog): string {
     return OF.FontClassNames.mediumPlus;
 }
 
-function getFirstInput(trainDialog: TrainDialog) : string {
+function getFirstInput(trainDialog: TrainDialog): string {
     if (trainDialog.rounds && trainDialog.rounds.length > 0) {
         return trainDialog.rounds[0].extractorStep.textVariations[0].text
     }
     return null;
 }
 
-function getLastInput(trainDialog: TrainDialog) : string {
+function getLastInput(trainDialog: TrainDialog): string {
     if (trainDialog.rounds && trainDialog.rounds.length > 0) {
         return trainDialog.rounds[trainDialog.rounds.length - 1].extractorStep.textVariations[0].text;
     }
@@ -76,7 +76,7 @@ function getLastResponse(trainDialog: TrainDialog, component: TrainDialogs): str
             let action = component.props.actions.find(a => a.actionId === actionId);
             if (action) {
                 return ActionBase.GetPayload(action, getDefaultEntityMap(component.props.entities))
-            } 
+            }
         }
     }
     return null;
@@ -99,9 +99,9 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                 let firstInput = getFirstInput(trainDialog);
                 if (firstInput) {
                     return (<span className={textClassName(trainDialog)}>
-                            {trainDialog.invalid === true && <Icon className="cl-icon" iconName="IncidentTriangle" />}
-                            {firstInput}
-                        </span>)
+                        {trainDialog.invalid === true && <Icon className="cl-icon" iconName="IncidentTriangle" />}
+                        {firstInput}
+                    </span>)
                 }
                 return <OF.Icon iconName="Remove" className="notFoundIcon" />
             },
@@ -220,8 +220,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     sortTrainDialogs(trainDialogs: TrainDialog[]): TrainDialog[] {
-
-        // If column header selected sort the items, always putting invald at the top
+        // If column header selected sort the items, always putting invalid at the top
         if (this.state.sortColumn) {
             trainDialogs
                 .sort((a, b) => {
@@ -273,14 +272,14 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     toActionFilter(action: ActionBase, entities: EntityBase[]): OF.IDropdownOption {
-        return { 
+        return {
             key: action.actionId,
             text: ActionBase.GetPayload(action, getDefaultEntityMap(entities))
         }
     }
-     
+
     toEntityFilter(entity: EntityBase): OF.IDropdownOption {
-        return { 
+        return {
             key: entity.entityId,
             text: entity.entityName,
             data: entity.negativeId
@@ -530,10 +529,10 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         })
     }
 
-    renderTrainDialogItems(): TrainDialog[] {
-        let filteredTrainDialogs : TrainDialog[] = null;
+    getFilteredAndSortedDialogs(): TrainDialog[] {
+        let filteredTrainDialogs: TrainDialog[] = null;
 
-        if (!this.state.searchValue && ! this.state.entityFilter && !this.state.actionFilter) {
+        if (!this.state.searchValue && !this.state.entityFilter && !this.state.actionFilter) {
             filteredTrainDialogs = this.props.trainDialogs;
         } else {
             // TODO: Consider caching as not very efficient
@@ -569,8 +568,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
                 // Filter out train dialogs that don't match filters (data = negativeId for multivalue)
                 if (this.state.entityFilter && this.state.entityFilter.key
-                        && !entitiesInTD.find(en => en.entityId === this.state.entityFilter.key)
-                        && !entitiesInTD.find(en => en.entityId === this.state.entityFilter.data)) {
+                    && !entitiesInTD.find(en => en.entityId === this.state.entityFilter.key)
+                    && !entitiesInTD.find(en => en.entityId === this.state.entityFilter.data)) {
                     return false;
                 }
                 if (this.state.actionFilter && this.state.actionFilter.key
@@ -592,9 +591,9 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     render() {
-        const { intl } = this.props
-        let trainDialogItems = this.renderTrainDialogItems()
-        let currentTrainDialog = this.state.currentTrainDialog
+        const { intl, trainDialogs } = this.props
+        const computedTrainDialogs = this.getFilteredAndSortedDialogs()
+        const currentTrainDialog = this.state.currentTrainDialog
         return (
             <div className="cl-page">
                 <div data-testid="train-dialogs-title" className={`cl-dialog-title cl-dialog-title--train ${OF.FontClassNames.xxLarge}`}>
@@ -629,75 +628,99 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                         })}
                         componentRef={component => this.newTeachSessionButton = component}
                     />
-                    <ReplayErrorList  
-                        open={this.state.isValidationWarningOpen}
-                        onClose={this.onCloseValidationWarning}
-                        textItems={this.state.validationErrors}
-                        formattedTitleId={this.state.validationErrorTitleId}
-                        formattedMessageId={this.state.validationErrorMessageId}
-                    />
-                    <TeachSessionModal
-                        app={this.props.app}
-                        editingPackageId={this.props.editingPackageId}
-                        teach={this.props.teachSessions.current}
-                        dialogMode={this.props.teachSessions.mode}
-                        isOpen={this.state.isTeachDialogModalOpen}
-                        onClose={() => this.onCloseTeachSession()}
-                        onUndo={(popRound) => this.onUndoTeachStep(popRound)}
-                        history={this.state.isTeachDialogModalOpen ? this.state.history : null}
-                        lastAction={this.state.lastAction}
-                        sourceTrainDialog={this.state.currentTrainDialog}
-                    />
                 </div>
-                <div>
-                    <OF.Label htmlFor="search" className={OF.FontClassNames.medium}>
-                        Search:
-                    </OF.Label>
-                    <OF.SearchBox
-                        data-testid="search-box"
-                        id="search"
-                        className={OF.FontClassNames.medium}
-                        onChange={(newValue) => this.onChangeSearchString(newValue)}
-                        onSearch={(newValue) => this.onChangeSearchString(newValue)}
-                    />
-                </div>
-                <div className="cl-list-filters">
-                    <OF.Dropdown
-                        data-testid="dropdown-filter-by-entity"
-                        label="Entity:"
-                        selectedKey={(this.state.entityFilter ? this.state.entityFilter.key : undefined)}
-                        onChanged={this.onSelectEntityFilter}
-                        placeHolder="Filter by Entity"
-                        options={this.props.entities
-                            // Only show positive versions of negatable entities
-                            .filter(e => e.positiveId == null)
-                            .map(e => this.toEntityFilter(e))
-                            .concat({key: null, text: '---', data: null})
-                        }
-                    /> 
-        
-                    <OF.Dropdown
-                        data-testid="dropdown-filter-by-action"
-                        label="Action:"
-                        selectedKey={(this.state.actionFilter ? this.state.actionFilter.key : undefined)}
-                        onChanged={this.onSelectActionFilter}
-                        placeHolder="Filter by Action"
-                        options={this.props.actions
-                            .map(a => this.toActionFilter(a, this.props.entities))
-                            .concat({key: null, text: '---'})
-                        }
-                    />
-                </div>
-                <OF.DetailsList
-                    data-testid="detail-list"
-                    key={this.state.dialogKey}
-                    className={OF.FontClassNames.mediumPlus}
-                    items={trainDialogItems}
-                    columns={this.state.columns}
-                    checkboxVisibility={OF.CheckboxVisibility.hidden}
-                    onColumnHeaderClick={this.onClickColumnHeader}
-                    onRenderItemColumn={(trainDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(trainDialog, this))}
-                    onActiveItemChanged={trainDialog => this.onClickTrainDialogItem(trainDialog)}
+
+                {trainDialogs.length === 0
+                    ? <div className="cl-page-placeholder">
+                        <div className="cl-page-placeholder__content">
+                            <div className={`cl-page-placeholder__description ${OF.FontClassNames.xxLarge}`}>Create a Train Dialog</div>
+                            <OF.PrimaryButton
+                                iconProps={{
+                                    iconName: "Add"
+                                }}
+                                disabled={this.props.editingPackageId !== this.props.app.devPackageId || this.props.invalidBot}
+                                onClick={() => this.onClickNewTeachSession()}
+                                ariaDescription={intl.formatMessage({
+                                    id: FM.TRAINDIALOGS_CREATEBUTTONARIALDESCRIPTION,
+                                    defaultMessage: 'Create a New Train Dialog'
+                                })}
+                                text={intl.formatMessage({
+                                    id: FM.TRAINDIALOGS_CREATEBUTTONTITLE,
+                                    defaultMessage: 'New Train Dialog'
+                                })}
+                            />
+                        </div>
+                    </div>
+                    : <React.Fragment>
+                        <div>
+                            <OF.Label htmlFor="search" className={OF.FontClassNames.medium}>
+                                Search:
+                            </OF.Label>
+                            <OF.SearchBox
+                                data-testid="search-box"
+                                id="search"
+                                className={OF.FontClassNames.medium}
+                                onChange={(newValue) => this.onChangeSearchString(newValue)}
+                                onSearch={(newValue) => this.onChangeSearchString(newValue)}
+                            />
+                        </div>
+                        <div className="cl-list-filters">
+                            <OF.Dropdown
+                                data-testid="dropdown-filter-by-entity"
+                                label="Entity:"
+                                selectedKey={(this.state.entityFilter ? this.state.entityFilter.key : undefined)}
+                                onChanged={this.onSelectEntityFilter}
+                                placeHolder="Filter by Entity"
+                                options={this.props.entities
+                                    // Only show positive versions of negatable entities
+                                    .filter(e => e.positiveId == null)
+                                    .map(e => this.toEntityFilter(e))
+                                    .concat({ key: null, text: '---', data: null })
+                                }
+                            />
+
+                            <OF.Dropdown
+                                data-testid="dropdown-filter-by-action"
+                                label="Action:"
+                                selectedKey={(this.state.actionFilter ? this.state.actionFilter.key : undefined)}
+                                onChanged={this.onSelectActionFilter}
+                                placeHolder="Filter by Action"
+                                options={this.props.actions
+                                    .map(a => this.toActionFilter(a, this.props.entities))
+                                    .concat({ key: null, text: '---' })
+                                }
+                            />
+                        </div>
+                        <OF.DetailsList
+                            data-testid="detail-list"
+                            key={this.state.dialogKey}
+                            className={OF.FontClassNames.mediumPlus}
+                            items={computedTrainDialogs}
+                            columns={this.state.columns}
+                            checkboxVisibility={OF.CheckboxVisibility.hidden}
+                            onColumnHeaderClick={this.onClickColumnHeader}
+                            onRenderItemColumn={(trainDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(trainDialog, this))}
+                            onActiveItemChanged={trainDialog => this.onClickTrainDialogItem(trainDialog)}
+                        />
+                    </React.Fragment>}
+                <ReplayErrorList
+                    open={this.state.isValidationWarningOpen}
+                    onClose={this.onCloseValidationWarning}
+                    textItems={this.state.validationErrors}
+                    formattedTitleId={this.state.validationErrorTitleId}
+                    formattedMessageId={this.state.validationErrorMessageId}
+                />
+                <TeachSessionModal
+                    app={this.props.app}
+                    editingPackageId={this.props.editingPackageId}
+                    teach={this.props.teachSessions.current}
+                    dialogMode={this.props.teachSessions.mode}
+                    isOpen={this.state.isTeachDialogModalOpen}
+                    onClose={() => this.onCloseTeachSession()}
+                    onUndo={(popRound) => this.onUndoTeachStep(popRound)}
+                    history={this.state.isTeachDialogModalOpen ? this.state.history : null}
+                    lastAction={this.state.lastAction}
+                    sourceTrainDialog={this.state.currentTrainDialog}
                 />
                 <TrainDialogModal
                     data-testid="train-dialog-modal"


### PR DESCRIPTION
Not as clean as I had thought it would be.

- Originally wanted to add some gifs explaining each item, but gif was only really help for entities.
There isn't easy way to distinguish between a dialog. What really matters is the source of content and role developer plays and that would need a custom graphic.

- I also was going to remove the redundant "new" buttons, but the other "new" buttons have the component reference that sets focus on every re-fresh and removing it was going to increase complexity

Fixes VSTS#916