### PR TITLE
 fix: normalize error code

### DIFF
--- a/src/actions/createActions.ts
+++ b/src/actions/createActions.ts
@@ -9,6 +9,7 @@ import { Dispatch } from 'redux'
 import { setErrorDisplay } from './displayActions'
 import * as ClientFactory from '../services/clientFactory' 
 import { fetchApplicationsAsync, fetchApplicationTrainingStatusThunkAsync } from './fetchActions';
+import { AxiosError } from 'axios';
 
 // --------------------------
 // App
@@ -27,8 +28,9 @@ export const createApplicationThunkAsync = (userId: string, application: AppBase
             dispatch(createApplicationFulfilled(newApp))
             return newApp
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.CREATE_APPLICATION_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_APPLICATION_ASYNC))
             throw error
         }
     }
@@ -60,8 +62,9 @@ export const copyApplicationThunkAsync = (srcUserId: string, destUserId: string,
             dispatch(fetchApplicationsAsync(destUserId))
             dispatch(copyApplicationFulfilled())
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.COPY_APPLICATION_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.COPY_APPLICATION_ASYNC))
             throw error
         }
         return;
@@ -103,8 +106,8 @@ export const createEntityThunkAsync = (appId: string, entity: EntityBase) => {
             
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId));
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.CREATE_ENTITY_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_ENTITY_ASYNC))
         }
     }
 }
@@ -138,8 +141,8 @@ export const createActionThunkAsync = (appId: string, action: ActionBase) => {
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId));
             return true;
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.CREATE_ACTION_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_ACTION_ASYNC))
             return false;
         }
     }
@@ -173,8 +176,9 @@ export const createAppTagThunkAsync = (appId: string, tagName: string, makeLive:
             dispatch(createAppTagFulfilled(updatedApp))
             return updatedApp
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.CREATE_APP_TAG_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_APP_TAG_ASYNC))
             throw error
         }
     }
@@ -208,8 +212,9 @@ export const createChatSessionThunkAsync = (appId: string, packageId: string, sa
             dispatch(createChatSessionFulfilled(session))
             return session
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.CREATE_CHAT_SESSION_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_CHAT_SESSION_ASYNC))
             throw error
         }
     }
@@ -239,8 +244,9 @@ export const createTeachSessionThunkAsync = (appId: string) => {
             dispatch(createTeachSessionFulfilled(teachResponse))
             return teachResponse
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.CREATE_TEACH_SESSION_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_TEACH_SESSION_ASYNC))
             dispatch(createTeachSessionRejected())
             throw error
         }
@@ -276,8 +282,9 @@ export const createTeachSessionFromHistoryThunkAsync = (app: AppBase, trainDialo
             dispatch(createTeachSessionFromHistoryFulfilled(teachWithHistory))
             return teachWithHistory
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.CREATE_TEACH_SESSION_FROMHISTORYASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_TEACH_SESSION_FROMHISTORYASYNC))
             dispatch(createTeachSessionRejected())
             throw error
         }
@@ -315,8 +322,9 @@ export const createTeachSessionFromUndoThunkAsync = (appId: string, teach: Teach
             dispatch(createTeachSessionFromUndoFulfilled(teachWithHistory))
             return teachWithHistory
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.CREATE_TEACH_SESSION_FROMUNDOASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_TEACH_SESSION_FROMUNDOASYNC))
             dispatch(createTeachSessionRejected())
             throw error
         }

--- a/src/actions/deleteActions.ts
+++ b/src/actions/deleteActions.ts
@@ -294,7 +294,7 @@ export const deleteLogDialogThunkAsync = (userId: string, app: AppBase, logDialo
         }
         catch (e) {
             const error = e as AxiosError
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.message], AT.DELETE_LOG_DIALOG_ASYNC))
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.DELETE_LOG_DIALOG_ASYNC))
             dispatch(deleteLogDialogRejected())
             dispatch(fetchAllLogDialogsAsync(userId, app, packageId));
         }

--- a/src/actions/deleteActions.ts
+++ b/src/actions/deleteActions.ts
@@ -8,6 +8,7 @@ import { AppBase, Session, Teach } from '@conversationlearner/models'
 import { setErrorDisplay } from './displayActions'
 import { fetchAllTrainDialogsAsync, fetchAllLogDialogsAsync, fetchApplicationTrainingStatusThunkAsync, fetchAllActionsAsync } from './fetchActions'
 import * as ClientFactory from '../services/clientFactory'
