### PR TITLE
fix: restore merge_node operation

### DIFF
--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -35,7 +35,7 @@ interface State {
     preBuiltEditorValues: SlateValue[]
 }
 
-const disallowedOperations = ['insert_text', 'remove_text', 'merge_node']
+const disallowedOperations = ['insert_text', 'remove_text']
 const externalChangeOperations = ['insert_node', 'remove_node']
 
 /**
@@ -180,8 +180,8 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
     onChange = (change: any) => {
         const { value, operations } = change
         const operationsJs = operations.toJS()
-        console.log(`operationsJs: `, operationsJs)
-        console.log(`disallowedOperations: `, disallowedOperations)
+        // console.log(`operationsJs: `, operationsJs)
+        // console.log(`disallowedOperations: `, disallowedOperations)
         const containsDisallowedOperations = operationsJs.some((o: any) => disallowedOperations.includes(o.type))
 
         if (containsDisallowedOperations) {
@@ -245,7 +245,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
      * right most position of the input and presses the left arrow.
      */
     onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>, change: any) => {
-        if (event.key === 'Enter') {
+        if (['Enter', 'Backspace'].includes(event.key)) {
             event.preventDefault()
             return true
         }


### PR DESCRIPTION
Apparently "merge_node" is used in some cases so this should not be disallowed