### PR TITLE
 fix: prevent showing previous bot errors (Problem #6)

### DIFF
--- a/src/routes/Apps/App/Dashboard.tsx
+++ b/src/routes/Apps/App/Dashboard.tsx
@@ -59,7 +59,8 @@ class Dashboard extends React.Component<Props, ComponentState> {
                         defaultMessage="Notifications about this model..."
                     />
                 </span>
-                {this.props.validationErrors.length > 0 && 
+                {this.props.validationErrors.length > 0
+                    && !this.props.loading &&
                 (
                     <div className="cl-errorpanel" >
                         <div className={`cl-font--emphasis ${FontClassNames.medium}`}>Please check that the correct version of your Bot is running.</div>
@@ -111,7 +112,8 @@ const mapDispatchToProps = (dispatch: any) => {
 }
 
 export interface ReceivedProps {
-    app: AppBase, 
+    app: AppBase,
+    loading: boolean,
     validationErrors: string[]
 }
 

--- a/src/routes/Apps/App/Dashboard.tsx
+++ b/src/routes/Apps/App/Dashboard.tsx
@@ -59,9 +59,8 @@ class Dashboard extends React.Component<Props, ComponentState> {
                         defaultMessage="Notifications about this model..."
                     />
                 </span>
-                {this.props.validationErrors.length > 0
-                    && !this.props.loading &&
-                (
+                {this.props.validationErrors.length > 0 &&
+                    (
                     <div className="cl-errorpanel" >
                         <div className={`cl-font--emphasis ${FontClassNames.medium}`}>Please check that the correct version of your Bot is running.</div>
                         {this.props.validationErrors.map((message: any, i) => { 
@@ -113,7 +112,6 @@ const mapDispatchToProps = (dispatch: any) => {
 
 export interface ReceivedProps {
     app: AppBase,
-    loading: boolean,
     validationErrors: string[]
 }
 

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -250,7 +250,7 @@ class Index extends React.Component<Props, ComponentState> {
                     <Route
                         exact={true}
                         path={match.url}
-                        render={props => <Dashboard {...props} app={app} loading={this.state.loading} validationErrors={this.state.validationErrors} />}
+                        render={props => <Dashboard {...props} app={app} validationErrors={this.state.loading ? [] : this.state.validationErrors} />}
                     />
                 </Switch>
             </div>


### PR DESCRIPTION
Clears validation errors when loading a bot since they will get reset.
Added a loading flag which blocks showing the item counts and error messages.
Kept the loading value separate than the other booleans like `invalidTraindialogs` since they have different life cycle and semantic meaning