+import { AxiosError } from 'axios';
 
 // ---------------------
 // App
@@ -52,8 +53,8 @@ export const deleteEntityThunkAsync = (appId: string, entityId: string) => {
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId));
             return true;
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.DELETE_ENTITY_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.DELETE_ENTITY_ASYNC))
             return false;
         }
     }
@@ -94,8 +95,8 @@ export const deleteActionThunkAsync = (appId: string, actionId: string) => {
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId));
             return true;
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.DELETE_ACTION_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.DELETE_ACTION_ASYNC))
             return false;
         }
     }
@@ -130,8 +131,8 @@ export const deleteChatSessionThunkAsync = (key: string, session: Session, app: 
             dispatch(fetchAllLogDialogsAsync(key, app, packageId))
             return true;
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.DELETE_CHAT_SESSION_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.DELETE_CHAT_SESSION_ASYNC))
             return false;
         }
     }
@@ -175,8 +176,8 @@ export const deleteTeachSessionThunkAsync = (key: string, teachSession: Teach, a
             dispatch(fetchApplicationTrainingStatusThunkAsync(app.appId));
             return true;
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.DELETE_TRAIN_DIALOG_REJECTED))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.DELETE_TRAIN_DIALOG_REJECTED))
             dispatch(fetchAllTrainDialogsAsync(app.appId));
             return false;
         }
@@ -217,8 +218,8 @@ export const deleteMemoryThunkAsync = (key: string, currentAppId: string) => {
             dispatch(deleteMemoryFulfilled());
             return true;
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.DELETE_MEMORY_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.DELETE_MEMORY_ASYNC))
             return false;
         }
     }
@@ -251,8 +252,8 @@ export const deleteTrainDialogThunkAsync = (userId: string, app: AppBase, trainD
             dispatch(deleteTrainDialogFulfilled(trainDialogId))
             dispatch(fetchApplicationTrainingStatusThunkAsync(app.appId));
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.DELETE_TRAIN_DIALOG_REJECTED))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.DELETE_TRAIN_DIALOG_REJECTED))
             dispatch(deleteTrainDialogRejected())
             dispatch(fetchAllTrainDialogsAsync(app.appId));
         }
@@ -292,7 +293,7 @@ export const deleteLogDialogThunkAsync = (userId: string, app: AppBase, logDialo
             dispatch(deleteLogDialogFulfilled(logDialogId))
         }
         catch (e) {
-            const error = e as Error
+            const error = e as AxiosError
             dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.message], AT.DELETE_LOG_DIALOG_ASYNC))
             dispatch(deleteLogDialogRejected())
             dispatch(fetchAllLogDialogsAsync(userId, app, packageId));

--- a/src/actions/fetchActions.ts
+++ b/src/actions/fetchActions.ts
@@ -24,6 +24,7 @@ import * as ClientFactory from '../services/clientFactory'
 import { setErrorDisplay } from './displayActions'
 import { Poller, IPollConfig } from '../services/poller';
 import { delay } from '../util';
+import { AxiosError } from 'axios';
 
 // ----------------------------------------
 // Train Dialogs
@@ -55,8 +56,8 @@ export const fetchHistoryThunkAsync = (appId: string, trainDialog: TrainDialog, 
             dispatch(fetchHistoryFulfilled(teachWithHistory))
             return teachWithHistory
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.FETCH_HISTORY_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.FETCH_HISTORY_ASYNC))
             return null;
         }
     }
@@ -153,8 +154,8 @@ export const fetchTutorialsThunkAsync = (userId: string) => {
             dispatch(fetchTutorialsFulfilled(tutorials))
             return tutorials
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.FETCH_TUTORIALS_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.FETCH_TUTORIALS_ASYNC))
             return null;
         }
     }
@@ -258,8 +259,8 @@ export const fetchAppSourceThunkAsync = (appId: string, packageId: string, updat
             dispatch(fetchAppSourceFulfilled(appDefinition))
             return appDefinition
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.FETCH_APPSOURCE_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.FETCH_APPSOURCE_ASYNC))
             return null;
         }
     }
