### PR TITLE
fix: bug 1642 - help icons need transparent background, not hardcoded

### DIFF
--- a/src/components/HelpIcon.tsx
+++ b/src/components/HelpIcon.tsx
@@ -20,9 +20,9 @@ class HelpIcon extends React.Component<Props, {}> {
                 iconProps={{ iconName: this.props.iconName || 'Info' }}
                 onClick={() => { this.props.setTipType(this.props.tipType) }}
                 styles={{
-                    rootHovered: [{ backgroundColor: "#ffffff" }],
-                    rootPressed: [{ backgroundColor: "#ffffff" }],
-                    iconHovered: [{ color: "#ff0000" }],
+                    rootHovered: [{ backgroundColor: "transparent !important" }],
+                    rootPressed: [{ backgroundColor: "transparent !important" }],
+                    iconHovered: [{ color: "#000000 !important" }],
                 }}
                 title="More Information"
             />


### PR DESCRIPTION
Set control's background to transparent and important to override Fabric's, yet handle colorized messages