### PR TITLE
 fix: ability to view and edit train rounds

### DIFF
--- a/src/actions/teachActions.ts
+++ b/src/actions/teachActions.ts
@@ -266,13 +266,13 @@ export const runExtractorThunkAsync = (key: string, appId: string, extractType: 
                     uiExtractResponse = await clClient.teachSessionsAddExtractStep(appId, sessionId, userInput)
                   break;
                 case models.DialogType.TRAINDIALOG:
-                    if (!turnIndex) {
+                    if (turnIndex === null) {
                         throw new Error(`Run extractor was called for a train dialog, but turnIndex was null. This should not be possible. Please open an issue.`)
                     }
                     uiExtractResponse = await clClient.trainDialogsUpdateExtractStep(appId, sessionId, turnIndex, userInput)
                   break;
                 case models.DialogType.LOGDIALOG:
-                    if (!turnIndex) {
+                    if (turnIndex === null) {
                         throw new Error(`Run extractor was called for a log dialog, but turnIndex was null. This should not be possible. Please open an issue.`)
                     }
                     uiExtractResponse = await clClient.logDialogsUpdateExtractStep(appId, sessionId, turnIndex, userInput)

--- a/src/actions/teachActions.ts
+++ b/src/actions/teachActions.ts
@@ -49,14 +49,13 @@ const createTeachSessionFulfilled = (teachResponse: models.TeachResponse): Actio
 // --------------------------
 // TeachSessionFromHistory
 // --------------------------
-export const createTeachSessionFromHistoryThunkAsync = (app: models.AppBase, trainDialog: models.TrainDialog, userName: string, userId: string, scoreInput: models.UIScoreInput | null = null) => {
+export const createTeachSessionFromHistoryThunkAsync = (app: models.AppBase, trainDialog: models.TrainDialog, userName: string, userId: string, extractChanged: boolean = false) => {
     return async (dispatch: Dispatch<any>) => {
         const clClient = ClientFactory.getInstance(AT.CREATE_TEACH_SESSION_FROMHISTORYASYNC)
         dispatch(createTeachSessionFromHistoryAsync(app.appId, trainDialog, userName, userId))
 
         try {
-            const extractChanged = scoreInput !== null;
-            const teachWithHistory = await clClient.teachSessionFromHistory(app.appId, trainDialog, userName, userId, extractChanged);
+            const teachWithHistory = await clClient.teachSessionFromHistory(app.appId, trainDialog, userName, userId, extractChanged)
             dispatch(createTeachSessionFromHistoryFulfilled(teachWithHistory))
             return teachWithHistory
         }

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -285,7 +285,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
             return
         }
 
-        if (!this.props.roundIndex) {
+        if (this.props.roundIndex === null) {
             throw new Error(`You attempted to submit text variation but roundIndex was null. This is likely a problem with the code. Please open an issue.`)
         }
 

--- a/src/components/modals/LogDialogAdmin.tsx
+++ b/src/components/modals/LogDialogAdmin.tsx
@@ -152,12 +152,12 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
         delete trainScorerStep.scoredAction;
 
         const roundIndex = this.state.roundIndex
-        if (!roundIndex) {
+        if (roundIndex === null) {
             throw new Error(`You selected an action, but roundIndex is not known. This should not be possible. Contact Support`)
         }
 
         const scoreIndex = this.state.scoreIndex
-        if (!scoreIndex) {
+        if (scoreIndex === null) {
             throw new Error(`You selected an action, but scoreIndex is not known. This should not be possible. Contact Support`)
         }
 
@@ -202,7 +202,7 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
 
     getPrevMemories(): Memory[] {
         const roundIndex = this.state.roundIndex
-        if (!roundIndex) {
+        if (roundIndex === null) {
             throw new Error(`You attempted to get previous memories, but roundIndex is not known. This should not be possible. Contact Support`)
         }
 
@@ -239,12 +239,12 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
         const { logDialog, selectedActivity } = this.props
         if (logDialog && selectedActivity) {
             const roundIndex = this.state.roundIndex
-            if (!roundIndex) {
+            if (roundIndex === null) {
                 throw new Error(`Activity is selected during rendering, but roundIndex is not known. This should not be possible. Contact Support`)
             }
 
             const scoreIndex = this.state.scoreIndex
-            if (!scoreIndex) {
+            if (scoreIndex === null) {
                 throw new Error(`Activity is selected during rendering, but scoreIndex is not known. This should not be possible. Contact Support`)
             }
 
@@ -301,7 +301,7 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
                     <div className="cl-dialog-admin__content">
                         <div className="cl-dialog-admin-title">Entity Detection</div>
                         <div>
-                            {this.state.roundIndex && round &&
+                            {this.state.roundIndex !== null && round &&
                                 <EntityExtractor
                                     app={this.props.app}
                                     editingPackageId={this.props.editingPackageId}

--- a/src/components/modals/LogDialogAdmin.tsx
+++ b/src/components/modals/LogDialogAdmin.tsx
@@ -79,10 +79,6 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
             throw new Error(`You confirmed conversion of log dialog to train dialog, but there was no log dialog to convert. This should not be possible. Contact Support`)
         }
 
-        if (!this.state.newScoreInput) {
-            throw new Error(`You confirmed conversion of log dialog to train dialog, but there was no new score input. This should not be possible. Contact Support`)
-        }
-
         // TODO: Update @models to allow defining TrainDialogInput without undefined properties
         const newTrainDialog: TrainDialog = {
             trainDialogId: undefined!,
@@ -98,7 +94,8 @@ class LogDialogAdmin extends React.Component<Props, ComponentState> {
             }
         }
 
-        this.props.onEdit(this.props.logDialog.logDialogId, newTrainDialog, this.state.newScoreInput);
+        const extractChanged = this.state.newScoreInput !== null
+        this.props.onEdit(this.props.logDialog.logDialogId, newTrainDialog, extractChanged)
         this.setState({ 
             newTrainDialog: null,
             newScoreInput: null
@@ -387,7 +384,7 @@ export interface ReceivedProps {
     logDialog: LogDialog
     selectedActivity: Activity | null,
     canEdit: boolean,
-    onEdit: (logDialogId: string, newTrainDialog: TrainDialog, newScoreInput: UIScoreInput) => void
+    onEdit: (logDialogId: string, newTrainDialog: TrainDialog, extractChanged: boolean) => void
     onExtractionsChanged: (changed: boolean) => void
 }
 

--- a/src/components/modals/LogDialogModal.tsx
+++ b/src/components/modals/LogDialogModal.tsx
@@ -14,7 +14,7 @@ import ConfirmCancelModal from './ConfirmCancelModal'
 import LogDialogAdmin from './LogDialogAdmin'
 import { Activity } from 'botframework-directlinejs'
 import actions from '../../actions'
-import { AppBase, TrainDialog, LogDialog, UIScoreInput } from '@conversationlearner/models'
+import { AppBase, TrainDialog, LogDialog } from '@conversationlearner/models'
 import { FM } from '../../react-intl-messages'
 import { injectIntl, InjectedIntlProps } from 'react-intl'
 
@@ -110,7 +110,7 @@ class LogDialogModal extends React.Component<Props, ComponentState> {
                                         canEdit={this.props.canEdit}
                                         logDialog={this.props.logDialog}
                                         selectedActivity={this.state.selectedActivity}
-                                        onEdit={(logDialogId: string, newTrainDialog: TrainDialog, newScoreInput: UIScoreInput) => this.props.onEdit(logDialogId, newTrainDialog, newScoreInput)}
+                                        onEdit={(logDialogId, newTrainDialog, extractChanged) => this.props.onEdit(logDialogId, newTrainDialog, extractChanged)}
                                         onExtractionsChanged={(changed: boolean) => this.onExtractionsChanged(changed)}
                                     />
                                 </div>
@@ -185,7 +185,7 @@ export interface ReceivedProps {
     open: boolean,
     canEdit: boolean,
     onClose: () => void,
-    onEdit: (logDialogId: string, newTrainDialog: TrainDialog, newScoreInput: UIScoreInput) => void,
+    onEdit: (logDialogId: string, newTrainDialog: TrainDialog, extractChanged: boolean) => void,
     onDelete: ()=> void,
     logDialog: LogDialog,
     history: Activity[]

--- a/src/components/modals/TrainDialogAdmin.tsx
+++ b/src/components/modals/TrainDialogAdmin.tsx
@@ -176,11 +176,8 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
                 newScoreInput: null
             });
         } else {
-            if (!this.state.newScoreInput) {
-                throw new Error(`Attempted to edit a train dialog, but the newScoreInput was not defined. This is likely a problem with code. Please file an issue.`)
-            }
-            
-            this.editTrainDialog(updatedTrainDialog, roundIndex, this.state.newScoreInput);
+            const extractChanged = this.state.newScoreInput !== null
+            this.editTrainDialog(updatedTrainDialog, roundIndex, extractChanged)
         }
     }
 
@@ -188,14 +185,12 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
         if (!this.state.newTrainDialog) {
             throw new Error(`Attempted to edit a train dialog, but the newTrainDialog was not defined. This is likely a problem with code. Please file an issue.`)
         }
-        if (!this.state.newScoreInput) {
-            throw new Error(`Attempted to edit a train dialog, but the newScoreInput was not defined. This is likely a problem with code. Please file an issue.`)
-        }
 
-        this.editTrainDialog(this.state.newTrainDialog, this.state.newSliceRound, this.state.newScoreInput);
+        const extractChanged = this.state.newScoreInput !== null
+        this.editTrainDialog(this.state.newTrainDialog, this.state.newSliceRound, extractChanged)
     }
 
-    editTrainDialog(sourceDialog: TrainDialog, sliceRound: number, newScoreInput: UIScoreInput) {
+    editTrainDialog(sourceDialog: TrainDialog, sliceRound: number, extractChanged: boolean) {
         let trainDialog: TrainDialog = {
             trainDialogId: undefined!,
             sourceLogDialogId: sourceDialog.sourceLogDialogId,
@@ -210,7 +205,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
             }
         }
 
-        this.props.onEdit(sourceDialog.trainDialogId, trainDialog, newScoreInput);
+        this.props.onEdit(sourceDialog.trainDialogId, trainDialog, extractChanged);
          
         this.props.clearExtractResponses();
 
@@ -554,7 +549,7 @@ export interface ReceivedProps {
     trainDialog: TrainDialog,
     selectedActivity: Activity | null,
     canEdit: boolean,
-    onEdit: (sourceTrainDialogId: string, editedTrainDialog: TrainDialog, newScoreInput: UIScoreInput) => void
+    onEdit: (sourceTrainDialogId: string, editedTrainDialog: TrainDialog, extractChanged: boolean) => void
     onReplace: (editedTrainDialog: TrainDialog) => void
     onExtractionsChanged: (changed: boolean) => void
 }

--- a/src/components/modals/TrainDialogAdmin.tsx
+++ b/src/components/modals/TrainDialogAdmin.tsx
@@ -137,12 +137,12 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
     // User changed the selected action for a round
     onActionScorerSubmit(trainScorerStep: TrainScorerStep): void {
         const roundIndex = this.state.roundIndex
-        if (!roundIndex) {
+        if (roundIndex === null) {
             throw new Error(`Cannot construct new train dialog scorer step because roundIndex is null. This is likely a problem in the code. Please open an issue.`)
         }
 
         const scoreIndex = this.state.scoreIndex
-        if (!scoreIndex) {
+        if (scoreIndex === null) {
             throw new Error(`Cannot construct new train dialog scorer step because scoreIndex is null. This is likely a problem in the code. Please open an issue.`)
         }
 
@@ -228,7 +228,7 @@ class TrainDialogAdmin extends React.Component<Props, ComponentState> {
         this.props.clearExtractResponses();
     }
     getPrevMemories(): Memory[] {
-        if (!this.state.roundIndex) {
+        if (this.state.roundIndex === null) {
             throw new Error(`Cannot get previous memories because roundIndex is null. This is likely a problem with code. Please open an issue.`)
         }
 

--- a/src/components/modals/TrainDialogModal.tsx
+++ b/src/components/modals/TrainDialogModal.tsx
@@ -11,7 +11,7 @@ import { Modal } from 'office-ui-fabric-react/lib/Modal';
 import { State } from '../../types';
 import Webchat from '../Webchat'
 import TrainDialogAdmin from './TrainDialogAdmin'
-import { AppBase, TrainDialog, UIScoreInput, SenderType } from '@conversationlearner/models'
+import { AppBase, TrainDialog, SenderType } from '@conversationlearner/models'
 import { Activity } from 'botframework-directlinejs';
 import ConfirmCancelModal from './ConfirmCancelModal'
 import { FM } from '../../react-intl-messages'
@@ -146,7 +146,7 @@ class TrainDialogModal extends React.Component<Props, ComponentState> {
                                     canEdit={this.props.canEdit}
                                     trainDialog={this.props.trainDialog}
                                     selectedActivity={this.state.selectedActivity}
-                                    onEdit={(sourceTrainDialogId: string, editedTrainDialog: TrainDialog, newScoreInput: UIScoreInput) => this.props.onEdit(editedTrainDialog, newScoreInput)}
+                                    onEdit={(sourceTrainDialogId, editedTrainDialog, extractChanged) => this.props.onEdit(editedTrainDialog, extractChanged)}
                                     onReplace={(editedTrainDialog: TrainDialog) => this.props.onReplace(editedTrainDialog)}
                                     onExtractionsChanged={(changed: boolean) => this.onExtractionsChanged(changed)}
                                 />
@@ -258,7 +258,7 @@ export interface ReceivedProps {
     canEdit: boolean,
     onClose: () => void,
     onBranch: (turnIndex: number) => void,
-    onEdit: (newTrainDialog: TrainDialog, newScoreInput: UIScoreInput) => void,
+    onEdit: (newTrainDialog: TrainDialog, extractChanged: boolean) => void,
     onReplace: (newTrainDialog: TrainDialog) => void,
     onDelete: () => void
     open: boolean

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -8,7 +8,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as OF from 'office-ui-fabric-react';
 import { State } from '../../../types'
-import { AppBase, LogDialog, Session, ModelUtils, Teach, TeachWithHistory, TrainDialog, ActionBase, ReplayError, UIScoreInput } from '@conversationlearner/models'
+import { AppBase, LogDialog, Session, ModelUtils, Teach, TeachWithHistory, TrainDialog, ActionBase, ReplayError } from '@conversationlearner/models'
 import { ChatSessionModal, LogDialogModal, TeachSessionModal } from '../../../components/modals'
 import actions from '../../../actions'
 import { injectIntl, InjectedIntl, InjectedIntlProps, FormattedMessage } from 'react-intl'
@@ -363,10 +363,10 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         this.onCloseLogDialogModal();
     }
 
-    onEditLogDialog(logDialogId: string, newTrainDialog: TrainDialog, newScoreInput: UIScoreInput) {
+    onEditLogDialog(logDialogId: string, newTrainDialog: TrainDialog, extractChanged: boolean) {
 
         // Create a new teach session from the train dialog
-        ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, newScoreInput) as any) as Promise<TeachWithHistory>)
+        ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, extractChanged) as any) as Promise<TeachWithHistory>)
             .then(teachWithHistory => {
                 if (teachWithHistory.replayErrors.length === 0) {
                     // Note: Don't clear currentLogDialog so I can update it if I save my edits
@@ -592,7 +592,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                     open={this.state.isLogDialogWindowOpen}
                     canEdit={this.props.editingPackageId === this.props.app.devPackageId && !this.props.invalidBot}
                     onClose={this.onCloseLogDialogModal}
-                    onEdit={(logDialogId: string, newTrainDialog: TrainDialog, newScoreInput: UIScoreInput) => this.onEditLogDialog(logDialogId, newTrainDialog, newScoreInput)}
+                    onEdit={(logDialogId, newTrainDialog, extractChanged) => this.onEditLogDialog(logDialogId, newTrainDialog, extractChanged)}
                     onDelete={this.onDeleteLogDialog}
                     logDialog={currentLogDialog!}
                     history={this.state.history}

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -8,7 +8,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as OF from 'office-ui-fabric-react';
 import { State } from '../../../types'
-import { AppBase, Teach, TrainDialog, TeachWithHistory, ActionBase, EntityBase, TeachResponse, ReplayError, UIScoreInput } from '@conversationlearner/models'
+import { AppBase, Teach, TrainDialog, TeachWithHistory, ActionBase, EntityBase, TeachResponse, ReplayError } from '@conversationlearner/models'
 import { TeachSessionModal, TrainDialogModal } from '../../../components/modals'
 import actions from '../../../actions'
 import { Icon } from 'office-ui-fabric-react/lib/Icon'
@@ -442,9 +442,9 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             })
     }
 
-    onEditTrainDialog(newTrainDialog: TrainDialog, newScoreInput: UIScoreInput) {
+    onEditTrainDialog(newTrainDialog: TrainDialog, extractChanged: boolean) {
 
-        ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, newScoreInput) as any) as Promise<TeachWithHistory>)
+        ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, extractChanged) as any) as Promise<TeachWithHistory>)
             .then(teachWithHistory => {
                 if (teachWithHistory.replayErrors.length === 0) {
                     // Note: Don't clear currentTrainDialog so I can delete it if I save my edits
@@ -750,10 +750,10 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                     canEdit={this.props.editingPackageId === this.props.app.devPackageId && !this.props.invalidBot}
                     open={this.state.isTrainDialogModalOpen}
                     onClose={() => this.onCloseTrainDialogModal()}
-                    onBranch={(turnIndex: number) => this.onBranchTrainDialog(turnIndex)}
+                    onBranch={(turnIndex) => this.onBranchTrainDialog(turnIndex)}
                     onDelete={() => this.onDeleteTrainDialog()}
-                    onEdit={(editedTrainDialog: TrainDialog, newScoreInput: UIScoreInput) => this.onEditTrainDialog(editedTrainDialog, newScoreInput)}
-                    onReplace={(editedTrainDialog: TrainDialog) => this.onReplaceTrainDialog(editedTrainDialog)}
+                    onEdit={(editedTrainDialog, extractChanged) => this.onEditTrainDialog(editedTrainDialog, extractChanged)}
+                    onReplace={(editedTrainDialog) => this.onReplaceTrainDialog(editedTrainDialog)}
                     trainDialog={currentTrainDialog!}
                     history={this.state.history}
                 />


### PR DESCRIPTION
I wonder why newScoreInput was sent, but I think it's better to not have null going through so many layers.  From admin, modal, then list page, then to action only to be evaluated based on non-null