### PR TITLE
fix: change generic "Status" to "Training"

### DIFF
--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -459,7 +459,7 @@ export default {
         [FM.APP_HEADER_SUPPORT]: 'Support',
 
         // TrainingStatus
-        [FM.APP_TRAINING_STATUS_STATUS]: 'Status',
+        [FM.APP_TRAINING_STATUS_STATUS]: 'Training',
         [FM.APP_TRAINING_STATUS_UNKNOWN]: 'Unknown',
         [FM.APP_TRAINING_STATUS_QUEUED]: 'Queued',
         [FM.APP_TRAINING_STATUS_RUNNING]: 'Running',


### PR DESCRIPTION
There was bug saying people didn't understand what the Status was for and suggested to use Training so it's clear that it is Training that is running or completed and not some other property of the model.