### PR TITLE
test: adding wait vs non wait actions test

### DIFF
--- a/cypress/integration/create_app.ts
+++ b/cypress/integration/create_app.ts
@@ -54,7 +54,7 @@ describe('Create application', function () {
       .type(newEntityName)
 
     // Select multi-value
-    cy.get('[data-testid="entity-creator-input-multivalue"]')
+    cy.get('[data-testid="entitycreator-checkbox-multivalued"]')
       .click()
 
     cy.route('POST', '/app/*/entity').as('postEntity')

--- a/cypress/integration/waitvsnonwait_actions_test.ts
+++ b/cypress/integration/waitvsnonwait_actions_test.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+* Copyright (c) Microsoft Corporation. All rights reserved.  
  * Licensed under the MIT License.
- */
+*/
 const { convLearnerPage,
   modelpage,
   entity,
@@ -15,10 +15,10 @@ const { convLearnerPage,
   logDialogModal,
   testLog } = components();
 
- /**
- * Wait action: After the system takes a "wait" action, it will stop taking actions and wait for user input.
- * Non-wait action: After the system takes a "non-wait" action, it will immediately choose another action (without waiting for user input)
- */
+/**
+* Wait action: After the system takes a "wait" action, it will stop taking actions and wait for user input.
+* Non-wait action: After the system takes a "non-wait" action, it will immediately choose another action (without waiting for user input)
+*/
 describe('Wait vs No Wait Action e2e test', function () {
   const postfix = Cypress.moment().format("MMMDD-HHmm")
   const modelName = `e2e-waitvsnowait-${postfix}`
@@ -62,9 +62,6 @@ describe('Wait vs No Wait Action e2e test', function () {
     actionsModal.selectTypeText();
     actionsModal.setPhrase(action01); //"Which animal would you like?"
     actionsModal.clickCreateButton();
-    // Verify that the action has been added
-    cy.get('.ms-DetailsRow-cell')
-      .should('contain', action01)
 
     // No Wait Actions:
     actions.createNew();
@@ -72,10 +69,6 @@ describe('Wait vs No Wait Action e2e test', function () {
     actionsModal.setPhrase(action02); //"Cows say moo!!"
     actionsModal.clickWaitForResponse(); // Unselect
     actionsModal.clickCreateButton();
-
-    // Verify that the action has been added
-    cy.get('.ms-DetailsRow-cell')
-      .should('contain', action02)
 
     actions.createNew();
     actionsModal.selectTypeText();
@@ -85,7 +78,9 @@ describe('Wait vs No Wait Action e2e test', function () {
 
     // Verify that the action has been added
     cy.get('.ms-DetailsRow-cell')
-      .should('contain', action03)
+      .should('contain', action01)
+      .and('contain', action02)
+      .and('contain', action03)
   })
 
   /** FEATURE: New Train Dialog - using different types of Actions*/

--- a/cypress/integration/waitvsnonwait_actions_test.ts
+++ b/cypress/integration/waitvsnonwait_actions_test.ts
@@ -59,16 +59,19 @@ describe('Wait vs No Wait Action e2e test', function () {
 
     // Wait Action:
     actions.createNew();
+    actionsModal.selectTypeText();
     actionsModal.setPhrase(action01); //"Which animal would you like?"
     actionsModal.clickCreateButton();
 
     // No Wait Actions:
     actions.createNew();
+    actionsModal.selectTypeText();
     actionsModal.setPhrase(action02); //"Cows say moo!!"
     actionsModal.clickWaitForResponse(); // Unselect
     actionsModal.clickCreateButton();
 
     actions.createNew();
+    actionsModal.selectTypeText();
     actionsModal.setPhrase(action03); //"Ducks say quack";
     actionsModal.clickWaitForResponse(); // Unselect
     actionsModal.clickCreateButton();

--- a/cypress/integration/waitvsnonwait_actions_test.ts
+++ b/cypress/integration/waitvsnonwait_actions_test.ts
@@ -62,6 +62,9 @@ describe('Wait vs No Wait Action e2e test', function () {
     actionsModal.selectTypeText();
     actionsModal.setPhrase(action01); //"Which animal would you like?"
     actionsModal.clickCreateButton();
+    // Verify that the action has been added
+    cy.get('.ms-DetailsRow-cell')
+      .should('contain', action01)
 
     // No Wait Actions:
     actions.createNew();
@@ -69,6 +72,10 @@ describe('Wait vs No Wait Action e2e test', function () {
     actionsModal.setPhrase(action02); //"Cows say moo!!"
     actionsModal.clickWaitForResponse(); // Unselect
     actionsModal.clickCreateButton();
+
+    // Verify that the action has been added
+    cy.get('.ms-DetailsRow-cell')
+      .should('contain', action02)
 
     actions.createNew();
     actionsModal.selectTypeText();
@@ -78,7 +85,7 @@ describe('Wait vs No Wait Action e2e test', function () {
 
     // Verify that the action has been added
     cy.get('.ms-DetailsRow-cell')
-      .should('contain', action01)
+      .should('contain', action03)
   })
 
   /** FEATURE: New Train Dialog - using different types of Actions*/

--- a/cypress/support/components/actionsmodal.js
+++ b/cypress/support/components/actionsmodal.js
@@ -6,18 +6,22 @@
 /** Selects Action Type = Text */
 function selectTypeText() {
   cy.get('[data-testid="dropdown-action-type"]')
+    .should("be.visible")
     .click()
     .click();
   // TODO: implement a more robust way to select an specific action type.
 }
+
 /** Enter action response phrase */
 function setPhrase(actionPhrase) {
   cy.get('div[data-slate-editor="true"]')
+    .should("be.visible")
     .type(actionPhrase);
 }
 
 function clickWaitForResponse() {
   cy.get('.ms-Checkbox-text')
+    .should("be.visible")
     .click({ force: true });
 }
 
@@ -28,6 +32,7 @@ function clickCreateButton() {
   cy.route('POST', '/app/*/action').as('postAction')
 
   cy.get('[data-testid="actioncreator-button-create"]')
+    .should("be.visible")
     .click({ force: true });
   cy.wait('@postAction');
 }

--- a/cypress/support/components/actionsmodal.js
+++ b/cypress/support/components/actionsmodal.js
@@ -18,13 +18,18 @@ function setPhrase(actionPhrase) {
 
 function clickWaitForResponse() {
   cy.get('.ms-Checkbox-text')
-    .click({force: true});
+    .click({ force: true });
 }
 
 /** Click on create action button */
 function clickCreateButton() {
+  //app/624ade4a-6631-4a72-95fc-06135ce2c8fa/action
+  cy.server()
+  cy.route('POST', '/app/*/action').as('postAction')
+
   cy.get('[data-testid="actioncreator-button-create"]')
-    .click({force: true});
+    .click({ force: true });
+  cy.wait('@postAction');
 }
 
 export { clickWaitForResponse, selectTypeText, setPhrase, clickCreateButton };

--- a/cypress/support/components/actionsmodal.js
+++ b/cypress/support/components/actionsmodal.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
- * Licensed under the MIT License.
- */
 
 /** Selects Action Type = Text */
 function selectTypeText() {
@@ -22,19 +18,28 @@ function setPhrase(actionPhrase) {
 function clickWaitForResponse() {
   cy.get('.ms-Checkbox-text')
     .should("be.visible")
-    .click({ force: true });
+    .click({
+      force: true
+    });
 }
 
 /** Click on create action button */
 function clickCreateButton() {
-  //app/624ade4a-6631-4a72-95fc-06135ce2c8fa/action
-  cy.server()
-  cy.route('POST', '/app/*/action').as('postAction')
-
+  cy.server();
+  cy.route('POST', '/app/*/action').as('postAction');
+  cy.route('GET', '/app/*/trainingstatus').as('getTrainingstatus');
   cy.get('[data-testid="actioncreator-button-create"]')
     .should("be.visible")
-    .click({ force: true });
+    .click({
+      force: true
+    });
   cy.wait('@postAction');
+  cy.wait('@getTrainingstatus');
 }
 
-export { clickWaitForResponse, selectTypeText, setPhrase, clickCreateButton };
+export {
+  clickWaitForResponse,
+  selectTypeText,
+  setPhrase,
+  clickCreateButton
+};

--- a/cypress/support/components/actionsmodal.js
+++ b/cypress/support/components/actionsmodal.js
@@ -15,10 +15,16 @@ function setPhrase(actionPhrase) {
   cy.get('div[data-slate-editor="true"]')
     .type(actionPhrase);
 }
-/** Click on create action button */
-function save() {
-  cy.get('[data-testid="actioncreator-button-create"]')
-    .click();
+
+function clickWaitForResponse() {
+  cy.get('.ms-Checkbox-text')
+    .click({force: true});
 }
 
-export {selectTypeText, setPhrase, save};
+/** Click on create action button */
+function clickCreateButton() {
+  cy.get('[data-testid="actioncreator-button-create"]')
+    .click({force: true});
+}
+
+export { clickWaitForResponse, selectTypeText, setPhrase, clickCreateButton };

--- a/cypress/support/components/actionspage.js
+++ b/cypress/support/components/actionspage.js
@@ -6,11 +6,16 @@ const testLog = require('../utils/testlog')
 
 /** Click on create a new action button */
 function createNew() {
+  cy.get('.cl-page').within(() => {
   cy
     .get('[data-testid="actions-button-create"]')
+    .should("be.visible")
     .then(function (response) {
       testLog.logStep("Create a New Action")
     })
-    .click();
+    .click({ force: true })
+  })
+  cy.get( '[data-testid="dropdown-action-type"]')
+    .should("be.visible");
 }
 export {createNew};

--- a/cypress/support/components/actionspage.js
+++ b/cypress/support/components/actionspage.js
@@ -1,21 +1,25 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+* Copyright (c) Microsoft Corporation. All rights reserved.  
  * Licensed under the MIT License.
- */
+*/
 const testLog = require('../utils/testlog')
 
 /** Click on create a new action button */
 function createNew() {
   cy.get('.cl-page').within(() => {
-  cy
-    .get('[data-testid="actions-button-create"]')
-    .should("be.visible")
-    .then(function (response) {
-      testLog.logStep("Create a New Action")
-    })
-    .click({ force: true })
+    cy
+      .get('[data-testid="actions-button-create"]')
+      .should("be.visible")
+      .then(function (response) {
+        testLog.logStep("Create a New Action");
+      })
+      .click({
+        force: true
+      });
   })
-  cy.get( '[data-testid="dropdown-action-type"]')
+  cy.get('[data-testid="dropdown-action-type"]')
     .should("be.visible");
 }
-export {createNew};
+export {
+  createNew
+};

--- a/cypress/support/components/entitymodal.js
+++ b/cypress/support/components/entitymodal.js
@@ -6,7 +6,7 @@ const testLog = require('../utils/testlog')
 
 /** Clicks on multivalue checkbox */
 function clickOnMultivalue() {
-    cy.get('[data-testid="entity-creator-input-multivalue"]')
+    cy.get('[data-testid="entitycreator-checkbox-multivalued"]')
         .click()
 }
 

--- a/cypress/support/components/homepage.js
+++ b/cypress/support/components/homepage.js
@@ -22,15 +22,18 @@ function createNewModel(modelName) {
 
   // Click the button to create app
   cy.get('[data-testid="apps-list-button-create-new"]')
+    .should("be.visible")
     .click()
 
   // Ensure that name input is focused
   cy.focused()
 
   cy.get('[data-testid="app-create-input-name"]')
+    .should("be.visible")
     .type(modelName)
 
   cy.get('[data-testid="app-create-button-submit"]')
+    .should("be.visible")
     .then(function (response) {
       testLog.logStep("Click on Create button ")
     })

--- a/cypress/support/components/logdialogmodal.js
+++ b/cypress/support/components/logdialogmodal.js
@@ -5,7 +5,7 @@
 const testLog = require('../utils/testlog')
 
 /** Chat: Types a new user's message */
-function newUserMessage(trainmessage) {
+function typeYourMessage(trainmessage) {
   // Submit message to WebChat
   cy.server()
   cy.route('POST', '/directline/conversations/**').as('postConversations')
@@ -24,4 +24,4 @@ function clickDone() {
     .click()
 }
 
-export { newUserMessage, clickDone };
+export { typeYourMessage, clickDone };

--- a/cypress/support/components/logdialogmodal.js
+++ b/cypress/support/components/logdialogmodal.js
@@ -10,8 +10,11 @@ function typeYourMessage(trainmessage) {
   cy.server()
   cy.route('POST', '/directline/conversations/**').as('postConversations')
 
-  cy.get('input[class="wc-shellinput"]').type(trainmessage)
+  cy.get('input[class="wc-shellinput"]')
+    .should("be.visible")
+    .type(trainmessage)
   cy.get('label[class="wc-send"]')
+    .should("be.visible")
     .then(function (response) {
       testLog.logStep("Send a new message to WebChat")
     })
@@ -21,6 +24,7 @@ function typeYourMessage(trainmessage) {
 
 function clickDone() {
   cy.get('[data-testid="chatsession-modal-footer-button1"]')
+    .should("be.visible")
     .click()
 }
 

--- a/cypress/support/components/logdialogspage.js
+++ b/cypress/support/components/logdialogspage.js
@@ -15,11 +15,11 @@ function createNew() {
   cy.server()
   cy.route('PUT', '/state/conversationId?username=ConversationLearnerDeveloper&id=*').as('putConv')
   cy.get('[data-testid="logdialogs-button-create"]')
+    .should("be.visible")
     .then(function (response) {
       testLog.logStep("Click button New Log Dialog ")
     })
     .click()
     .wait('@putConv')
 }
-
 export { verifyPageTitle, createNew };

--- a/cypress/support/components/scorermodal.js
+++ b/cypress/support/components/scorermodal.js
@@ -16,4 +16,20 @@ function selectAnAction() {
         .wait('@postScore')
 }
 
-export { selectAnAction }
+/** Selects the action that matches the text passed to this function*/
+function selectAnActionWithText(action) {
+    cy.server()
+    cy.route('POST', '/app/*/teach/*/scorer').as('postScore')
+
+    cy.get('.ms-List-page').within(() => {
+        cy.contains(action)
+        .parents('[class*="ms-DetailsRow-fields"]')
+        .find('.ms-Button-flexContainer')
+        .click({ force: true })
+      })
+
+     cy.wait('@postScore')
+}
+
+
+export { selectAnAction, selectAnActionWithText }

--- a/cypress/support/components/scorermodal.js
+++ b/cypress/support/components/scorermodal.js
@@ -9,6 +9,7 @@ function selectAnAction() {
     cy.server()
     cy.route('POST', '/app/*/teach/*/scorer').as('postScore')
     cy.get('[data-testid="actionscorer-buttonClickable"]')
+        .should("be.visible")
         .then(function (response) {
             testLog.logStep("Select an action")
         })
@@ -21,7 +22,7 @@ function selectAnActionWithText(action) {
     cy.server()
     cy.route('POST', '/app/*/teach/*/scorer').as('postScore')
 
-    cy.get('.ms-List-page').within(() => {
+    cy.get('.ms-List-page').should("be.visible").within(() => {
         cy.contains(action)
         .parents('[class*="ms-DetailsRow-fields"]')
         .find('.ms-Button-flexContainer')

--- a/cypress/support/components/traindialogmodal.js
+++ b/cypress/support/components/traindialogmodal.js
@@ -6,7 +6,7 @@
 const testLog = require('../utils/testlog')
 
 /** Chat: Types a new user's message */
-function newUserMessage(trainmessage) {
+function typeYourMessage(trainmessage) {
     // Submit message to WebChat
     cy.server()
     cy.route('PUT', '/app/*/teach/*/extractor').as('putExtractor')
@@ -21,7 +21,7 @@ function newUserMessage(trainmessage) {
 }
 
 /** Click on 'Score Action' button */
-function proceedToScoreAction() {
+function clickScoreActions() {
     cy.server()
     cy.route('PUT', '/app/*/teach/*/scorer').as('putScorer')
     cy.get('[data-testid="button-proceedto-scoreactions"]')
@@ -30,11 +30,10 @@ function proceedToScoreAction() {
         })
         .click()
         .wait('@putScorer');
-
 }
 
-/** Finalize the training */
-function done() {
+/** Finalize the training by clicking the Click done Teaching button*/
+function clickDoneTeaching() {
     cy.get('[data-testid="teachsession-footer-button-done"]')
         .then(function (response) {
             testLog.logStep("Click Done Teaching button")
@@ -42,4 +41,4 @@ function done() {
         .click();
 }
 
-export { newUserMessage, proceedToScoreAction, done };
+export { typeYourMessage, clickScoreActions, clickDoneTeaching };

--- a/src/components/modals/EntityCreatorEditor.tsx
+++ b/src/components/modals/EntityCreatorEditor.tsx
@@ -465,6 +465,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                 <br />
                 <div className="cl-entity-creator-checkbox">
                     <TC.Checkbox
+                        data-testid="entitycreator-checkbox-programmaticonly"
                         label={intl.formatMessage({
                             id: FM.ENTITYCREATOREDITOR_FIELDS_PROGRAMMATICONLY_LABEL,
                             defaultMessage: 'Programmatic Only'
@@ -477,7 +478,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                 </div>
                 <div className="cl-entity-creator-checkbox">
                     <TC.Checkbox
-                        data-testid="entity-creator-input-multivalue"
+                        data-testid="entitycreator-checkbox-multivalued"
                         label={intl.formatMessage({
                             id: FM.ENTITYCREATOREDITOR_FIELDS_MULTIVALUE_LABEL,
                             defaultMessage: 'Multi-valued'
@@ -490,6 +491,7 @@ class EntityCreatorEditor extends React.Component<Props, ComponentState> {
                 </div>
                 <div className="cl-entity-creator-checkbox">
                     <TC.Checkbox
+                        data-testid="entitycreator-checkbox-negatable"
                         label={intl.formatMessage({
                             id: FM.ENTITYCREATOREDITOR_FIELDS_NEGATABLE_LABEL,
                             defaultMessage: 'Negatable'


### PR DESCRIPTION
- implementation of new test to validate the use of Wait Actions VS Non Wait Actions during the train dialog creation.

Wait action: After the system takes a "wait" action, it will stop taking actions and wait for user input.
Non-wait action: After the system takes a "non-wait" action, it will immediately choose another action (without waiting for user input)
Also, added new  data-testids for entity creation checkboxes.
finally, I also modified function names to match action + element name.