### PR TITLE
 fix: add ability to remove poll after deleting app

### DIFF
--- a/src/actions/appActions.ts
+++ b/src/actions/appActions.ts
@@ -263,6 +263,7 @@ export const deleteApplicationThunkAsync = (appId: string) => {
 
         try {
             await clClient.appsDelete(appId)
+            poller.removePoll(appId)
             dispatch(deleteApplicationFulfilled(appId))
             return true;
         } catch (e) {

--- a/src/services/poller.test.ts
+++ b/src/services/poller.test.ts
@@ -145,4 +145,30 @@ describe('Poller', () => {
         
         expect(after - now).toBeGreaterThanOrEqual(400)
     })
+
+    test('poll removePoll should remove from list of polls preventing further polling', async () => {
+        const requestMock = jest.fn(async () => {
+            return 0
+        })
+        const isResolvedMock = jest.fn(n => false)
+        const onExpiredMock = jest.fn()
+        const onUpdateMock = jest.fn(trainingStatus => {
+        })
+        const pollConfig: poller.IPollConfig<number> = {
+            id: 'pc1',
+            maxDuration: 500,
+            request: requestMock,
+            isResolved: isResolvedMock,
+            onExpired: onExpiredMock,
+            onUpdate: onUpdateMock
+        }
+
+        const poller1 = new poller.Poller({ interval: 100 })
+        poller1.addPoll(pollConfig)
+        poller1.removePoll(pollConfig.id)
+
+        expect(requestMock.mock.calls.length).toBe(0)
+        expect(isResolvedMock.mock.calls.length).toBe(0)
+        expect(onUpdateMock.mock.calls.length).toBe(0)
+    })
 })

--- a/src/services/poller.ts
+++ b/src/services/poller.ts
@@ -64,6 +64,10 @@ export class Poller {
         return promise
     }
 
+    removePoll(pollId: string) {
+        this.polls = this.polls.filter(p => p.id !== pollId)
+    }
+
     private async poll() {
         const now = (new Date()).getTime()
         // Alternate approach is to split this into three phases: Filter those expired, await all requests, then filter all resolved.


### PR DESCRIPTION
If you trigger training and then delete an app, it would have still polled until the timeout and each request would fail since that app no longer exists. This will now remove / stop the polling after successful deletion.