### PR TITLE
feat: init memory fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -420,9 +420,9 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.174.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.174.0.tgz",
-      "integrity": "sha512-Fh1PKLmmuh7Ch/B1m6ynx8qfkQWqI/FeFhxR0KlPP7vQl3ZgrdJM9ScoSDjZ3BfMcKURZjPDPjLk91MMDIO1Zw=="
+      "version": "0.175.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.175.0.tgz",
+      "integrity": "sha512-J6lFIt096LylzHeqYzO/taBwjyd2klCMTbLXT4q0W/q3YOHeF+bZeExp/dNKGwlJ5DR67f/2ihx+LtvDLlDX7A=="
     },
     "@conversationlearner/webchat": {
       "version": "0.137.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "private": true,
   "dependencies": {
-    "@conversationlearner/models": "0.174.0",
+    "@conversationlearner/models": "0.175.0",
     "@conversationlearner/webchat": "0.137.0",
     "@types/file-saver": "^1.3.0",
     "@types/uuid": "^3.4.4",

--- a/src/actions/entityActions.ts
+++ b/src/actions/entityActions.ts
@@ -30,7 +30,7 @@ export const createEntityThunkAsync = (appId: string, entity: EntityBase) => {
 
             // If created entity is prebuilt entity, we fetch all entities to make sure 
             // that definition of reserved prebuilt entity is in the memory
-            if(posEntity.entityType !== EntityType.LOCAL && posEntity.entityType !== EntityType.LUIS)
+            if (posEntity.entityType !== EntityType.LOCAL && posEntity.entityType !== EntityType.LUIS)
             {
                 dispatch(fetchAllEntitiesThunkAsync(appId));
             }

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -682,11 +682,6 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         })
     }
 
