### PR TITLE
fix: bug 1697 - switch timestamp logic to consider span, not calendar days

### DIFF
--- a/src/Utils/util.ts
+++ b/src/Utils/util.ts
@@ -85,5 +85,5 @@ export function formatMessageId(intl: ReactIntl.InjectedIntl, id: IntlMessages.F
 }
 
 export function earlierDateOrTimeToday(timestamp: string): string {
-    return moment(timestamp).format(moment().format('L') === moment(timestamp).format('L') ? 'LTS' : 'L')
+    return moment(timestamp).format(moment().diff(moment(timestamp), "hours") < 24 ? 'LTS' : 'L')
 }


### PR DESCRIPTION
Requested feature change; display HH:MM if the timestamp is less than 24 hours difference for timestamps