### PR TITLE
fix: allow refresh/resume on app specific pages

### DIFF
--- a/src/actions/fetchActions.ts
+++ b/src/actions/fetchActions.ts
@@ -109,18 +109,35 @@ export const fetchAllLogDialogsFulfilled = (logDialogs: LogDialog[]): ActionObje
 // ----------------------------------------
 // Bot Info
 // ----------------------------------------
-export const fetchBotInfoAsync = (browserId: string): ActionObject => {
+const fetchBotInfoAsync = (browserId: string): ActionObject => {
     return {
         type: AT.FETCH_BOTINFO_ASYNC,
-        browserId: browserId
+        browserId
     }
 }
 
-export const fetchBotInfoFulfilled = (botInfo: BotInfo, browserId: string): ActionObject => {
+const fetchBotInfoFulfilled = (botInfo: BotInfo, browserId: string): ActionObject => {
     return {
         type: AT.FETCH_BOTINFO_FULFILLED,
-        botInfo: botInfo,
-        browserId: browserId
+        botInfo,
+        browserId
+    }
+}
+
+export const fetchBotInfoThunkAsync = (browserId: string) => {
+    return async (dispatch: Dispatch<any>) => {
+        const clClient = ClientFactory.getInstance(AT.FETCH_BOTINFO_ASYNC)
+        dispatch(fetchBotInfoAsync(browserId))
+
+        try {
+            const botInfo = await clClient.getBotInfo(browserId)
+            dispatch(fetchBotInfoFulfilled(botInfo, browserId))
+            return botInfo
+        } catch (e) {
+            const error = e as AxiosError
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? [JSON.stringify(error.response, null, '  ')] : [], AT.FETCH_BOTINFO_ASYNC))
+            return null;
+        }
     }
 }
 

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -9,7 +9,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Plain from 'slate-plain-serializer'
 import { 
-    fetchBotInfoAsync,
+    fetchBotInfoThunkAsync,
     fetchActionDeleteValidationThunkAsync,
     fetchActionEditValidationThunkAsync } from '../../actions/fetchActions'
 import { Modal } from 'office-ui-fabric-react/lib/Modal'
@@ -396,7 +396,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
     }
 
     onClickSyncBotInfo() {
-        this.props.fetchBotInfoAsync(this.props.browserId);
+        this.props.fetchBotInfoThunkAsync(this.props.browserId)
     }
 
     onClickViewCard() {
@@ -1161,7 +1161,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        fetchBotInfoAsync,
+        fetchBotInfoThunkAsync,
         fetchActionDeleteValidationThunkAsync,
         fetchActionEditValidationThunkAsync
     }, dispatch);

