### PR TITLE
feat: add close button to help panel (Problem #3)

### DIFF
--- a/src/components/HelpPanel.css
+++ b/src/components/HelpPanel.css
@@ -1,0 +1,8 @@
+.cl-help-panel-footer {
+    padding: 20px 20px 20px 20px;
+    position: absolute;
+    bottom: 00px;
+    right: 20px;
+    text-align: right;
+    background: white;
+}

--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -10,6 +10,9 @@ import { connect } from 'react-redux';
 import * as ToolTip from './ToolTips';
 import * as OF from 'office-ui-fabric-react';
 import { setTipType } from '../actions/displayActions'
+import { injectIntl, InjectedIntlProps } from 'react-intl'
+import { FM } from '../react-intl-messages'
+import './HelpPanel.css'
 
 class HelpPanel extends React.Component<Props, {}> {
     onDismiss(): void {
@@ -17,6 +20,7 @@ class HelpPanel extends React.Component<Props, {}> {
     }
 
     render() {
+        const { intl } = this.props
         return (
             <OF.Panel
                 focusTrapZoneProps={{}}
@@ -28,7 +32,20 @@ class HelpPanel extends React.Component<Props, {}> {
                 customWidth="400px"
                 closeButtonAriaLabel="Close"
             >
-                <span>{ToolTip.GetTip(this.props.tipType)}</span>
+                <div>{ToolTip.GetTip(this.props.tipType)}</div>
+                <div className="cl-help-panel-footer">
+                    <OF.DefaultButton
+                        onClick={() => this.onDismiss()}
+                        ariaDescription={intl.formatMessage({
+                            id: FM.HELP_PANEL_CLOSE,
+                            defaultMessage: 'Close'
+                        })}
+                        text={intl.formatMessage({
+                            id: FM.HELP_PANEL_CLOSE,
+                            defaultMessage: 'Close'
+                        })}
+                    />
+                </div>
             </OF.Panel>
         )
     }
@@ -51,6 +68,6 @@ export interface ReceivedProps {
 // Props types inferred from mapStateToProps & dispatchToProps
 const stateProps = returntypeof(mapStateToProps);
 const dispatchProps = returntypeof(mapDispatchToProps);
-type Props = typeof stateProps & typeof dispatchProps & ReceivedProps;
+type Props = typeof stateProps & typeof dispatchProps & ReceivedProps & InjectedIntlProps;
 
-export default connect<typeof stateProps, typeof dispatchProps, ReceivedProps>(mapStateToProps, mapDispatchToProps)(HelpPanel);
+export default connect<typeof stateProps, typeof dispatchProps, ReceivedProps>(mapStateToProps, mapDispatchToProps)(injectIntl(HelpPanel));

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -199,6 +199,9 @@ export enum FM {
     ERROR_PRIMARYBUTTON_ARIADESCRIPTION = 'Error.ariaDescription',
     ERROR_PRIMARYBUTTON_TEXT = 'Error.text',
 
+    // Help Panel
+    HELP_PANEL_CLOSE = 'HelpPanel.close',
+    
     // LogDialogModal
     LOGDIALOGMODAL_DEFAULTBUTTON_ARIADESCRIPTION = 'LogDialogModal.defaultButton.ariaDescription',
     LOGDIALOGMODAL_DEFAULTBUTTON_TEXT = 'LogDialogModal.defaultButton.text',
@@ -769,6 +772,9 @@ export default {
         [FM.ERROR_WARNING]: 'Warning',
         [FM.ERROR_PRIMARYBUTTON_ARIADESCRIPTION]: 'Ok',
         [FM.ERROR_PRIMARYBUTTON_TEXT]: 'Ok',
+
+        // Help Panel
+        [FM.HELP_PANEL_CLOSE]: 'Close',
 
         // LogDialogModal
         [FM.LOGDIALOGMODAL_DEFAULTBUTTON_ARIADESCRIPTION]: 'Delete',


### PR DESCRIPTION
I had the button placed absolutely positioned to stay on the bottom since the content of the modal shrinks to smallest height possible.

The problem is that text can go behind the button and broken.  I added a white padding to try to keep these a little separate.  An alternative would be to reserve space at the bottom so nothing can crosss the bottom but it takes up unnecessary space in certain scenarios