### PR TITLE
fix: handle undefined persisted state

### DIFF
--- a/src/reduxStore.ts
+++ b/src/reduxStore.ts
@@ -13,13 +13,14 @@ import * as localStorage from './services/localStorage'
 import * as ClientFactory from './services/clientFactory'
 
 export const createReduxStore = (): Store<State> => {
-    const persistedState: Partial<State> = localStorage.load()
+    // TODO: The return type of persisted state should include 'undefined'
+    const persistedState = localStorage.load<Partial<State>>()
 
     /**
      * This is a work around to auto reset port to 3978 from 5000
      * and avoid users having to manually resetting
      */
-    const settings = persistedState.settings
+    const settings = persistedState && persistedState.settings
     if (settings) {
         if (settings.botPort === previousBotPort) {
             settings.botPort = defaultBotPort


### PR DESCRIPTION
I had added in the check for resetting default port after the persisted state object had already been created on my machine so I missed this.  Compounded with other issue of this project not having `strictNullChecks` allowed TypeScript to mask that the persistedState was possibly `undefined` even though the `load` function explicitly says it returns `T | undefined`

Fixes #657 