### PR TITLE
feat: add scroll bar to entity picker results list (Problem #4)

### DIFF
--- a/src/components/ExtractorResponseEditor/EntityPicker.css
+++ b/src/components/ExtractorResponseEditor/EntityPicker.css
@@ -53,6 +53,8 @@
     padding: 0;
     padding-bottom: 0.25em;
     border-bottom: 1px solid lightgrey;
+    overflow-y: auto;
+    max-height: 7em;
 }
 
 .custom-toolbar__result {

--- a/src/components/ExtractorResponseEditor/EntityPicker.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPicker.tsx
@@ -19,6 +19,7 @@ interface MenuProps {
     onClickNewEntity: () => void
     position: IPosition
     menuRef: any
+    resultsRef: React.Ref<HTMLUListElement>
     searchText: string
     value: any
 }
@@ -40,7 +41,7 @@ export default class EntityPicker extends React.Component<MenuProps> {
                     ? <div className="custom-toolbar__warning">Cannot add overlapping entities.<br />Remove the entity or change the selection.</div>
                     : <React.Fragment>
                         {this.props.matchedOptions.length !== 0
-                            && <ul className="custom-toolbar__results">
+                            && <ul className="custom-toolbar__results" ref={this.props.resultsRef}>
                                 {this.props.matchedOptions.map((matchedOption, i) =>
                                     <li
                                         key={matchedOption.original.id}

--- a/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
@@ -63,7 +63,7 @@ export default class EntityPickerContainer extends React.Component<Props, State>
     defaultMatchedOptions: MatchedOption<IOption>[]
     fuse: Fuse
     element: HTMLElement
-
+    resultsElement: HTMLUListElement = null
     state = initialState
 
     constructor(props: Props) {
@@ -143,7 +143,20 @@ export default class EntityPickerContainer extends React.Component<Props, State>
 
         this.setState(prevState => ({
             highlightIndex: modifyFunction(prevState.highlightIndex, prevState.matchedOptions.length - 1)
-        }))
+        }), () => this.scrollHighlightedElementIntoView())
+    }
+
+    scrollHighlightedElementIntoView = () => {
+        const selectedElement = this.resultsElement
+            ? this.resultsElement.querySelector('.custom-toolbar__result--highlight') as HTMLUListElement
+            : null
+
+        if (selectedElement) {
+            selectedElement.scrollIntoView({
+                behavior: "smooth",
+                block: "nearest"
+            })
+        }
     }
 
     onSelectHighlightedOption = () => {
@@ -198,6 +211,7 @@ export default class EntityPickerContainer extends React.Component<Props, State>
                 maxDisplayedOptions={this.props.maxDisplayedOptions}
                 position={this.props.position}
                 menuRef={this.props.menuRef}
+                resultsRef={el => this.resultsElement = el}
                 searchText={this.state.searchText}
                 value={this.props.value}
 

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -317,7 +317,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
                             isOverlappingOtherEntities={this.state.isSelectionOverlappingOtherEntities}
                             isVisible={this.state.isMenuVisible}
                             options={this.props.options}
-                            maxDisplayedOptions={4}
+                            maxDisplayedOptions={10}
                             menuRef={this.menuRef}
                             position={this.state.menuPosition}
                             value={this.state.value}


### PR DESCRIPTION
Increase `maxDisplayedOptions` so more than 4 items can be shown.

Also I only chose `7em` size so that when there are more items and it has scroll bar you will see slight clipping of text letter the user know there is more below. Alternative is to make it be even cutoff 

Some thoughts about this change unrelated to the fix.  I realize it's confusing that there are only 4 entities when you actually have more, but I don't think making the list scrollable to the best solution.  I had imagined people are going to have apps with 100's of entities and didn't want them scrolling all of these in this tiny menu.  I intended people to tab into the search bar and begin typing to filter the results so that they find there desired entity filters its way to the top (within the 4).

I'm not sure what is better but an alternative is to add text saying "showing 4 out of 29 entities". Also realized we could do better to make the "New Entity" look more like a button and add the OfficeFabric + (plus) sign in front to be consistent