-    @autobind
-    onDismissModal() {
-        this.props.handleClose()
-    }
-
     onChangedActionType = (actionTypeOption: OF.IDropdownOption) => {
         const textPayload = this.state.slateValuesMap[TEXT_SLOT]
         const isPayloadValid = actionTypeOption.key !== ActionTypes.TEXT && actionTypeOption.key !== ActionTypes.END_SESSION
@@ -891,7 +886,6 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         return (
             <Modal
                 isOpen={this.props.open}
-                onDismiss={this.onDismissModal}
                 isBlocking={false}
                 containerClassName="cl-modal cl-modal--medium"
             >

--- a/src/components/modals/TeachSessionAdmin.tsx
+++ b/src/components/modals/TeachSessionAdmin.tsx
@@ -33,6 +33,7 @@ export interface RenderData {
 interface RoundLookup {
     textVariations?: CLM.TextVariation[] | null
     uiScoreResponse?: CLM.UIScoreResponse | null
+    memories?: CLM.Memory[]
 }
 interface ComponentState {
     isScoresRefreshVisible: boolean
@@ -76,7 +77,7 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
         // If first turn, set offset based on existing activities
         let turnLookupOffset = this.state.turnLookup.length === 0 ? this.props.activityIndex - 1 : this.state.turnLookupOffset
                 
-        turnLookup.push({textVariations})
+        turnLookup.push({textVariations, memories: [...this.props.teachSession.memories]})
         turnLookup.push({uiScoreResponse})
         this.setState({
             isScoresRefreshVisible: true,
@@ -201,12 +202,12 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
                         }
                     }
                 else if (turnData.textVariations) {
-                    const memories = (prevTurn && prevTurn.uiScoreResponse) ? prevTurn.uiScoreResponse.memories : []
+                    //LARSconst memories = (prevTurn && prevTurn.uiScoreResponse) ? prevTurn.uiScoreResponse.memories : []
                     return {
                         dialogMode: CLM.DialogMode.Extractor,
                         extractResponses: this.props.teachSession.extractResponses,
                         textVariations: turnData.textVariations,  
-                        memories,
+                        memories: turnData.memories || [],
                         prevMemories,
                         roundIndex: this.roundIndex(lookupIndex)
                     }
@@ -219,11 +220,15 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
             throw new Error("Bad TurnData")
         }
         else {
+            const memories = this.props.initialEntities
+                ? this.props.initialEntities.ToMemory()
+                : this.props.teachSession.memories
+
             return {
                 dialogMode: this.props.teachSession.mode,
                 scoreInput: this.props.teachSession.scoreInput!,
                 scoreResponse: this.props.teachSession.scoreResponse!,
-                memories: this.props.teachSession.memories,
+                memories: memories,
                 prevMemories: this.props.teachSession.prevMemories,
                 extractResponses: this.props.teachSession.extractResponses,
                 textVariations: [],
@@ -429,6 +434,7 @@ export interface ReceivedProps {
     app: CLM.AppBase
     editingPackageId: string
     editType: EditDialogType,
+    initialEntities: CLM.FilledEntityMap | null,
     // Index to attach to channel data
     activityIndex: number
     // If user clicked on an Activity

--- a/src/components/modals/TeachSessionModal.tsx
+++ b/src/components/modals/TeachSessionModal.tsx
@@ -34,6 +34,7 @@ interface ComponentState {
     isUserInputModalOpen: boolean,
     isInitStateOpen: boolean,
     isInitAvailable: boolean,
+    initialEntities: CLM.FilledEntityMap | null,
     webchatKey: number,
     editing: boolean,
     hasTerminalAction: boolean,
@@ -51,6 +52,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
         isUserInputModalOpen: false,
         isInitStateOpen: false,
         isInitAvailable: true,
+        initialEntities: null,
         webchatKey: 0,
         editing: false,
         hasTerminalAction: false,
@@ -90,10 +92,12 @@ class TeachModal extends React.Component<Props, ComponentState> {
         let nextActivityIndex = this.state.nextActivityIndex
         let selectedActivityIndex = this.state.selectedActivityIndex
         let selectedHistoryActivity = this.state.selectedHistoryActivity
+        let initialEntities = this.state.initialEntities
 
         if (!newProps.isOpen) {
             selectedActivityIndex = null
             selectedHistoryActivity = null
+            initialEntities = null
         }
 
         if (this.props.initialHistory !== newProps.initialHistory) {
@@ -106,6 +110,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
         if (this.props.teach !== newProps.teach) {
             isInitAvailable = true
             hasTerminalAction = false
+            initialEntities = null
         }
         // Set terminal action from History but only if I just loaded it
         if (this.props.initialHistory !== newProps.initialHistory && newProps.initialHistory && newProps.initialHistory.length > 0) {
@@ -121,6 +126,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                 webchatKey,
                 hasTerminalAction,
                 isInitAvailable,
+                initialEntities,
                 nextActivityIndex,
                 selectedActivityIndex,
                 selectedHistoryActivity
@@ -138,10 +144,11 @@ class TeachModal extends React.Component<Props, ComponentState> {
     @autobind
     async onCloseInitState(filledEntityMap?: CLM.FilledEntityMap) {
         if (filledEntityMap && this.props.onSetInitialEntities) {
-            await this.props.onSetInitialEntities(filledEntityMap.FilledEntities())          
+            await this.props.onSetInitialEntities(filledEntityMap.FilledEntities())              
         }
         this.setState({
-            isInitStateOpen: false
+            isInitStateOpen: false,
+            initialEntities: filledEntityMap || null
         })
     }
 
@@ -230,6 +237,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
             this.setState({ 
                  // No initialization allowed after first input
                 isInitAvailable: false, 
+                initialEntities: null,
                 nextActivityIndex: this.state.nextActivityIndex + 1,
                 selectedActivityIndex: null,
                 selectedHistoryActivity: null
@@ -612,6 +620,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                                         app={this.props.app}
                                         editingPackageId={this.props.editingPackageId}
                                         editType={this.props.editType}
+                                        initialEntities={this.state.initialEntities}
                                         activityIndex={this.state.nextActivityIndex}
                                         selectedActivityIndex={this.state.selectedActivityIndex}
                                         historyRenderData={this.state.selectedHistoryActivity ? this.historyRender : null}

--- a/src/reducers/appsReducer.ts
+++ b/src/reducers/appsReducer.ts
@@ -22,12 +22,13 @@ const appsReducer: Reducer<AppsState> = (state = initialState, action: ActionObj
             return { ...state, all: action.uiAppList.appList.apps, activeApps: action.uiAppList.activeApps } 
         case AT.FETCH_APPLICATION_TRAININGSTATUS_ASYNC: {
             const app = state.all.find(a => a.appId === action.appId)
-            // User may have delete the app
+            // User may have deleted the app
             if (!app) {
                 return state;
             }
             const newApp: App = {
                 ...app,
+                trainingStatus: TrainingStatusCode.Running,
                 didPollingExpire: false
             }
 


### PR DESCRIPTION
1490: Entity Memory is "Empty" on a new train dialog AFTER "Set Initial State" is used

1498: Update training status to running immediately when polling starts

1491 Create Entity and Action Dialogs Need Consistent Cancel Behavior