### PR TITLE
fix: bug 1593; scroll bar hides status text

### DIFF
--- a/src/components/modals/TeachSessionAdmin.tsx
+++ b/src/components/modals/TeachSessionAdmin.tsx
@@ -291,7 +291,7 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
             <div className={`cl-dialog-admin ${OF.FontClassNames.small}`}>
                 <div className="cl-ux-flexpanel">
                     <div className="cl-ux-flexpanel--primary">
-                        <div className="cl-ux-flexpanel--left" style={{width: '70%'}}>
+                        <div className="cl-ux-flexpanel--left" style={{width:'65%'}}>
                             <div className={`cl-dialog-title cl-dialog-title--${editTypeClass} ${OF.FontClassNames.large}`}>
                             <OF.Icon 
                                 iconName={isLogDialog ? 'UserFollowed' : 'EditContact'}
@@ -299,7 +299,7 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
                             {isLogDialog ? 'Log Dialog' : 'Train Dialog'}
                             </div>
                         </div>
-                        <div className="cl-ux-flexpanel--right" style={{width: '30%'}}>
+                        <div className="cl-ux-flexpanel--right" style={{width:'35%',marginRight:'2em'}}>
                             <TrainingStatusContainer
                                 app={this.props.app}
                             />

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -1215,7 +1215,6 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                         <OF.DetailsList
                             data-testid="detail-list"
                             key={this.state.dialogKey}
-                            isHeaderVisible = {computedTrainDialogs.length != 0}
                             className={OF.FontClassNames.mediumPlus}
                             items={computedTrainDialogs}
                             columns={this.state.columns}


### PR DESCRIPTION
Status area now includes a little right side margin bumper. Bumped up the area's allocation a bit while here