### PR TITLE
fix: close entity picker after creating new entity (Problem #7)

### DIFF
--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -100,6 +100,11 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
                     }
 
                     this.props.onChangeCustomEntities([...nextProps.customEntities, newCustomEntity])
+
+                    // EntityPicker stays open after creation of new entity. Force it to close.
+                    this.setState({
+                        isMenuVisible: false
+                    })
                     return
                 }
             }


### PR DESCRIPTION
I can't remember why I didn't do this before. Hoping it was just oversight and not intentionally not adding this because it caused a problem.