@@ -345,8 +346,8 @@ export const fetchEntityDeleteValidationThunkAsync = (appId: string, packageId: 
             dispatch(fetchEntityDeleteValidationFulfilled())
             return invalidTrainDialogIds
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.FETCH_ENTITY_DELETE_VALIDATION_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.FETCH_ENTITY_DELETE_VALIDATION_ASYNC))
             return null;
         }
     }
@@ -380,8 +381,8 @@ export const fetchEntityEditValidationThunkAsync = (appId: string, packageId: st
             dispatch(fetchEntityEditValidationFulfilled())
             return invalidTrainDialogIds
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.FETCH_ENTITY_EDIT_VALIDATION_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.FETCH_ENTITY_EDIT_VALIDATION_ASYNC))
             return null;
         }
     }
@@ -415,8 +416,8 @@ export const fetchActionDeleteValidationThunkAsync = (appId: string, packageId: 
             dispatch(fetchActionDeleteValidationFulfilled())
             return invalidTrainDialogIds
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.FETCH_ACTION_DELETE_VALIDATION_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.FETCH_ACTION_DELETE_VALIDATION_ASYNC))
             return null;
         }
     }
@@ -450,8 +451,8 @@ export const fetchActionEditValidationThunkAsync = (appId: string, packageId: st
             dispatch(fetchActionEditValidationFulfilled())
             return invalidTrainDialogIds
         } catch (e) {
-            const error = e as Error
-            dispatch(setErrorDisplay(ErrorType.Error, error.name, [error.message], AT.FETCH_ACTION_EDIT_VALIDATION_ASYNC))
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.FETCH_ACTION_EDIT_VALIDATION_ASYNC))
             return null;
         }
     }

--- a/src/actions/teachActions.ts
+++ b/src/actions/teachActions.ts
@@ -13,6 +13,7 @@ import {
     UIScoreResponse, UITrainScorerStep, UIPostScoreResponse,
     DialogType, DialogMode, FilledEntityMap, Memory
 } from '@conversationlearner/models'
+import { AxiosError } from 'axios';
 
 // --------------------------
 // InitMemory
@@ -27,8 +28,9 @@ export const initMemoryThunkAsync = (appId: string, sessionId: string, filledEnt
             dispatch(initMemoryFulfilled(memories))
             return
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.INIT_MEMORY_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.INIT_MEMORY_ASYNC))
             throw error
         }
     }
@@ -78,8 +80,9 @@ export const runExtractorThunkAsync = (key: string, appId: string, extractType: 
             dispatch(runExtractorFulfilled(appId, sessionId, uiExtractResponse))
             return uiExtractResponse
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.RUN_EXTRACTOR_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.RUN_EXTRACTOR_ASYNC))
             throw error
         }
     }
@@ -141,8 +144,9 @@ export const getScoresThunkAsync = (key: string, appId: string, sessionId: strin
             dispatch(getScoresFulfilled(key, appId, sessionId, uiScoreResponse))
             return uiScoreResponse
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.GET_SCORES_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.GET_SCORES_ASYNC))
             throw error
         }
     }
@@ -180,8 +184,9 @@ export const runScorerThunkAsync = (key: string, appId: string, teachId: string,
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId))
             return uiScoreResponse
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.RUN_SCORER_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.RUN_SCORER_ASYNC))
             throw error
         }
     }
@@ -230,8 +235,9 @@ export const postScorerFeedbackThunkAsync = (key: string, appId: string, teachId
             }
             return uiPostScoreResponse
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.POST_SCORE_FEEDBACK_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.POST_SCORE_FEEDBACK_ASYNC))
             throw error
         }
     }

--- a/src/actions/updateActions.ts
+++ b/src/actions/updateActions.ts
@@ -9,6 +9,7 @@ import * as ClientFactory from '../services/clientFactory'
 import { setErrorDisplay } from './displayActions'
 import { Dispatch } from 'redux'
 import { fetchAllTrainDialogsAsync, fetchApplicationTrainingStatusThunkAsync } from './fetchActions';
+import { AxiosError } from 'axios';
 
 // ----------------------------------------
 // App
@@ -60,8 +61,9 @@ export const editEntityThunkAsync = (appId: string, entity: EntityBase) => {
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId))
             return entity
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.EDIT_ENTITY_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.EDIT_ENTITY_ASYNC))
             throw error
         }
     }
