### PR TITLE
fix: fetchbotinfo takes appid

### DIFF
--- a/src/actions/fetchActions.ts
+++ b/src/actions/fetchActions.ts
@@ -109,10 +109,11 @@ export const fetchAllLogDialogsFulfilled = (logDialogs: LogDialog[]): ActionObje
 // ----------------------------------------
 // Bot Info
 // ----------------------------------------
-const fetchBotInfoAsync = (browserId: string): ActionObject => {
+const fetchBotInfoAsync = (browserId: string, appId: string): ActionObject => {
     return {
         type: AT.FETCH_BOTINFO_ASYNC,
-        browserId
+        browserId,
+        appId
     }
 }
 
@@ -124,13 +125,13 @@ const fetchBotInfoFulfilled = (botInfo: BotInfo, browserId: string): ActionObjec
     }
 }
 
-export const fetchBotInfoThunkAsync = (browserId: string) => {
+export const fetchBotInfoThunkAsync = (browserId: string, appId: string = null) => {
     return async (dispatch: Dispatch<any>) => {
         const clClient = ClientFactory.getInstance(AT.FETCH_BOTINFO_ASYNC)
-        dispatch(fetchBotInfoAsync(browserId))
+        dispatch(fetchBotInfoAsync(browserId, appId))
 
         try {
-            const botInfo = await clClient.getBotInfo(browserId)
+            const botInfo = await clClient.getBotInfo(browserId, appId)
             dispatch(fetchBotInfoFulfilled(botInfo, browserId))
             return botInfo
         } catch (e) {

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -445,7 +445,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
     }
 
     onClickSyncBotInfo() {
-        this.props.fetchBotInfoThunkAsync(this.props.browserId)
+        this.props.fetchBotInfoThunkAsync(this.props.browserId, this.props.app.appId)
     }
 
     onClickViewCard() {

--- a/src/routes/Apps/App/Dashboard.tsx
+++ b/src/routes/Apps/App/Dashboard.tsx
@@ -26,7 +26,7 @@ class Dashboard extends React.Component<Props, ComponentState> {
     }
 
     onClickRetry = () => {
-        this.props.fetchBotInfoThunkAsync(this.props.browserId)
+        this.props.fetchBotInfoThunkAsync(this.props.browserId, this.props.app.appId)
 
         /**
          * This is here to toggle visibility of text for the screen reader.

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -46,7 +46,7 @@ class Index extends React.Component<Props, ComponentState> {
     async loadApp(app: AppBase, packageId: string): Promise<void> {
         this.setState({ packageId: packageId})
 
-        await this.props.fetchBotInfoThunkAsync(this.props.browserId)
+        await this.props.fetchBotInfoThunkAsync(this.props.browserId, app.appId)
 
         this.props.setCurrentApp(this.props.user.id, app)
         this.props.fetchAllLogDialogsAsync(this.props.user.id, app, packageId) // Note: a separate call as eventually we want to page

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -90,9 +90,9 @@ export default class ClClient {
     }
 
     // Each browser instance has a different browserId
-    getBotInfo(browserId: string): Promise<models.BotInfo> {
+    getBotInfo(browserId: string, appId: string | null): Promise<models.BotInfo> {
         return this.send<models.BotInfo>({
-            url: `${this.baseUrl}/bot?browserId=${browserId}`
+            url: `${this.baseUrl}/bot?browserId=${browserId}${appId ? `&appId=${appId}` : ''}`
         })
             .then(response => response.data)
     }

--- a/src/types/ActionObject.ts
+++ b/src/types/ActionObject.ts
@@ -131,7 +131,8 @@ export type FetchAction = {
     userId: string
 } | {
     type: AT.FETCH_BOTINFO_ASYNC,
-    browserId: string
+    browserId: string,
+    appId: string
 } | {
     type: AT.FETCH_BOTINFO_FULFILLED,
     botInfo: BotInfo,


### PR DESCRIPTION
Required for multi-model application to support loading right APIs