### PR TITLE
fix: include 'I' as tag name to ignore

### DIFF
--- a/src/components/ExtractorResponseEditor/CustomEntity.tsx
+++ b/src/components/ExtractorResponseEditor/CustomEntity.tsx
@@ -27,7 +27,7 @@ export const CustomEntity = (props: Props) => {
             <div className="cl-entity-node-indicator noselect">
                 <div className="cl-entity-node-indicator__mincontent">
                     <div className="cl-entity-node-indicator__controls">
-                        {isEditing &&       
+                        {isEditing &&
                             <IconButton
                                 className="ms-Button--headstone"
                                 iconProps={{ iconName: 'Delete' }}

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -208,7 +208,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
             if (selectionParentElement == null) {
                 console.warn(`selectionParentElement is null or undefined. Value: ${value.document.text}`)
             }
-            else if (selectionParentElement.tagName ===  "BUTTON") {
+            else if (["BUTTON", "I"].includes(selectionParentElement.tagName)) {
                 shouldExpandSelection = false
             }
 


### PR DESCRIPTION
Previously there was only a Button element, but the new button from OF also has an Icon element inside it that seems to confuse the poicker.  Even when clicking on the portion of the button outside the icon it still seems to return the icon element and I'm not sure why, but this will at least mitigate the issue.