### PR TITLE
BROKEN feat: select words to label in train dialog (Problem #5)

### DIFF
--- a/cypress/integration/create_app.ts
+++ b/cypress/integration/create_app.ts
@@ -3,7 +3,7 @@ describe('Create application', function () {
 
   it('should create new application with random name and verify name on application page', function () {
     cy.server()
-    cy.route('GET', '/apps?**').as('getApps')
+    cy.route('GET', '/sdk/apps?**').as('getApps')
 
     // Open application
     cy.visit('http://localhost:5050')
@@ -20,7 +20,7 @@ describe('Create application', function () {
     cy.get('[data-testid="app-create-input-name"]')
       .type(newAppName)
 
-    cy.route('POST', '/app?userId=**').as('postApp')
+    cy.route('POST', '/sdk/app?userId=**').as('postApp')
 
     // Click the submit button
     cy.get('[data-testid="app-create-button-submit"]')
@@ -57,7 +57,7 @@ describe('Create application', function () {
     cy.get('[data-testid="entitycreator-checkbox-multivalued"]')
       .click()
 
-    cy.route('POST', '/app/*/entity').as('postEntity')
+    cy.route('POST', '/sdk/app/*/entity').as('postEntity')
 
     // Select the submit button
     cy.get('[data-testid="entity-creator-button-save"]')
@@ -85,7 +85,7 @@ describe('Create application', function () {
       .click()
 
     // Select name for actions
-    cy.route('POST', '/app/*/action').as('postAction')
+    cy.route('POST', '/sdk/app/*/action').as('postAction')
 
     const samplePayload = "some payload"
     cy.get('.editor-container [contenteditable="true"]')

--- a/cypress/integration/entityLabel.ts
+++ b/cypress/integration/entityLabel.ts
@@ -1,0 +1,65 @@
+/**
+* Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Licensed under the MIT License.
+*/
+const { convLearnerPage,
+  modelpage,
+  entity,
+  entityModal,
+  actions,
+  actionsModal,
+  trainDialogPage,
+  trainDialogModal,
+  scorerModal,
+  logDialogPage,
+  logDialogModal,
+  testLog } = components();
+
+/**
+* Wait action: After the system takes a "wait" action, it will stop taking actions and wait for user input.
+* Non-wait action: After the system takes a "non-wait" action, it will immediately choose another action (without waiting for user input)
+*/
+describe('Label text in train dialog', function () {
+  const postfix = Cypress.moment().format("MMMDD-HHmm")
+  const modelName = `e2e-entity-${postfix}`
+
+  it('create a New Model', function () {
+    convLearnerPage.navigateTo();
+    convLearnerPage.createNewModel(modelName);
+    modelpage.verifyPageTitle(modelName);
+  })
+
+  it('should train a dialog using Wait and Non Wait actions', () => {
+    modelpage.navigateToTrainDialogs();
+    trainDialogPage.verifyPageTitle();
+    trainDialogPage.createNew();
+    cy.wait(2000)
+    trainDialogModal.typeYourMessage('my hovercraft is full of eels');
+    cy.wait(2000)
+    trainDialogModal.labelWords('hovercraft is', 'myEntity')
+    trainDialogModal.clickScoreActions();
+  })
+
+  /** FEATURE: Delete a Model */
+  it('should delete an existent model', () => {
+    convLearnerPage.navigateTo();
+    convLearnerPage.deleteModel(modelName);
+    cy.end()
+  })
+})
+
+function components() {
+  const actions = require('../support/components/actionspage');
+  const actionsModal = require('../support/components/actionsmodal');
+  const convLearnerPage = require('../support/components/homepage');
+  const entity = require('../support/components/entitiespage');
+  const entityModal = require('../support/components/entitymodal');
+  const modelpage = require('../support/components/modelpage');
+  const logDialogPage = require('../support/components/logdialogspage');
+  const logDialogModal = require('../support/components/logdialogmodal');
+  const scorerModal = require('../support/components/scorermodal');
+  const trainDialogPage = require('../support/components/traindialogspage');
+  const trainDialogModal = require('../support/components/traindialogmodal');
+  const testLog = require('../support/utils/testlog');
+  return { convLearnerPage, modelpage, entity, entityModal, actions, actionsModal, trainDialogPage, trainDialogModal, scorerModal, logDialogPage, logDialogModal, testLog };
+}

--- a/cypress/support/components/actionsmodal.js
+++ b/cypress/support/components/actionsmodal.js
@@ -85,8 +85,8 @@ function clickWaitForResponse() {
 function clickCreateButton() {
   testLog.logStart("ActionsModal: Click Create (save)");
   cy.server();
-  cy.route('POST', '/app/*/action').as('postAction');
-  cy.route('GET', '/app/*/trainingstatus').as('getTrainingstatus');
+  cy.route('POST', '/sdk/app/*/action').as('postAction');
+  cy.route('GET', '/sdk/app/*/trainingstatus').as('getTrainingstatus');
   cy.get('[data-testid="actioncreator-button-create"]')
     .should("be.visible")
     .click();

--- a/cypress/support/components/entitymodal.js
+++ b/cypress/support/components/entitymodal.js
@@ -40,7 +40,7 @@ function clickOnNegatable() {
 function clickCreateButton() {
     testLog.logStart("Entity Modal: Click Create (save)");
     cy.server()
-    cy.route('POST', '/app/*/entity').as('postEntity')
+    cy.route('POST', '/sdk/app/*/entity').as('postEntity')
     cy.get('[data-testid="entity-creator-button-save"]')
         .then(function (response) {
             testLog.logStep("Click create button")

--- a/cypress/support/components/homepage.js
+++ b/cypress/support/components/homepage.js
@@ -9,7 +9,7 @@ const testLog = require('../utils/testlog')
 function navigateTo() {
   testLog.logStart("Navigate to homepage");
   cy.server()
-  cy.route('GET', '/apps?**').as('getHomePage')
+  cy.route('GET', '/sdk/apps?**').as('getHomePage')
 
   // Open application
   cy.visit('http://localhost:5050')
@@ -21,7 +21,7 @@ function navigateTo() {
 function createNewModel(modelName) {
   testLog.logStart("Create New Model");
   cy.server()
-  cy.route('POST', '/app?userId=**').as('postcreateNew')
+  cy.route('POST', '/sdk/app?userId=**').as('postcreateNew')
 
   // Click the button to create app
   cy.get('[data-testid="apps-list-button-create-new"]')

--- a/cypress/support/components/logdialogspage.js
+++ b/cypress/support/components/logdialogspage.js
@@ -13,7 +13,7 @@ function verifyPageTitle() {
 /** starts a new log dialog */
 function createNew() {
   cy.server()
-  cy.route('PUT', '/state/conversationId?username=ConversationLearnerDeveloper&id=*').as('putConv')
+  cy.route('PUT', '/sdk/state/conversationId?username=ConversationLearnerDeveloper&id=*').as('putConv')
   cy.get('[data-testid="logdialogs-button-create"]')
     .should("be.visible")
     .then(function (response) {

--- a/cypress/support/components/modelpage.js
+++ b/cypress/support/components/modelpage.js
@@ -15,7 +15,7 @@ function verifyPageTitle(modelName) {
 /** Navigate back to the Converation Learner Home page */
 function navigateToHomepage() {
   cy.server()
-  cy.route('GET', '/apps?**').as('getHomePage')
+  cy.route('GET', '/sdk/apps?**').as('getHomePage')
   cy.visit('http://localhost:5050')
   cy.wait('@getHomePage')
 }

--- a/cypress/support/components/scorermodal.js
+++ b/cypress/support/components/scorermodal.js
@@ -7,7 +7,7 @@ const testLog = require('../utils/testlog')
 /** Selects the first enabled action */
 function selectAnAction() {
     cy.server()
-    cy.route('POST', '/app/*/teach/*/scorer').as('postScore')
+    cy.route('POST', '/sdk/app/*/teach/*/scorer').as('postScore')
     cy.get('[data-testid="actionscorer-buttonClickable"]')
         .should("be.visible")
         .then(function (response) {
@@ -22,7 +22,7 @@ function selectAnActionWithText(action) {
     cy.wait(3000);
     testLog.logStart("Scorer: Action Selection")
     cy.server()
-    cy.route('POST', '/app/*/teach/*/scorer').as('postScore')
+    cy.route('POST', '/sdk/app/*/teach/*/scorer').as('postScore')
 
     cy.get('.ms-List-page').should("be.visible").within(() => {
         cy.contains(action)

--- a/cypress/support/components/traindialogmodal.js
+++ b/cypress/support/components/traindialogmodal.js
@@ -58,10 +58,33 @@ function clickDoneTeaching() {
     .click();
 }
 
+function labelWords(phrase, entityName) {
+  cy.get('.slate-editor')
+    .type('{selectall}')
+
+  cy.get('.slate-editor')
+    .get('.cl-token-node')
+    .contains('hovercraft')
+    .then(element => {
+      selectWord(element[0])
+    })
+
+  cy.wait(10000) 
+}
+
+function selectWord(element) {
+  const range = document.createRange();
+  range.selectNodeContents(element);  
+  var selection = window.getSelection();
+  selection.removeAllRanges(); 
+  selection.addRange(range);
+}
+
 export {
   typeYourMessage,
   clickScoreActions,
   clickDoneTeaching,
   highlightWord,
-  verifyTokenNodeExists
+  verifyTokenNodeExists,
+  labelWords
 };

--- a/cypress/support/components/traindialogmodal.js
+++ b/cypress/support/components/traindialogmodal.js
@@ -9,7 +9,7 @@ const testLog = require('../utils/testlog')
 function typeYourMessage(trainmessage) {
   testLog.logStart("Submit message to WebChat");
   cy.server()
-  cy.route('PUT', '/app/*/teach/*/extractor').as('putExtractor')
+  cy.route('PUT', '/sdk/app/*/teach/*/extractor').as('putExtractor')
   cy.get('input[class="wc-shellinput"]').type(trainmessage)
   cy.get('label[class="wc-send"]')
     .then(function (response) {
@@ -39,7 +39,7 @@ function verifyTokenNodeExists() {
 function clickScoreActions() {
   testLog.logStart("Click on Score Actions");
   cy.server()
-  cy.route('PUT', '/app/*/teach/*/scorer').as('putScorer')
+  cy.route('PUT', '/sdk/app/*/teach/*/scorer').as('putScorer')
   cy.get('[data-testid="button-proceedto-scoreactions"]')
     .then(function (response) {
       testLog.logStep("proceed to score actions")

--- a/cypress/support/components/traindialogspage.js
+++ b/cypress/support/components/traindialogspage.js
@@ -15,9 +15,9 @@ function verifyPageTitle() {
 function createNew() {
   testLog.logStart("TrainDialog: Click Create New");
   cy.server()
-  cy.route('POST', '/app/*/teach').as('postTeach')
+  cy.route('POST', '/sdk/app/*/teach').as('postTeach')
   cy.route('POST', 'directline/conversations').as('postConv')
-  cy.route('PUT', '/state/conversationId?username=ConversationLearnerDeveloper&id=*').as('putConv')
+  cy.route('PUT', '/sdk/state/conversationId?userName=*&conversationId=*').as('putConv')
 
   cy.get('[data-testid="button-new-train-dialog"]')
     .then(function (response) {


### PR DESCRIPTION
I wasn't able to complete this one.  I tried the following:

1. **Using the `cy.type()` command to implicitly submit events.**
Hoped to emulate key presses that the user could have typed such as Cntrl + Shift + Right arrow them figure out the number of right arrows by the word offset and length.  Internally cypress handles all the keyup down and mouse stuff. However, it didn't seem to select the word. The first right arrow seemed to work but the entity menu closed immediately and I wasn't able to select the New Entity or existing entity button

2. **Use the `cy.trigger()` command to explicitly submit events.**
I looked up techniques used to simulate drag'n drop behavior thinking thats similar to highlighting text with your mouse. They seemed to rely and invoking the `mousedown` `mousemove` and `mouseup` events directly the correct elements.  This didn't seem to have any affect. No selection or bringing up the entity picker.

    Note: I saw an existing method in the `traindialogmodal.js` page called `highlightWord` and tried to use it which would have been a similar technique, but it didn't work eitherl

3. **Use the `cy.then()` to get direct access to `.slate-editor` element**
Since the above two approaches didn't work I was resorting to an even more low-level API. I thought I could manually build and set the browser selection / range.  It seems to select the entire node contents using `selectNodeContents` and didnt work when I tried to use the more specialized `setStartBefore` and `setEndAfter` to select only the specified words.

  Even tried just selection `.cl-token-node` containing the word "hovercraft" but that didn't work either.

