### PR TITLE
fix: bug 1657  - add right margin to training status indicators

### DIFF
--- a/src/components/modals/EditDialogAdmin.tsx
+++ b/src/components/modals/EditDialogAdmin.tsx
@@ -352,7 +352,7 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
                                 {isLogDialog ? 'Log Dialog' : 'Train Dialog'}
                             </div>
                         </div>
-                        <div className="cl-ux-flexpanel--right" style={{ width: "20%" }}>
+                        <div className="cl-ux-flexpanel--right" style={{ width: "20%", marginRight: '3em' }}>
                             <TrainingStatusContainer
                                 app={this.props.app}
                             />

--- a/src/components/modals/TeachSessionAdmin.tsx
+++ b/src/components/modals/TeachSessionAdmin.tsx
@@ -300,7 +300,7 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
                                 {isLogDialog ? 'Log Dialog' : 'Train Dialog'}
                             </div>
                         </div>
-                        <div className="cl-ux-flexpanel--right" style={{ width: '35%', marginRight: '2em' }}>
+                        <div className="cl-ux-flexpanel--right" style={{ width: '35%', marginRight: '3em' }}>
                             <TrainingStatusContainer
                                 app={this.props.app}
                             />


### PR DESCRIPTION
Bump up the right margin a bit more for better display on smaller screens