### PR TITLE
test: cypress configuration updates

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "projectId": "so64kq",
   "reporter": "mocha-multi-reporters",
-  "requestTimeout": 10000,
+  "requestTimeout": 20000,
   "reporterOptions": {
     "configFile": "config-mocha-reporter.json"
   }

--- a/cypress.json
+++ b/cypress.json
@@ -3,6 +3,8 @@
   "reporter": "mocha-multi-reporters",
   "requestTimeout": 20000,
   "responseTimeout": 45000,
+  "viewportHeight": 900,
+  "viewportWidht": 1600,
   "reporterOptions": {
     "configFile": "config-mocha-reporter.json"
   }

--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,7 @@
   "projectId": "so64kq",
   "reporter": "mocha-multi-reporters",
   "requestTimeout": 20000,
+  "responseTimeout": 45000,
   "reporterOptions": {
     "configFile": "config-mocha-reporter.json"
   }


### PR DESCRIPTION
- screen default values (1000x660) won't  let the screenshots to view all the elements; this change sets the viewport values to 1600x900 which is a decent size and allow us to see more details.
sample:  https://dashboard.cypress.io/#/projects/so64kq/runs/129/failures/277d8d7f-5797-4ab1-ac23-92301b0e5a8a
- Some request are still taking long (sample below):
 https://dashboard.cypress.io/#/projects/so64kq/runs/108/failures/bd119809-8068-47cb-92c5-a1bc0e7a0422 (see delete test step failure)