### PR TITLE
fix: update URL to LUIS app keys page (Problem #1)

### DIFF
--- a/src/components/ToolTips.tsx
+++ b/src/components/ToolTips.tsx
@@ -386,8 +386,10 @@ export function GetTip(tipType: string) {
 
                     <h2>Find / Set your LUIS Subscription key:</h2>
                     <ol>
-                        <li>Click on the "Go to LUIS" button in the Conversation Learner UI.  This will take you to the LUIS application associated with your model.</li>
-                        <li>In your LUIS' apps "Publish Tab", click on "Add Key"
+                        <li>Click on the "Go to LUIS" button (to the left) in the Conversation Learner management application.
+                        <br />This will take you to the <b>"Keys and Endpoint settings"</b> page of your LUIS application where you can add a previously provisioned Subscription key.</li>
+                        <li>On this page click on "Assign Resource"
+                            <br />
                             <img src="https://blisstorage.blob.core.windows.net/uiimages/addkey.PNG" width="50%"  />
                         </li>
                         <li>If you don't yet have an Azure Suscription key you'll need to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/luis/azureibizasubscription" target="_blank">Create One</a></li>

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -419,7 +419,7 @@ class Settings extends React.Component<Props, ComponentState> {
                             />
                         </OF.Label>
                         <div>
-                            <a href={`https://www.luis.ai/applications/${this.props.app.luisAppId}/versions/2.0/manage/endpoints`} target="_blank">
+                            <a href={`https://www.luis.ai/applications/${this.props.app.luisAppId}/versions/0.1/manage/endpoints`} target="_blank">
                                 <OF.DefaultButton
                                     iconProps={{ iconName: "OpenInNewWindow" }}
                                     ariaDescription="Go to LUIS"

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -419,7 +419,7 @@ class Settings extends React.Component<Props, ComponentState> {
                             />
                         </OF.Label>
                         <div>
-                            <a href={`https://www.luis.ai/applications/${this.props.app.luisAppId}/versions/0.1/publish`} target="_blank">
+                            <a href={`https://www.luis.ai/applications/${this.props.app.luisAppId}/versions/2.0/manage/endpoints`} target="_blank">
                                 <OF.DefaultButton
                                     iconProps={{ iconName: "OpenInNewWindow" }}
                                     ariaDescription="Go to LUIS"


### PR DESCRIPTION
Looks like LUIS team updated their page breaking our link. This change updates it to the new URL.

I also changed text on related help panel to match button and say "Assign Resource" instead of "Add Key"