### PR TITLE
fix: invalid response error sometimes shows as box (Problem #2)

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -979,8 +979,8 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                 </div>
                                 {!this.state.isPayloadValid &&
                                     (<div>
-                                        <p className="ms-TextField-errorMessage css-83 errorMessage_20d9206e">
-                                            <OF.Icon iconName="Error" /><span aria-live="assertive" data-automation-id="error-message">Response is required</span>
+                                        <p className="ms-TextField-errorMessage errorMessage_20d9206e">
+                                            <OF.Icon iconName="Error" />&nbsp;<span aria-live="assertive" data-automation-id="error-message">Response is required</span>
                                         </p>
                                     </div>)}
                             </div>
@@ -1001,8 +1001,8 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                 </div>
                                 {!this.state.isPayloadValid &&
                                     (<div>
-                                        <p className="ms-TextField-errorMessage css-83 errorMessage_20d9206e">
-                                            <OF.Icon iconName="Error" /><span aria-live="assertive" data-automation-id="error-message">Response is required</span>
+                                        <p className="ms-TextField-errorMessage errorMessage_20d9206e">
+                                            <OF.Icon iconName="Error" />&nbsp;<span aria-live="assertive" data-automation-id="error-message">Response is required</span>
                                         </p>
                                     </div>)}
                             </div>


### PR DESCRIPTION
As far as I can tell `css-83` is conflicting with the `errorMessage_20d9206e` and causing the malformed icon and message. Removing it eliminates the possibility of conflict and preserves the red coloring

I thought `css-83` was one of the font size classes and I'm not sure why it was necessary, but would agree having slightly different size is much safer problem than unreadable error message. 

From what I remember from previous investigation this happens due to the inconsistent order React puts the style elements in the HTML. During live reload these get mixed up. The build they have is smart enough to not reload the entire application when you only change the CSS but is has this side effect. I believe when you do an official build the CSS is consistent