@@ -102,8 +104,9 @@ export const editActionThunkAsync = (appId: string, action: ActionBase) => {
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId))
             return action
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.EDIT_ACTION_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.EDIT_ACTION_ASYNC))
             throw error
         }
     }
@@ -138,8 +141,9 @@ export const editTrainDialogThunkAsync = (appId: string, trainDialog: TrainDialo
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId))
             return trainDialog
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.EDIT_TRAINDIALOG_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.EDIT_TRAINDIALOG_ASYNC))
             throw error
         }
     }
@@ -186,8 +190,9 @@ export const editAppLiveTagThunkAsync = (appId: string, tagId: string) => {
             dispatch(editAppLiveTagFulfilled(updatedApp))
             return updatedApp
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.EDIT_APP_LIVE_TAG_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.EDIT_APP_LIVE_TAG_ASYNC))
             throw error
         }
     }
@@ -220,8 +225,9 @@ export const editAppEditingTagThunkAsync = (appId: string, packageId: string) =>
             dispatch(editAppEditingTagFulfilled(activeApps))
             return activeApps
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.EDIT_APP_EDITING_TAG_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.EDIT_APP_EDITING_TAG_ASYNC))
             throw error
         }
     }
@@ -253,8 +259,9 @@ export const setAppSourceThunkAsync = (appId: string, appDefinition: AppDefiniti
             dispatch(setAppSourceFulfilled())
             return true
         }
-        catch (error) {
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, [error.response], AT.CREATE_APPLICATION_ASYNC))
+        catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.CREATE_APPLICATION_ASYNC))
             throw error
         }
     }

--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -266,7 +266,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                             <FilePicker
                                 extensions={['cl']}
                                 onChange={this.onChangeFile}
-                                onError={(err: string) => setErrorDisplay(ErrorType.Error, err, null, null)}
+                                onError={(error: string) => setErrorDisplay(ErrorType.Error, error, [], null)}
                             >
                                 <div className="cl-action-creator-file-picker">
                                     <OF.PrimaryButton

--- a/src/components/modals/ChatSessionModal.tsx
+++ b/src/components/modals/ChatSessionModal.tsx
@@ -110,7 +110,7 @@ const mapStateToProps = (state: State) => {
     return {
         chatSession: state.chatSessions,
         user: state.user,
-        error: state.error.error
+        error: state.error.title
     }
 }
 

--- a/src/components/modals/ErrorPanel.tsx
+++ b/src/components/modals/ErrorPanel.tsx
@@ -94,16 +94,9 @@ class ErrorPanel extends React.Component<Props, {}> {
                         defaultMessage='Unknown '
                     /> Failed</div>}
                     <div className={FontClassNames.medium}>{this.props.error.error}</div>
