### PR TITLE
feat: Edit polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -425,9 +425,9 @@
       "integrity": "sha512-m7bWleKFz+pTQMIwPTE2xttWjsYvbHGq0MTeZnUCfEpqDS2Rg1jpDyLOFyWqCx6BQhbfn1LD4tUUnkoi1wM8Hg=="
     },
     "@conversationlearner/webchat": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/webchat/-/webchat-0.136.0.tgz",
-      "integrity": "sha512-lppT9o/YBlvq5fGuLftGWuRBXIey+8DWglnV6nS4QoIvg1ZTFPwyebpQCnoyV9gRxK//DaEJ7oo5lrZVFFaysQ==",
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/webchat/-/webchat-0.137.0.tgz",
+      "integrity": "sha512-FvS9OtGpzOk6NPrO2S6y+KMICkfyg8j7DL+wSMBh1vL6V+W3GxXA4Mv+1M5D1Iz3d3dp+IAT2uCrO5w09UAkew==",
       "requires": {
         "botframework-directlinejs": "^0.9.12",
         "core-js": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "private": true,
   "dependencies": {
     "@conversationlearner/models": "0.173.0",
-    "@conversationlearner/webchat": "0.136.0",
+    "@conversationlearner/webchat": "0.137.0",
     "@types/file-saver": "^1.3.0",
     "@types/uuid": "^3.4.4",
     "adaptivecards": "1.0.0",

--- a/public/botchat.css
+++ b/public/botchat.css
@@ -173,8 +173,9 @@ body .wc-app, .wc-app button, .wc-app input, .wc-app textarea {
   cursor: pointer; }
 
 .wc-message-selected {
-  border: 2px solid #FFFF00;
-  background-color: #ffffcc;
+  background-color: #ffeeee;
+  outline: 1px solid #ffaaaa;
+  outline-offset: 2px;
 }
 
 .wc-message-content img {
@@ -435,7 +436,7 @@ body .wc-app, .wc-app button, .wc-app input, .wc-app textarea {
 }
 
 .wc-message-downarrow-points-red {
-  fill: #ce2e2e;
+  fill: #ffd2d2;
 }
 
 /* console */

--- a/public/index.css
+++ b/public/index.css
@@ -269,47 +269,21 @@ i[data-icon-name="Delete"]:hover, i[data-icon-name="Edit"]:hover{
 .cl-wc-buttonbar {
   background-color: transparent;
 }
+
 .cl-wc-deleteturn {
   border: none !important;
   position: absolute !important;
   background-color: transparent !important;
   top: 5px;
+  z-index: 1000;
 }
 
 .cl-wc-deleteturn--bot {
-  right: -8px;
+  right: -4px;
 }
 
 .cl-wc-deleteturn--user {
   left: 0px;
-}
-
-.cl-wc-addscore {
-  border: none !important;
-  position: absolute !important;
-  bottom: -8px;
-}
-
-.cl-wc-addscore--bot {
-  right: 20px;
-}
-
-.cl-wc-addscore--user {
-  left: 25px;
-}
-
-.cl-wc-addinput {
-  border: none !important;
-  position: absolute !important;
-  bottom: -8px;
-}
-
-.cl-wc-addinput--bot {
-  right: 45px;
-}
-
-.cl-wc-addinput--user {
-  left: 50px;
 }
 
 .cl-wc-branchturn {
@@ -317,14 +291,12 @@ i[data-icon-name="Delete"]:hover, i[data-icon-name="Edit"]:hover{
   position: absolute !important;
   background-color: transparent !important;
   bottom: -8px;
+  z-index: 1000;
+  right: 166px;
 }
 
-.cl-wc-branchturn--bot {
-  right: -9px;
-}
-
-.cl-wc-branchturn--user {
-  left: 0px;
+.cl-wc-branchturn:not(:disabled):hover {
+  fill: var(--color-themeDark) !important;
 }
 
 /* botframework-webchat component override */

--- a/src/components/modals/AddButton.css
+++ b/src/components/modals/AddButton.css
@@ -1,0 +1,50 @@
+.cl-addbutton-add {
+    border: none !important;
+    position: absolute !important;
+    bottom: -8px;
+    z-index: 1000;
+    width: 25px;
+}
+
+.cl-addbutton-addscore {
+    right: 194px;
+}
+
+.cl-addbutton-addinput {
+    right: 142px;
+}
+
+.cl-addbutton-svg {
+    height: 22px;
+    width: 25px;
+    position: relative;
+    cursor: pointer;
+    -webkit-filter: drop-shadow( -2px 2px 2px rgba(0, 0, 0, 0.05) );
+    filter: drop-shadow( -2px 2px 2px rgba(0, 0, 0, 0.05) );
+}
+
+.cl-addbutton-svg-input {
+    fill: var(--color-themePrimary);
+    stroke: var(--color-themeDarker);
+}
+
+.cl-addbutton-svg-input:not(:disabled):hover {
+    fill: var(--color-themeDark) !important;
+}
+
+.cl-addbutton-svg-score {
+    fill: var(--color-neutralQuaternary);
+    stroke: var(--color-neutralTertiary);
+}
+
+.cl-addbutton-svg-score:not(:disabled):hover {
+    fill: var(--color-themeDark) !important;
+}
+
+.cl-addbutton-addscore-text {
+    stroke: #222222
+}
+
+.cl-addbutton-addinput-text {
+    stroke: #ffffff
+}

--- a/src/components/modals/AddButtonInput.tsx
+++ b/src/components/modals/AddButtonInput.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Licensed under the MIT License.
+ */
+import * as React from 'react'
+import './AddButton.css'
+
+interface Props {
+    onClick: () => void,
+}
+
+class AddButtonInput extends React.Component<Props, {}> {
+    render() {
+        return (
+            <div
+                role="button"
+                className={`cl-addbutton-add cl-addbutton-addinput`}
+                onClick={this.props.onClick}
+            >
+                <svg className="cl-addbutton-svg cl-addbutton-svg-input">
+                    <polygon 
+                        points="0,2 19,2 19,6 24,10 19,13 19,17 0,17"
+                    />
+                    <text className="cl-addbutton-addinput-text" x="5" y="14">+</text>
+                </svg>
+            </div>
+        )
+    }
+}
+
+export default AddButtonInput

--- a/src/components/modals/AddButtonInput.tsx
+++ b/src/components/modals/AddButtonInput.tsx
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 import * as React from 'react'
+import { TooltipHost, DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
+import { FM } from '../../react-intl-messages'
+import { FormattedMessage } from 'react-intl'
 import './AddButton.css'
 
 interface Props {
@@ -12,18 +15,30 @@ interface Props {
 class AddButtonInput extends React.Component<Props, {}> {
     render() {
         return (
-            <div
-                role="button"
-                className={`cl-addbutton-add cl-addbutton-addinput`}
-                onClick={this.props.onClick}
-            >
-                <svg className="cl-addbutton-svg cl-addbutton-svg-input">
-                    <polygon 
-                        points="0,2 19,2 19,6 24,10 19,13 19,17 0,17"
-                    />
-                    <text className="cl-addbutton-addinput-text" x="5" y="14">+</text>
-                </svg>
-            </div>
+                <div
+                    role="button"
+                    className={`cl-addbutton-add cl-addbutton-addinput`}
+                    onClick={this.props.onClick}
+                >
+                    <TooltipHost 
+                        directionalHint={DirectionalHint.topCenter}
+                        tooltipProps={{
+                            onRenderContent: () =>
+                                <FormattedMessage
+                                    id={FM.TOOLTIP_ADD_USER_INPUT_BUTTON}
+                                    defaultMessage="Add a new user input"
+                                />
+                        }}
+                    >
+                        <svg className="cl-addbutton-svg cl-addbutton-svg-input">
+                            <polygon 
+                                points="0,2 19,2 19,6 24,10 19,13 19,17 0,17"
+                            />
+                            <text className="cl-addbutton-addinput-text" x="5" y="14">+</text>
+                        </svg>
+                    </TooltipHost>
+                </div>
+    
         )
     }
 }

--- a/src/components/modals/AddButtonScore.tsx
+++ b/src/components/modals/AddButtonScore.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Licensed under the MIT License.
+ */
+import * as React from 'react'
+import './AddButton.css'
+
+interface Props {
+    onClick: () => void,
+}
+
+class AddButtonScore extends React.Component<Props, {}> {
+    render() {
+        return (
+            <div
+                role="button"
+                className={`cl-addbutton-add cl-addbutton-addscore`}
+                onClick={this.props.onClick}
+            >
+                <svg className="cl-addbutton-svg cl-addbutton-svg-score">
+                    <polygon 
+                        points="0,2 19,2 19,6 24,10 19,13 19,17 0,17"
+                        transform="rotate(180) translate(-24, -19)"
+                    />
+                    <text className="cl-addbutton-addscore-text" x="10" y="14">+</text>
+                </svg>
+            </div>
+        )
+    }
+}
+
+export default AddButtonScore

--- a/src/components/modals/AddButtonScore.tsx
+++ b/src/components/modals/AddButtonScore.tsx
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 import * as React from 'react'
+import { TooltipHost, DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
+import { FM } from '../../react-intl-messages'
+import { FormattedMessage } from 'react-intl'
 import './AddButton.css'
 
 interface Props {
@@ -17,13 +20,24 @@ class AddButtonScore extends React.Component<Props, {}> {
                 className={`cl-addbutton-add cl-addbutton-addscore`}
                 onClick={this.props.onClick}
             >
-                <svg className="cl-addbutton-svg cl-addbutton-svg-score">
-                    <polygon 
-                        points="0,2 19,2 19,6 24,10 19,13 19,17 0,17"
-                        transform="rotate(180) translate(-24, -19)"
-                    />
-                    <text className="cl-addbutton-addscore-text" x="10" y="14">+</text>
-                </svg>
+                    <TooltipHost
+                        directionalHint={DirectionalHint.topCenter}
+                        tooltipProps={{
+                            onRenderContent: () =>
+                                <FormattedMessage
+                                    id={FM.TOOLTIP_ADD_BOT_RESONSE_BUTTON}
+                                    defaultMessage="Add a new bot response"
+                                />
+                        }}
+                    >
+                    <svg className="cl-addbutton-svg cl-addbutton-svg-score">
+                        <polygon 
+                            points="0,2 19,2 19,6 24,10 19,13 19,17 0,17"
+                            transform="rotate(180) translate(-24, -19)"
+                        />
+                        <text className="cl-addbutton-addscore-text" x="10" y="14">+</text>
+                    </svg>
+                </TooltipHost>
             </div>
         )
     }

--- a/src/components/modals/EditDialogModal.tsx
+++ b/src/components/modals/EditDialogModal.tsx
@@ -11,6 +11,7 @@ import { Modal } from 'office-ui-fabric-react/lib/Modal'
 import { State } from '../../types'
 import actions from '../../actions'
 import Webchat, { renderActivity } from '../Webchat'
+import { TooltipHost, DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 import * as BotChat from '@conversationlearner/webchat'
 import { EditDialogAdmin, EditDialogType, EditState } from '.'
 import * as CLM from '@conversationlearner/models'
@@ -224,7 +225,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
     @autobind
     renderSelectedActivity(activity: Activity, isLastActivity: boolean): (JSX.Element | null) {
 
-        if (this.props.editState !== EditState.CAN_EDIT) {
+        if (this.props.editState !== EditState.CAN_EDIT || !this.props.trainDialog) {
             return null
         }
         
@@ -248,6 +249,11 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
             curRound.scorerSteps.length === 0 ||
             (hasNoScorerStep && this.props.trainDialog.rounds.length > 1)
 
+        const hideBranch =  !canBranch || !this.props.onBranchDialog
+                this.state.pendingExtractionChanges ||
+                this.props.editState !== EditState.CAN_EDIT ||
+                (this.props.trainDialog && this.props.trainDialog.invalid === true)
+        
         return (
             <div className="cl-wc-buttonbar">
                 <AddButtonInput 
@@ -272,21 +278,27 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
                         ariaDescription="Delete Turn"
                     />
                 }
-                {this.props.onBranchDialog &&
-                    <OF.IconButton
-                        disabled={!canBranch ||
-                            this.state.pendingExtractionChanges ||
-                            this.props.editState !== EditState.CAN_EDIT ||
-                            (this.props.trainDialog && this.props.trainDialog.invalid === true)}
-                        
-                        className={`cl-wc-branchturn`}
-                        iconProps={{ iconName: 'BranchMerge' }}
-                        onClick={this.onClickBranch}
-                        ariaDescription={this.props.intl.formatMessage({
-                            id: FM.EDITDIALOGMODAL_BRANCH_ARIADESCRIPTION,
-                            defaultMessage: 'Branch'
-                        })}
+                {!hideBranch &&
+                    <TooltipHost 
+                        directionalHint={DirectionalHint.topCenter}
+                        tooltipProps={{
+                            onRenderContent: () =>
+                                <FormattedMessage
+                                    id={FM.TOOLTIP_BRANCH_BUTTON}
+                                    defaultMessage="Create a new Train Dialog by branching at this step"
+                                />
+                        }}
+                    >
+                        <OF.IconButton
+                            className={`cl-wc-branchturn`}
+                            iconProps={{ iconName: 'BranchMerge' }}
+                            onClick={this.onClickBranch}
+                            ariaDescription={this.props.intl.formatMessage({
+                                id: FM.EDITDIALOGMODAL_BRANCH_ARIADESCRIPTION,
+                                defaultMessage: 'Branch'
+                            })}
                     />
+                    </TooltipHost>
                 }
                 </div>
         )

--- a/src/components/modals/TeachSessionModal.tsx
+++ b/src/components/modals/TeachSessionModal.tsx
@@ -10,13 +10,16 @@ import { connect } from 'react-redux';
 import { ErrorHandler } from '../../ErrorHandler'
 import { AT } from '../../types/ActionTypes'
 import { Modal } from 'office-ui-fabric-react/lib/Modal';
+import * as BotChat from '@conversationlearner/webchat'
 import * as OF from 'office-ui-fabric-react';
 import { State } from '../../types';
-import Webchat from '../Webchat'
+import Webchat, { renderActivity } from '../Webchat'
 import TeachSessionAdmin from './TeachSessionAdmin'
 import TeachSessionInitState from './TeachSessionInitState'
 import * as CLM from '@conversationlearner/models'
 import { Activity } from 'botframework-directlinejs'
+import AddButtonInput from './AddButtonInput'
+import AddScoreButton from './AddButtonScore'
 import actions from '../../actions'
 import ConfirmCancelModal from './ConfirmCancelModal'
 import UserInputModal from './UserInputModal'
@@ -239,6 +242,11 @@ class TeachModal extends React.Component<Props, ComponentState> {
         }
     }
 
+    renderActivity(activityProps: BotChat.WrappedActivityProps, children: React.ReactNode, setRef: (div: HTMLDivElement | null) => void): JSX.Element {
+       return renderActivity(activityProps, children, setRef, this.renderSelectedActivity)
+    }
+
+    @autobind
     renderSelectedActivity(activity: Activity): (JSX.Element | null) {
 
         if (this.state.selectedActivityIndex === null) {
@@ -256,17 +264,11 @@ class TeachModal extends React.Component<Props, ComponentState> {
 
         return (
             <div className="cl-wc-buttonbar">
-                <OF.IconButton
-                    className={`cl-wc-addinput ${isUser ? `cl-wc-addinput--user` : `cl-wc-addinput--bot`}`}
+                <AddButtonInput 
                     onClick={this.onClickAddUserInput}
-                    ariaDescription="Insert Input Turn"
-                    iconProps={{ iconName: 'CommentAdd' }}
                 />
-                <OF.IconButton
-                    className={`cl-wc-addscore ${isUser ? `cl-wc-addscore--user` : `cl-wc-addscore--bot`}`}
+                <AddScoreButton 
                     onClick={this.onInsertAction}
-                    ariaDescription="Insert Score Turn"
-                    iconProps={{ iconName: 'CommentAdd' }}
                 />
                 {canDeleteRound &&
                     <OF.IconButton
@@ -421,7 +423,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                                     hideInput={this.props.dialogMode !== CLM.DialogMode.Wait}
                                     focusInput={this.props.dialogMode === CLM.DialogMode.Wait}
                                     highlightClassName={'wc-message-selected'}
-                                    renderSelectedActivity={activity => this.renderSelectedActivity(activity)}
+                                    renderActivity={(props, children, setRef) => this.renderActivity(props, children, setRef)}
                                 />
                                 {chatDisable}
                             </div>

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -380,6 +380,11 @@ export enum FM {
     TOOLTIP_ACTION_TYPE_CARD = 'ToolTip.ACTION_TYPE.Card',
     TOOLTIP_ACTION_WAIT = 'ToolTip.ACTION_WAIT',
     TOOLTIP_ACTION_WAIT_TITLE = 'ToolTip.ACTION_WAIT_TITLE',
+
+    TOOLTIP_ADD_USER_INPUT_BUTTON = 'ToolTip.ADD_USER_INPUT_BUTTON',
+    TOOLTIP_ADD_BOT_RESONSE_BUTTON = 'ToolTip.ADD_BOT_RESPONSE_BUTTON',
+    TOOLTIP_BRANCH_BUTTON = 'ToolTip.BRANCH_BUTTON',
+
     TOOLTIP_BOTINFO_INVALID = 'ToolTip.BOTINFO_INVALID',
     TOOLTIP_ENTITY_ACTION_REQUIRED = 'ToolTip.ENTITY_ACTION_REQUIRED',
     TOOLTIP_ENTITY_ACTION_DISQUALIFIED = 'ToolTip.ENTITY_ACTION_BLOCKED',
@@ -712,6 +717,11 @@ export default {
         [FM.TOOLTIP_ACTION_TYPE_CARD]: 'Renders an Adaptive Card template',
         [FM.TOOLTIP_ACTION_WAIT]: 'When selected, Bot will wait for more user input before taking another action',
         [FM.TOOLTIP_ACTION_WAIT_TITLE]: 'Wait For Response',
+
+        [FM.TOOLTIP_ADD_USER_INPUT_BUTTON]: 'Add a new user input',
+        [FM.TOOLTIP_ADD_BOT_RESONSE_BUTTON]: 'Add a new bot response',
+        [FM.TOOLTIP_BRANCH_BUTTON]: 'Create a new Train Dialog by branching at this step',
+
         [FM.TOOLTIP_BOTINFO_INVALID]: 'This model contains Card or API references that do not exist in the running Bot',
         [FM.TOOLTIP_ENTITY_ACTION_DISQUALIFIED]: `Actions that are blocked from use if this Entity is set`,
         [FM.TOOLTIP_ENTITY_ACTION_REQUIRED]: `Actions that are only employed when this Entity is set`,

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -738,6 +738,12 @@ class LogDialogs extends React.Component<Props, ComponentState> {
 
     async onSaveTrainDialog(newTrainDialog: CLM.TrainDialog, isInvalid: boolean) {
 
+        // Remove actionless dummy step (used for rendering) if it exits
+        let lastRound = newTrainDialog.rounds[newTrainDialog.rounds.length - 1] 
+        if (lastRound.scorerSteps.length > 0 && lastRound.scorerSteps[0].labelAction === undefined) {
+            lastRound.scorerSteps = []
+        }
+        
         newTrainDialog.invalid = isInvalid
         newTrainDialog.definitions = null
         try { 

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -445,6 +445,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     async onInsertAction(trainDialog: CLM.TrainDialog, selectedActivity: Activity) {
 
         try {
+            const senderType = selectedActivity.channelData.senderType
             const roundIndex = selectedActivity.channelData.roundIndex
             let scoreIndex = selectedActivity.channelData.scoreIndex
             const definitions = {
@@ -493,6 +494,9 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             if (curRound.scorerSteps.length === 0 || curRound.scorerSteps[0].labelAction === undefined) {
                 curRound.scorerSteps = [scorerStep]
             }
+            else if (senderType === CLM.SenderType.User) {
+                curRound.scorerSteps = [scorerStep, ...curRound.scorerSteps]
+            } 
             // Or insert 
             else {
                 curRound.scorerSteps.splice(scoreIndex + 1, 0, scorerStep)

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -732,6 +732,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 originalTrainDialogId: originalId,
                 selectedHistoryIndex: activityIndex,
                 isEditDialogModalOpen: true,
+                isTeachDialogModalOpen: false,
                 editType: this.state.editType === EditDialogType.NEW 
                         ? EditDialogType.NEW
                         : EditDialogType.TRAIN_EDITED
@@ -777,6 +778,12 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
     // Replace the current trainDialog with a new one
     async onReplaceTrainDialog(newTrainDialog: CLM.TrainDialog, isInvalid: boolean) {
+
+        // Remove actionless dummy step (used for rendering) if it exits
+        let lastRound = newTrainDialog.rounds[newTrainDialog.rounds.length - 1] 
+        if (lastRound.scorerSteps.length > 0 && lastRound.scorerSteps[0].labelAction === undefined) {
+            lastRound.scorerSteps = []
+        }
 
         newTrainDialog.invalid = isInvalid
         newTrainDialog.definitions = null


### PR DESCRIPTION
Error when editing log dialog and saving it as a new train dialog

add tips on icons when you are editing a train dialog

Can't save with dummy last round, need to clean

Make edit icons look better

the bot response is added below the existing bot response / not above as expected.

Switch sub-bubble text to always be "user" and "bot:"

Text in webchat control for the source: would be good to say “User” & “Bot”

Sometimes the source is: “Bot at Invalid date”

Refactor webchat rendering

Better way to show that next step bot response when on bottom of page
