### PR TITLE
fix: bug 1524: info icon re-alignment

### DIFF
--- a/src/components/TrainingStatus.css
+++ b/src/components/TrainingStatus.css
@@ -20,6 +20,10 @@
     cursor: pointer;
     color: var(--color-alert);
 }
+.cl-training-status__icon-row .cl-icon {
+    margin-left:0.3em;
+}
+
 .cl-training-status__icon-label {
     color: var(--color-neutralPrimary);
 }


### PR DESCRIPTION
pad the icon a bit on the left so no longer pushed up against the label