### PR TITLE
fix: misc bugs

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -66,7 +66,7 @@ html {
 }
 
 .cl-errorpanel {
-  background-color: #FDE7E9;
+  background-color: var(--color-errorBackground);
   padding: 5px
 }
 

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -43,12 +43,20 @@ function getColumns(intl: InjectedIntl, hideScore: boolean): IRenderableColumn[]
             isResizable: true,
             getSortValue: action => action.actionId,
             render: (action, component, index) => {
-                if (!component.props.canEdit) {
-                    return null
-                }
 
                 const selected = (component.props.dialogType !== DialogType.TEACH && index === 0)
                 const buttonText = selected ? 'Selected' : 'Select'
+                if (!component.props.canEdit) {
+                    return (
+                        <PrimaryButton
+                            data-testid="actionscorer-buttonNoClick"
+                            disabled={true}
+                            ariaDescription={buttonText}
+                            text={buttonText}
+                        />
+                    )
+                }
+
                 const isAvailable = component.isUnscoredActionAvailable(action as UnscoredAction)
                 if (!isAvailable || selected) {
                     return (

--- a/src/components/modals/EditDialogAdmin.tsx
+++ b/src/components/modals/EditDialogAdmin.tsx
@@ -16,7 +16,7 @@ import { Activity } from 'botframework-directlinejs'
 import * as OF from 'office-ui-fabric-react';
 import * as CLM from '@conversationlearner/models' 
 import { FM } from '../../react-intl-messages'
-import { EditDialogType } from '.'
+import { EditDialogType, EditState } from '.'
 import { injectIntl, InjectedIntlProps, FormattedMessage } from 'react-intl'
 
 interface RenderData {
@@ -236,16 +236,17 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
         if (!this.props.trainDialog) {
             return null;
         }
+        const isLogDialog = (this.props.editType === EditDialogType.LOG_EDITED || this.props.editType === EditDialogType.LOG_ORIGINAL)
+        const editTypeClass = isLogDialog ? 'log' : 'train'
 
-        const editTypeClass = this.props.editType === EditDialogType.LOG ? 'log' : 'train'
         let renderData = this.getRenderData();
         return (
             <div className={`cl-dialog-admin ${OF.FontClassNames.large}`}>
                 <div data-testid="traindialog-title" className={`cl-dialog-title cl-dialog-title--${editTypeClass} ${OF.FontClassNames.xxLarge}`}>
                     <OF.Icon 
-                        iconName={this.props.editType === EditDialogType.LOG ? 'UserFollowed' : 'EditContact'}
+                        iconName={isLogDialog ? 'UserFollowed' : 'EditContact'}
                     />
-                    {this.props.editType === EditDialogType.LOG ? 'Log Dialog' : 'Train Dialog'}
+                    {isLogDialog ? 'Log Dialog' : 'Train Dialog'}
                 </div>
                 {this.props.selectedActivity && (this.state.senderType === CLM.SenderType.User
                     ? (
@@ -324,8 +325,8 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
                                     data-testid="dialog-admin-entity-extractor"
                                     app={this.props.app}
                                     editingPackageId={this.props.editingPackageId}
-                                    canEdit={this.props.canEdit} 
-                                    extractType={this.props.editType === EditDialogType.LOG
+                                    canEdit={this.props.editState === EditState.CAN_EDIT} 
+                                    extractType={isLogDialog
                                         ? CLM.DialogType.LOGDIALOG
                                         : CLM.DialogType.TRAINDIALOG}
                                     sessionId={this.props.editingLogDialog
@@ -366,8 +367,8 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
                                 data-testid="dialog-admin-scorer"
                                 app={this.props.app}
                                 editingPackageId={this.props.editingPackageId}
-                                canEdit={this.props.canEdit}
-                                hideScore={true}
+                                canEdit={this.props.editState === EditState.CAN_EDIT}
+                                hideScore={false}  // LARS
                                 dialogType={CLM.DialogType.TRAINDIALOG}
                                 sessionId={this.props.trainDialog.trainDialogId}
                                 autoTeach={false}
@@ -411,7 +412,7 @@ export interface ReceivedProps {
     // If editing a log dialog, this was the source
     editingLogDialog: CLM.LogDialog | null
     selectedActivity: Activity | null,
-    canEdit: boolean,
+    editState: EditState,
     editType: EditDialogType,
     onChangeAction: (trainScorerStep: CLM.TrainScorerStep) => void,
     onChangeExtraction: (extractResponse: CLM.ExtractResponse, textVariations: CLM.TextVariation[]) => void                              

--- a/src/components/modals/TeachSessionAdmin.tsx
+++ b/src/components/modals/TeachSessionAdmin.tsx
@@ -145,16 +145,17 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
 
         const renderData = this.getRenderData()
         const mode = this.props.teachSession.mode
-        const autoTeachWithRound = this.props.teachSession.autoTeach 
-        const editTypeClass = this.props.editType === EditDialogType.LOG ? 'log' : 'train'
+        const autoTeachWithRound = this.props.teachSession.autoTeach
+        const isLogDialog = (this.props.editType === EditDialogType.LOG_EDITED || this.props.editType === EditDialogType.LOG_ORIGINAL) 
+        const editTypeClass = isLogDialog ? 'log' : 'train'
         
         return (
             <div className={`cl-dialog-admin ${FontClassNames.large}`}>
                 <div className={`cl-dialog-title cl-dialog-title--${editTypeClass} ${FontClassNames.xxLarge}`}>
                     <Icon 
-                        iconName={this.props.editType === EditDialogType.LOG ? 'UserFollowed' : 'EditContact'}
+                        iconName={isLogDialog ? 'UserFollowed' : 'EditContact'}
                     />
-                    {this.props.editType === EditDialogType.LOG ? 'Log Dialog' : 'Train Dialog'}
+                    {isLogDialog ? 'Log Dialog' : 'Train Dialog'}
                 </div>
                 {this.props.teachSession.mode === CLM.DialogMode.Extractor && (
                     <div className="cl-dialog-admin__content">

--- a/src/components/modals/TeachSessionModal.tsx
+++ b/src/components/modals/TeachSessionModal.tsx
@@ -245,7 +245,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
             })
         }
         // Editing a Log Dialog
-        else if (this.props.editType === EditDialogType.LOG) {
+        else if (this.props.editType === EditDialogType.LOG_EDITED) {
             return intl.formatMessage({
                 id: FM.BUTTON_SAVE_AS_TRAIN_DIALOG,
                 defaultMessage: 'Save as Train Dialog'

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -15,11 +15,22 @@ import ErrorPanel from './ErrorPanel'
 import SpinnerWindow from './SpinnerWindow'
 import Expando from './Expando'
 
+// What is being edited
 export enum EditDialogType {
     NEW = 'NEW',
     TRAIN_EDITED = 'TRAIN_EDITED',
     TRAIN_ORIGINAL = 'TRAIN_ORIGINAL',
-    LOG = 'LOG'
+    LOG_EDITED = 'LOG_EDITED',
+    LOG_ORIGINAL = 'LOG_ORIGINAL',
+}
+
+// What is being edited
+export enum EditState {
+    CAN_EDIT = 'CAN_EDIT',
+    // Runing bot not compatible with Model
+    INVALID_BOT = 'INVALID_BOT',
+    // Attemping to edit older package id
+    INVALID_PACKAGE = 'INVALID_PACKAGE'
 }
 
 export {

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -121,8 +121,8 @@ export enum FM {
     BUTTON_ABANDON = 'Button.ABANDON',
     BUTTON_ABANDON_EDIT = 'Button.ABANDON_EDIT',
     BUTTON_CANCEL = 'Button.CANCEL',
+    BUTTON_CLOSE = 'Button.CLOSE',
     BUTTON_DELETE = 'Button.DELETE',
-    BUTTON_DONE = 'Button.DONE',
     BUTTON_INFO = 'Button.INFO',
     BUTTON_IMPORT = 'Button.IMPORT',
     BUTTON_OK = 'Button.OK',
@@ -412,9 +412,12 @@ export enum FM {
     EDITDIALOGMODAL_BRANCH_ARIADESCRIPTION = 'EditDialogModal.branch.ariaDescription',
     EDITDIALOGMODAL_BRANCH_TEXT = 'EditDialogModal.branch.text',
     EDITDIALOGMODAL_BRANCH_TIP = 'EditDialogModal.branch.tip',
-    EDITDIALOGMODAL_CONFIRMDELETE_TITLE = 'EditDialogModal.confirmDelete.title',
+    EDITDIALOGMODAL_CONFIRMDELETELOG_TITLE = 'EditDialogModal.confirmDeleteLog.title',
+    EDITDIALOGMODAL_CONFIRMDELETETRAIN_TITLE = 'EditDialogModal.confirmDeleteTrain.title',
     EDITDIALOGMODAL_CONFIRMABANDON_NEW_TITLE = 'EditDialogModal.confirmAbandonNew.title',
     EDITDIALOGMODAL_CONFIRMABANDON_EDIT_TITLE = 'EditDialogModal.confirmAbandonEdit.title',
+    EDITDIALOGMODAL_WARNING_INVALID_BOT = 'EditDialogModal.warningInvalidBot.title',
+    EDITDIALOGMODAL_WARNING_INVALID_PACKAGE = 'EditDialogModal.warningInvalidPackage.title',
 
     // Train Dialogs
     TRAINDIALOGS_TITLE = 'TrainDialogs.title',
@@ -560,7 +563,7 @@ export default {
         [FM.BUTTON_ABANDON]: 'Abandon',
         [FM.BUTTON_ABANDON_EDIT]: 'Abandon Edit',
         [FM.BUTTON_CANCEL]: 'Cancel',
-        [FM.BUTTON_DONE]: 'Done',
+        [FM.BUTTON_CLOSE]: 'Close',
         [FM.BUTTON_DELETE]: 'Delete',
         [FM.BUTTON_IMPORT]: 'Import',
         [FM.BUTTON_INFO]: 'Info',
@@ -882,10 +885,13 @@ export default {
         [FM.EDITDIALOGMODAL_BRANCH_ARIADESCRIPTION]: 'Branch',
         [FM.EDITDIALOGMODAL_BRANCH_TEXT]: 'Branch',
         [FM.EDITDIALOGMODAL_BRANCH_TIP] : 'First select a round in the conversation by clicking on it.  Then click "Branch" to create a new Training Dialog starting at that round.',
-        [FM.EDITDIALOGMODAL_CONFIRMDELETE_TITLE]: 'Are you sure you want to delete this Training Dialog?',
+        [FM.EDITDIALOGMODAL_CONFIRMDELETELOG_TITLE]: 'Are you sure you want to delete this Log Dialog?',
+        [FM.EDITDIALOGMODAL_CONFIRMDELETETRAIN_TITLE]: 'Are you sure you want to delete this Training Dialog?',
         [FM.EDITDIALOGMODAL_CONFIRMABANDON_NEW_TITLE]: 'Are you sure you want to abandon this Training Dialog?',
         [FM.EDITDIALOGMODAL_CONFIRMABANDON_EDIT_TITLE]: 'Are you sure you want to abandon your edits?',
-        
+        [FM.EDITDIALOGMODAL_WARNING_INVALID_BOT]: 'Running Bot not compatible with this Model',
+        [FM.EDITDIALOGMODAL_WARNING_INVALID_PACKAGE]: 'Editing only permitted on the Master tag',
+             
         // UserInput Modal
         [FM.USERINPUT_TITLE]: 'Add User Input',
         [FM.USERINPUT_PLACEHOLDER]: 'User Input...',

--- a/src/routes/App.css
+++ b/src/routes/App.css
@@ -160,9 +160,16 @@
     padding-bottom: 10px;
 }
 
-.cl-dialogwarning {
+.cl-editdialog-error {
     background-color: var(--color-error);
     color: white;
+    border-radius: 15px;
+    padding: 10px;
+}
+
+.cl-editdialog-warning {
+    background-color: var(--color-errorBackground);
+    color: black;
     border-radius: 15px;
     padding: 10px;
 }

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import * as OF from 'office-ui-fabric-react';
 import { State } from '../../../types'
 import * as CLM from '@conversationlearner/models'
-import { TeachSessionModal, EditDialogModal, EditDialogType } from '../../../components/modals'
+import { TeachSessionModal, EditDialogModal, EditDialogType, EditState } from '../../../components/modals'
 import actions from '../../../actions'
 import { Icon } from 'office-ui-fabric-react/lib/Icon'
 import { injectIntl, InjectedIntl, InjectedIntlProps, FormattedMessage } from 'react-intl'
@@ -569,7 +569,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     async onReplaceTrainDialog(newTrainDialog: CLM.TrainDialog, isInvalid: boolean) {
 
         newTrainDialog.invalid = isInvalid
-
+        newTrainDialog.definitions = null
         try { 
             await ((this.props.editTrainDialogThunkAsync(this.props.app.appId, newTrainDialog) as any) as Promise<CLM.TeachWithHistory>);
         }
@@ -742,6 +742,12 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     render() {
         const { intl, trainDialogs } = this.props
         const computedTrainDialogs = this.getFilteredAndSortedDialogs()
+        const editState = (this.props.editingPackageId !== this.props.app.devPackageId) 
+            ? EditState.INVALID_PACKAGE 
+            : this.props.invalidBot
+            ? EditState.INVALID_BOT
+            : EditState.CAN_EDIT
+
         return (
             <div className="cl-page">
                 <div data-testid="train-dialogs-title" className={`cl-dialog-title cl-dialog-title--train ${OF.FontClassNames.xxLarge}`}>
@@ -879,7 +885,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                     data-testid="train-dialog-modal"
                     app={this.props.app}
                     editingPackageId={this.props.editingPackageId}
-                    canEdit={this.props.editingPackageId === this.props.app.devPackageId && !this.props.invalidBot}
+                    editState={editState}
                     open={this.state.isEditDialogModalOpen}
                     trainDialog={this.state.currentTrainDialog!}
                     editingLogDialog={null}

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -336,7 +336,7 @@ export default class ClClient {
             data: trainDialog
         })
         .then(response => {
-            trainDialog.trainDialogId = response.data
+            trainDialog.trainDialogId = response.data.trainDialogId 
             return trainDialog
         })
     }


### PR DESCRIPTION
Can't add action to last user input at bottom

Log dialog before edit - abandon button should be delete

Add delete button to logdialogs when not edit

Can save as train dialog when running wrong bot.  Shouldn't be allowed

Failed to delete train dialog right after converting from log

Disable turn editing when can't edit