### PR TITLE
fix: bug 1665 - check value length inside ENTER handler too

### DIFF
--- a/src/components/modals/UserInputModal.tsx
+++ b/src/components/modals/UserInputModal.tsx
@@ -51,7 +51,7 @@ class UserInputModal extends React.Component<Props, ComponentState> {
     onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
         // On enter attempt to create the model if required fields are set
         // Not on import as explicit button press is required to pick the file
-        if (event.key === 'Enter' && this.state.userInputVal) {
+        if ((this.onGetInputErrorMessage(this.state.userInputVal) === "") && (event.key === 'Enter') && this.state.userInputVal) {
             this.onClickSubmit();
         }
     }


### PR DESCRIPTION
We were trapping long input values on the button handlers, but not Enter. Now check on keydown events as well