### PR TITLE
 fix: move logdialog refresh button to top

### DIFF
--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -503,7 +503,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                         />
                     </span>
                 }
-                <div>
+                <div className="cl-buttons-row">
                     <OF.PrimaryButton
                         data-testid="logdialogs-button-create"
                         disabled={this.props.editingPackageId !== this.props.app.devPackageId || this.props.invalidBot}
@@ -517,6 +517,13 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                             defaultMessage: 'New Log Dialog'
                         })}
                         componentRef={component => this.newChatSessionButton = component}
+                    />
+                    <OF.DefaultButton
+                        data-testid="logdialogs-button-refresh"
+                        onClick={() => this.onClickSync()}
+                        ariaDescription="Refresh"
+                        text="Refresh"
+                        iconProps={{ iconName: 'Sync' }}
                     />
                 </div>
                 {logDialogs.length === 0
@@ -553,15 +560,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                                 onSearch={(newValue) => this.onChange(newValue)}
                             />
                         </div>
-                        <div>
-                            <OF.PrimaryButton
-                                data-testid="logdialogs-button-refresh"
-                                onClick={() => this.onClickSync()}
-                                ariaDescription="Refresh"
-                                text="Refresh"
-                                iconProps={{ iconName: 'Sync' }}
-                            />
-                        </div>
+
                         <OF.DetailsList
                             data-testid="logdialogs-details-list"
                             key={this.state.dialogKey}
@@ -604,7 +603,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                     teach={this.props.teachSessions.current}
                     dialogMode={this.props.teachSessions.mode}
                     isOpen={this.state.isTeachDialogModalOpen}
-                    onClose={this.onCloseTeachSession} 
+                    onClose={this.onCloseTeachSession}
                     onUndo={(popRound) => this.onUndoTeachStep(popRound)}
                     history={this.state.isTeachDialogModalOpen ? this.state.history : null}
                     lastAction={this.state.lastAction}

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -381,7 +381,7 @@ class Settings extends React.Component<Props, ComponentState> {
                         onGetErrorMessage={value => this.onGetNameErrorMessage(value)}
                         value={this.state.appNameVal}
                     />
-                    <div className="cl-modal-buttons_primary">
+                    <div className="cl-buttons-row">
                         <OF.PrimaryButton
                             onClick={this.onExport}
                             ariaDescription={intl.formatMessage({
@@ -520,7 +520,7 @@ class Settings extends React.Component<Props, ComponentState> {
                         </React.Fragment>
                     }
 
-                    <div className="cl-modal-buttons_primary">
+                    <div className="cl-buttons-row">
                         <OF.PrimaryButton
                             disabled={this.state.edited === false || this.onGetNameErrorMessage(this.state.appNameVal) !== ''}
                             onClick={this.onClickSave}

--- a/src/routes/Apps/AppsList.tsx
+++ b/src/routes/Apps/AppsList.tsx
@@ -283,7 +283,7 @@ class AppsList extends React.Component<Props, ComponentState> {
                         defaultMessage="Create and Manage your Conversation Learner applications..."
                     />
                 </span>
-                <div className="cl-modal-buttons_primary">
+                <div className="cl-buttons-row">
                     <OF.PrimaryButton
                         data-testid="apps-list-button-create-new"
                         onClick={this.onClickCreateNewApp}


### PR DESCRIPTION
It follows pattern from home page where all commands on the list below are in row at top.
Allow button to be used even when there are no log dialogs

Fixes: VSTS#1419