-                    {this.props.error && this.props.error.messages.map((message: any) => { 
-                            if (message == null)
-                            { 
-                                message = 'Unknown';
-                            }
-                            else if (typeof message !== 'string') {
-                                message = JSON.stringify(message);
-                            }
+                    {this.props.error && this.props.error.messages.map(message => { 
                             // TODO: Need to not base this on string compare, but will greatly help end users so putting in for now
-                            if (message.indexOf("LUIS_AUTHORING_KEY") > -1) {
+                            if (message.includes("LUIS_AUTHORING_KEY")) {
                                 return (
                                     <div>
                                         <div key={key++} className={FontClassNames.medium}>{message}</div>

--- a/src/components/modals/ErrorPanel.tsx
+++ b/src/components/modals/ErrorPanel.tsx
@@ -2,13 +2,13 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.  
  * Licensed under the MIT License.
  */
-import * as React from 'react';
-import { returntypeof } from 'react-redux-typescript';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { Panel, PanelType, FontClassNames, DefaultButton } from 'office-ui-fabric-react';
+import * as React from 'react'
+import { returntypeof } from 'react-redux-typescript'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import * as OF from 'office-ui-fabric-react'
 import { clearErrorDisplay } from '../../actions/displayActions'
-import { State } from '../../types'
+import { State, ErrorState } from '../../types'
 import { ErrorHandler } from '../../ErrorHandler'
 import { injectIntl, InjectedIntlProps, InjectedIntl, FormattedMessage } from 'react-intl'
 import { AT } from '../../types/ActionTypes'
@@ -16,103 +16,82 @@ import { FM } from '../../react-intl-messages'
 import { GetTip, TipType } from '../ToolTips'
 
 class ErrorPanel extends React.Component<Props, {}> {
-
-    static callbacks: ((actionType: AT) => void)[] = [];
-
-    static customErrors = 
-        {
-            'Network Error' : FM.CUSTOMERROR_NETWORK_ERROR
-        };
-
-    public static registerCallback(actionType: AT, callback: (at: AT) => void[]): void {
-        if (!ErrorPanel.callbacks[actionType]) {
-            ErrorPanel.callbacks[actionType] = [];
-        }
-        ErrorPanel.callbacks[actionType].push(callback);
+    static customErrors = {
+        'Network Error': FM.CUSTOMERROR_NETWORK_ERROR
     }
 
-    constructor(p: any) { 
-        super(p);
-
-        this.handleClose = this.handleClose.bind(this)
-    }
-
-    handleClose(actionType: AT) {
-        this.props.clearErrorDisplay();
+    handleClose = (actionType: AT) => {
+        this.props.clearErrorDisplay()
 
         // If error associated with an action
         if (actionType) {
-          ErrorHandler.handleError(actionType);
+            ErrorHandler.handleError(actionType)
         }
     }
 
     onRenderFooterContent(): JSX.Element {
         return (
-          <div>
-            <DefaultButton
-              onClick={() => this.handleClose(this.props.error.actionType) }
-            >
-              Close
-            </DefaultButton>
-          </div>
+            <div>
+                <OF.DefaultButton
+                    onClick={() => this.handleClose(this.props.error.actionType)}
+                >
+                    Close
+                </OF.DefaultButton>
+            </div>
         );
-      }
+    }
 
-    getCustomError(intl: InjectedIntl): string {
-        if (this.props.error) {
-            let fm = ErrorPanel.customErrors[this.props.error.error];
-            return fm &&
-                intl.formatMessage({
-                    id: fm,
-                    defaultMessage: fm
-                })
+    getCustomError(intl: InjectedIntl, error: ErrorState): string {
+        if (!error) {
+            return null
         }
-        return null;
+
+        const formattedMessageId = ErrorPanel.customErrors[error.title]
+        return formattedMessageId &&
+            intl.formatMessage({
+                id: formattedMessageId,
+                defaultMessage: formattedMessageId
+            })
     }
 
     render() {
-        let key = 0;
-        const { intl } = this.props
-        let customError = this.getCustomError(intl);
+        const { intl, error } = this.props
+        const customError = this.getCustomError(intl, error)
         return (
-            <div>
-            {this.props.error.error != null &&
-                <Panel
-                    focusTrapZoneProps={{}}
-                    isOpen={this.props.error.error != null}
-                    type={PanelType.medium}
-                    onDismiss={() => this.handleClose(this.props.error.actionType)}
-                    isFooterAtBottom={ true }
-                    closeButtonAriaLabel='Close'
-                    onRenderFooterContent={() =>this.onRenderFooterContent() }
-                    customWidth='600px'
-                >
-                <div className="cl-errorpanel" >
-                    {this.props.error.actionType && <div className={FontClassNames.large}>
-                    <FormattedMessage
-                        id={this.props.error.actionType || FM.ERROR_ERROR}
-                        defaultMessage='Unknown '
-                    /> Failed</div>}
-                    <div className={FontClassNames.medium}>{this.props.error.error}</div>
-                    {this.props.error && this.props.error.messages.map(message => { 
-                            // TODO: Need to not base this on string compare, but will greatly help end users so putting in for now
-                            if (message.includes("LUIS_AUTHORING_KEY")) {
-                                return (
-                                    <div>
-                                        <div key={key++} className={FontClassNames.medium}>{message}</div>
-                                        {GetTip(TipType.LUIS_AUTHORING_KEY)}
-                                    </div>
-                                )
-                            }
-                            return message.length === 0 ? <br key={key++}></br> : <div key={key++} className={FontClassNames.medium}>{message}</div>;
-                        })
-                    }
+            <OF.Panel
+                focusTrapZoneProps={{}}
+                isOpen={error.title != null}
+                type={OF.PanelType.medium}
+                onDismiss={() => this.handleClose(error.actionType)}
+                isFooterAtBottom={true}
+                closeButtonAriaLabel='Close'
+                onRenderFooterContent={() => this.onRenderFooterContent()}
+                customWidth='600px'
+            >
+                <div className="cl-errorpanel">
+                    {this.props.error.actionType && <div className={OF.FontClassNames.large}>
+                        <FormattedMessage
+                            id={this.props.error.actionType || FM.ERROR_ERROR}
+                            defaultMessage='Unknown '
+                        /> Failed</div>}
+                    <div className={OF.FontClassNames.medium}>{this.props.error.title}</div>
+                    {this.props.error && Array.isArray(this.props.error.messages) && this.props.error.messages.map((message, key) => {
+                        // TODO: Need to not base this on string compare, but will greatly help end users so putting in for now
+                        if (message.includes("LUIS_AUTHORING_KEY")) {
+                            return (
+                                <div key={key}>
+                                    <div>{message}</div>
+                                    {GetTip(TipType.LUIS_AUTHORING_KEY)}
+                                </div>
+                            )
+                        }
+
+                        return <div key={key}>{message}</div>
+                    })}
                     {customError &&
-                        <div className={FontClassNames.medium}>{customError}</div>}
+                        <div className={OF.FontClassNames.medium}>{customError}</div>}
                 </div>
-                </Panel>
-            }
-            </div>
+            </OF.Panel>
         );
     }
 }

--- a/src/epics/apiHelpers.ts
+++ b/src/epics/apiHelpers.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.  
  * Licensed under the MIT License.
  */
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 import {
   AppBase
 } from '@conversationlearner/models'
@@ -196,15 +196,16 @@ export const getAllTeachSessionsForApp = (appId: string): Rx.Observable<ActionOb
     .catch(err => handleError(obs, err, AT.FETCH_TEACH_SESSIONS_ASYNC)));
 };
 
-const handleError = (obs: Rx.Observer<ActionObject>, err: any, actionType: AT) => {
+const handleError = (obs: Rx.Observer<ActionObject>, e: any, actionType: AT) => {
   if (!obs.closed) {
     // Service call failure
-    obs.next(actions.display.setErrorDisplay(ErrorType.Error, err.message, [toErrorString(err.response)], actionType));
+    const error = e as AxiosError
+    obs.next(actions.display.setErrorDisplay(ErrorType.Error, error.message, [toErrorString(error.response)], actionType));
     obs.complete();
   }
   else {
     // Means we've hit a code error not a service failure
-    throw (err);
+    throw (e);
   }
 }
 

--- a/src/reducers/errorReducer.ts
+++ b/src/reducers/errorReducer.ts
@@ -8,9 +8,9 @@ import { Reducer } from 'redux'
 import { AT } from '../types/ActionTypes'
 
 const initialState: ErrorState = {
-    errorType: ErrorType.Error,
-    error: null,
-    messages: null,
+    type: ErrorType.Error,
+    title: null,
+    messages: [],
     actionType: AT.NO_OP
 }
 
@@ -20,18 +20,18 @@ const errorReducer: Reducer<ErrorState> = (state = initialState, action: ActionO
             return { ...initialState }
         case AT.SET_ERROR_DISPLAY:
             return { 
-                errorType: action.errorType,
-                error: action.title,
+                type: action.errorType,
+                title: action.title,
                 messages: action.messages,
                 actionType: action.actionType
             }
         case AT.FETCH_BOTINFO_FULFILLED:
             if (action.botInfo.validationErrors.length > 0) {
                 return {
-                    errorType: ErrorType.Error,
-                    error: `Configuration Error`,
+                    type: ErrorType.Error,
+                    title: `Configuration Error`,
                     messages: action.botInfo.validationErrors,
-                    actionType: null
+                    actionType: AT.FETCH_BOTINFO_ASYNC
                 }
             }
             return { ...state }

--- a/src/types/StateTypes.ts
+++ b/src/types/StateTypes.ts
@@ -19,8 +19,8 @@ import { TipType } from '../components/ToolTips'
 export type ActionState = ActionBase[];
 export type EntityState = EntityBase[];
 export type ErrorState = {
-    errorType: ErrorType,
-    error: string,
+    type: ErrorType,
+    title: string,
     messages: string[],
     actionType: AT
 }


### PR DESCRIPTION
- Use AxiosError instead of Error when setting display
- Parse message outside of panel
- Remove manually managed key
- Use type and title instead of redundant error properties