--- a/src/epics/apiHelpers.ts
+++ b/src/epics/apiHelpers.ts
@@ -55,17 +55,6 @@ export const setConversationId = (userName: string, userId: string, conversation
 //=========================================================
 // GET ROUTES
 //=========================================================
-
-export const getBotInfo = (browserId: string): Rx.Observable<ActionObject> => {
-  const clClient = ClientFactory.getInstance(AT.FETCH_BOTINFO_ASYNC)
-  return Rx.Observable.create((obs: Rx.Observer<ActionObject>) => clClient.getBotInfo(browserId)
-    .then(botInfo => {
-      obs.next(actions.fetch.fetchBotInfoFulfilled(botInfo, browserId));
-      obs.complete();
-    })
-    .catch(err => handleError(obs, err, AT.FETCH_BOTINFO_ASYNC)));
-};
-
 export const getAllApps = (userId: string): Rx.Observable<ActionObject> => {
   const clClient = ClientFactory.getInstance(AT.FETCH_APPLICATIONS_ASYNC)
   return Rx.Observable.create((obs: Rx.Observer<ActionObject>) => clClient.apps(userId)

--- a/src/epics/fetchEpics.ts
+++ b/src/epics/fetchEpics.ts
@@ -6,17 +6,9 @@ import * as Rx from 'rxjs';
 import { ActionsObservable, Epic } from 'redux-observable'
 import { State, ActionObject } from '../types'
 import { AT } from '../types/ActionTypes'
-import { getBotInfo, getAllApps, getAllEntitiesForApp, getAllActionsForApp, getAllSessionsForApp, getAllTeachSessionsForApp, getAllTrainDialogsForApp, getAllLogDialogsForApp } from "./apiHelpers";
+import { getAllApps, getAllEntitiesForApp, getAllActionsForApp, getAllSessionsForApp, getAllTeachSessionsForApp, getAllTrainDialogsForApp, getAllLogDialogsForApp } from "./apiHelpers";
  
 const assertNever = () => { throw Error(`Should not reach here`) }
-
-export const fetchBotInfoEpic: Epic<ActionObject, State> = (action$: ActionsObservable<ActionObject>): Rx.Observable<ActionObject> => {
-    return action$.ofType(AT.FETCH_BOTINFO_ASYNC)
-        .flatMap(action =>
-            (action.type === AT.FETCH_BOTINFO_ASYNC)
-                ? getBotInfo(action.browserId)
-                : assertNever())
-}
 
 export const fetchApplicationsEpic: Epic<ActionObject, State> = (action$: ActionsObservable<ActionObject>): Rx.Observable<ActionObject> => {
     return action$.ofType(AT.FETCH_APPLICATIONS_ASYNC)

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -39,7 +39,7 @@ class App extends React.Component<Props, ComponentState> {
   dismissBanner(banner: Banner) {
     // Can't clear error banners
     if (banner.type.toLowerCase() !== "error") {
-      this.props.clearBanner(this.props.banner)
+      this.props.clearBanner(banner)
     }
   }
 
@@ -69,6 +69,7 @@ class App extends React.Component<Props, ComponentState> {
   }
 
   render() {
+    const banner = this.props.botInfo ? this.props.botInfo.banner : null
     return (
       <Router>
         <div className="cl-app">
@@ -94,31 +95,36 @@ class App extends React.Component<Props, ComponentState> {
 
           <div className="cl-app_header-placeholder" />
           <div className="cl-app_content">
-            {this.shouldShowBanner(this.props.banner) &&
+            {this.shouldShowBanner(banner) &&
               <OF.MessageBar
                 className="cl-messagebar"
                 isMultiline={true}
-                onDismiss={() => this.dismissBanner(this.props.banner)}
+                onDismiss={() => this.dismissBanner(banner)}
                 dismissButtonAriaLabel='Close'
-                messageBarType={this.getMessageBarType(this.props.banner.type)}
+                messageBarType={this.getMessageBarType(banner.type)}
               >
-                {this.props.banner.message}
-                {this.props.banner.message.link && this.props.banner.linktext &&
-                  <OF.Link href={this.props.banner.link}>{this.props.banner.linktext}</OF.Link>
+                {banner.message}
+                {banner.message.link && banner.linktext &&
+                  <OF.Link href={banner.link}>{banner.linktext}</OF.Link>
                 }
-                {this.props.banner.datestring &&
+                {banner.datestring &&
                   <div>
-                    <span className="cl-font--demphasis">{this.props.banner.datestring}</span>
+                    <span className="cl-font--demphasis">{banner.datestring}</span>
                   </div>
                 }
               </OF.MessageBar>
             }
-            <Switch>
-              <Route exact path="/" render={() => <Redirect to="/home" />} />
-              <Route path="/home" component={AppsIndex} />
-              <Route path="/settings" component={Settings} />
-              <Route component={NoMatch} />
-            </Switch>
+            <React.Fragment>
+              {this.props.botInfo === null
+                ? <div>Loading Bot Info...</div>
+                : <Switch>
+                <Route exact path="/" render={() => <Redirect to="/home" />} />
+                <Route path="/home" component={AppsIndex} />
+                <Route path="/settings" component={Settings} />
+                <Route component={NoMatch} />
+              </Switch>
+              }
+            </React.Fragment>
           </div>
           <div className="cl-app_modals">
             <ErrorPanel />
@@ -142,7 +148,7 @@ const mapStateToProps = (state: State) => {
   return {
     user: state.user,
     browserId: state.bot.browserId,
-    banner: state.bot.botInfo ? state.bot.botInfo.banner : null,
+    botInfo: state.bot.botInfo,
     clearedBanner: state.display.clearedBanner
   }
 }

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -20,7 +20,7 @@ import { SpinnerWindow, ErrorPanel } from '../components/modals'
 import './App.css'
 import { FormattedMessage } from 'react-intl'
 import { FM } from '../react-intl-messages'
-import { fetchBotInfoAsync } from '../actions/fetchActions'
+import { fetchBotInfoThunkAsync } from '../actions/fetchActions'
 import { clearBanner } from '../actions/displayActions'
 
 interface ComponentState {
@@ -33,13 +33,13 @@ class App extends React.Component<Props, ComponentState> {
   state = initialState
 
   componentDidMount() {
-    this.props.fetchBotInfoAsync(this.props.browserId)
+    this.props.fetchBotInfoThunkAsync(this.props.browserId)
   }
 
   dismissBanner(banner: Banner) {
     // Can't clear error banners
     if (banner.type.toLowerCase() !== "error") {
-      this.props.clearBanner(this.props.banner) 
+      this.props.clearBanner(this.props.banner)
     }
   }
 
@@ -47,11 +47,11 @@ class App extends React.Component<Props, ComponentState> {
     if (!banner || !banner.message) {
       return false;
     }
-    
+
     if (!this.props.clearedBanner) {
       return true;
     }
-      
+
     if (JSON.stringify(banner) === JSON.stringify(this.props.clearedBanner)) {
       return false;
     }
@@ -72,7 +72,7 @@ class App extends React.Component<Props, ComponentState> {
     return (
       <Router>
         <div className="cl-app">
-          <div className="cl-app_header-placeholder"/>
+          <div className="cl-app_header-placeholder" />
           <header className={`cl-app_header cl-header`}>
             <nav className="cl-header_links">
               <img className="cl-header-logo" src="/Microsoft-logo_rgb_c-wht.png" alt="Microsoft Logo" />
@@ -91,14 +91,14 @@ class App extends React.Component<Props, ComponentState> {
             </nav>
             <NavLink className="cl-header_user" to="/settings"><OF.Icon className="cl-header-office-icon" iconName="Settings" /> Settings</NavLink>
           </header>
-          
+
           <div className="cl-app_header-placeholder" />
           <div className="cl-app_content">
             {this.shouldShowBanner(this.props.banner) &&
               <OF.MessageBar
                 className="cl-messagebar"
                 isMultiline={true}
-                onDismiss={()=>this.dismissBanner(this.props.banner) }
+                onDismiss={() => this.dismissBanner(this.props.banner)}
                 dismissButtonAriaLabel='Close'
                 messageBarType={this.getMessageBarType(this.props.banner.type)}
               >
@@ -133,8 +133,8 @@ class App extends React.Component<Props, ComponentState> {
 
 const mapDispatchToProps = (dispatch: any) => {
   return bindActionCreators({
-      fetchBotInfoAsync,
-      clearBanner
+    fetchBotInfoThunkAsync,
+    clearBanner
   }, dispatch);
 }
 

--- a/src/routes/Apps/App/Dashboard.tsx
+++ b/src/routes/Apps/App/Dashboard.tsx
@@ -12,7 +12,7 @@ import { bindActionCreators } from 'redux'
 import { FontClassNames, PrimaryButton } from 'office-ui-fabric-react'
 import { FM } from '../../../react-intl-messages'
 import ReactPlayer from 'react-player'
-import { fetchBotInfoAsync } from '../../../actions/fetchActions'
+import { fetchBotInfoThunkAsync } from '../../../actions/fetchActions'
 import * as ReactMarkdown from 'react-markdown'
 import './Dashboard.css'
 
@@ -26,8 +26,12 @@ class Dashboard extends React.Component<Props, ComponentState> {
     }
 
     onClickRetry = () => {
-        this.props.fetchBotInfoAsync(this.props.browserId)
+        this.props.fetchBotInfoThunkAsync(this.props.browserId)
 
+        /**
+         * This is here to toggle visibility of text for the screen reader.
+         * Because it's meant for reading and not as a direct match of request duration it is fixed to 1000 ms
+         */
         this.setState({
             retrying: true
         }, () => {
@@ -102,7 +106,7 @@ const mapStateToProps = (state: State) => {
 
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        fetchBotInfoAsync
+        fetchBotInfoThunkAsync
     }, dispatch);
 }
 

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -43,27 +43,28 @@ class Index extends React.Component<Props, ComponentState> {
         packageId: null
     }
 
-    loadApp(app: AppBase, packageId: string): void {
-        
+    async loadApp(app: AppBase, packageId: string): Promise<void> {
+        console.log(`loadApp`, app, packageId)
         this.setState({ packageId: packageId})
+
+        await this.props.fetchBotInfoThunkAsync(this.props.browserId)
 
         this.props.setCurrentApp(this.props.user.id, app)
         this.props.fetchAllLogDialogsAsync(this.props.user.id, app, packageId) // Note: a separate call as eventually we want to page
         this.props.fetchAppSource(app.appId, packageId)
-        this.props.fetchBotInfoAsync(this.props.browserId)
         // this.props.fetchAllChatSessionsAsync(app.appId)
         // this.props.fetchAllTeachSessions(app.appId)
     }
 
     componentWillMount() {
-        // If we're loading Index due to page refresh where model is not in router state
-        // force back to /home route to mimic old behavior and allow user to login again
-        const { location, history } = this.props
+        const { match, location } = this.props
+        
+        console.table(match)
+        
         const app: AppBase | null = location.state && location.state.app
         if (!app) {
-            console.log(`${this.constructor.name} componentWillMount. location.state.app is undefined: Redirect to /home`)
-            history.push('/home')
-            return
+            console.log(`${this.constructor.name} componentWillMount. location.state.app is undefined`)
+            throw new Error(`App from state not defined. Why? When does this occurr?`)
         }
 
         let editPackageId = this.props.activeApps[app.appId] || app.devPackageId;
@@ -71,7 +72,6 @@ class Index extends React.Component<Props, ComponentState> {
     }
 
     componentWillReceiveProps(newProps: Props) {
- 
         const app: AppBase | null = newProps.location.state && newProps.location.state.app
         let editPackageId = newProps.activeApps[app.appId] || app.devPackageId;
         if (this.state.packageId !== editPackageId) {
@@ -252,7 +252,7 @@ const mapDispatchToProps = (dispatch: any) => {
         createApplicationThunkAsync: actions.create.createApplicationThunkAsync,
         fetchAppSource: actions.fetch.fetchAppSourceThunkAsync,
         fetchAllLogDialogsAsync: actions.fetch.fetchAllLogDialogsAsync,
-        fetchBotInfoAsync: actions.fetch.fetchBotInfoAsync
+        fetchBotInfoThunkAsync: actions.fetch.fetchBotInfoThunkAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State) => {

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -58,17 +58,15 @@ class Index extends React.Component<Props, ComponentState> {
 
     componentWillMount() {
         const { match, location } = this.props
-        
-        console.table(match)
-        
         const app: AppBase | null = location.state && location.state.app
         if (!app) {
-            console.log(`${this.constructor.name} componentWillMount. location.state.app is undefined`)
-            throw new Error(`App from state not defined. Why? When does this occurr?`)
+            // TODO: Is there a way to recover getting appId from URL instead of router state
+            const appId = match.params.appId
+            console.error(`${this.constructor.name} componentWillMount. location.state.app is for app ${appId} undefined`)
         }
 
         let editPackageId = this.props.activeApps[app.appId] || app.devPackageId;
-        this.loadApp(app, editPackageId);
+        this.loadApp(app, editPackageId)
     }
 
     componentWillReceiveProps(newProps: Props) {
@@ -271,6 +269,10 @@ const mapStateToProps = (state: State) => {
 // Props types inferred from mapStateToProps & dispatchToProps
 const stateProps = returntypeof(mapStateToProps);
 const dispatchProps = returntypeof(mapDispatchToProps);
-type Props = typeof stateProps & typeof dispatchProps & RouteComponentProps<any> & InjectedIntlProps;
+
+interface MatchParams {
+    appId: string
+}
+type Props = typeof stateProps & typeof dispatchProps & RouteComponentProps<MatchParams> & InjectedIntlProps;
 
 export default connect<typeof stateProps, typeof dispatchProps, RouteComponentProps<any>>(mapStateToProps, mapDispatchToProps)(injectIntl(Index));

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -44,7 +44,6 @@ class Index extends React.Component<Props, ComponentState> {
     }
 
     async loadApp(app: AppBase, packageId: string): Promise<void> {
-        console.log(`loadApp`, app, packageId)
         this.setState({ packageId: packageId})
 
         await this.props.fetchBotInfoThunkAsync(this.props.browserId)
@@ -63,6 +62,8 @@ class Index extends React.Component<Props, ComponentState> {
             // TODO: Is there a way to recover getting appId from URL instead of router state
             const appId = match.params.appId
             console.error(`${this.constructor.name} componentWillMount. location.state.app is for app ${appId} undefined`)
+
+
         }
 
         let editPackageId = this.props.activeApps[app.appId] || app.devPackageId;

--- a/src/routes/Apps/AppsIndex.tsx
+++ b/src/routes/Apps/AppsIndex.tsx
@@ -22,23 +22,6 @@ interface ComponentState {
 }
 
 class AppsIndex extends React.Component<Props, ComponentState> {
-    updateAppsAndBot() {
-        if (this.props.user.id !== null && this.props.user.id.length > 0) {
-            this.props.fetchApplicationsAsync(this.props.user.id)
-            this.props.fetchBotInfoThunkAsync(this.props.browserId)
-        }
-    }
-    componentDidMount() {
-        this.updateAppsAndBot()
-    }
-
-    componentDidUpdate(prevProps: Props, prevState: ComponentState) {
-        // TODO: See if this code can be removed. It seems like componentWillMount is called every time the user navigates to /home route
-        if (typeof (this.props.user.id) === 'string' && this.props.user.id !== prevProps.user.id) {
-            this.updateAppsAndBot()
-        }
-    }
-
     onClickDeleteApp = (appToDelete: AppBase) => {
         this.props.deleteApplicationAsync(appToDelete)
     }

--- a/src/routes/Apps/AppsIndex.tsx
+++ b/src/routes/Apps/AppsIndex.tsx
@@ -19,54 +19,23 @@ import AppsList from './AppsList'
 import { CL_IMPORT_ID } from '../../types/const'
 
 interface ComponentState {
-    selectedApp: AppBase | null
 }
 
 class AppsIndex extends React.Component<Props, ComponentState> {
-    state: ComponentState = {
-        selectedApp: null
-    }
-
-    componentWillMount() {
-        const { history } = this.props
-        if (history.location.pathname !== '/home') {
-            // TODO: There seems to be bug where the router state is not cleared sychronously here
-            // Thus when refreshing on non home page such as entities list for an model, this will force redirect to home
-            // howver, the other component at the entities page still runs component will mount with old router state.
-            // Perhaps we need to use componentDidMount to inspect router state in children?
-            history.replace('/home', null)
-            return
-        }
-    }
-
     updateAppsAndBot() {
         if (this.props.user.id !== null && this.props.user.id.length > 0) {
             this.props.fetchApplicationsAsync(this.props.user.id)
-            this.props.fetchBotInfoAsync(this.props.browserId)
+            this.props.fetchBotInfoThunkAsync(this.props.browserId)
         }
     }
     componentDidMount() {
-        this.updateAppsAndBot();
+        this.updateAppsAndBot()
     }
 
-    componentDidUpdate(prevProps: Props, _prevState: ComponentState) {
+    componentDidUpdate(prevProps: Props, prevState: ComponentState) {
         // TODO: See if this code can be removed. It seems like componentWillMount is called every time the user navigates to /home route
         if (typeof (this.props.user.id) === 'string' && this.props.user.id !== prevProps.user.id) {
-            this.updateAppsAndBot();
-        }
-
-        const { history, location } = this.props
-        const appFromLocationState: AppBase | null = location.state && location.state.app
-        if (appFromLocationState) {
-            const app = this.props.apps.find(a => a.appId === appFromLocationState.appId)
-            if (!app) {
-                console.warn(`Attempted to find selected model in list of models: ${this.state.selectedApp.appId} but it could not be found.`)
-                return
-            }
-
-            if (appFromLocationState !== app) {
-                history.replace(location.pathname, { app })
-            }
+            this.updateAppsAndBot()
         }
     }
 
@@ -113,7 +82,7 @@ class AppsIndex extends React.Component<Props, ComponentState> {
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
         fetchApplicationsAsync: actions.fetch.fetchApplicationsAsync,
-        fetchBotInfoAsync: actions.fetch.fetchBotInfoAsync,
+        fetchBotInfoThunkAsync: actions.fetch.fetchBotInfoThunkAsync,
         createApplicationThunkAsync: actions.create.createApplicationThunkAsync,
         deleteApplicationAsync: actions.delete.deleteApplicationAsync,
         copyApplicationThunkAsync: actions.create.copyApplicationThunkAsync


### PR DESCRIPTION
previously the app would redirect back to /home from /apps/:appId pages