### PR TITLE
fix: bug 1775 - fix favicon.ico size error, shown in console

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "192x192",
+      "sizes": "48x48",
       "type": "image/png"
     }
   ],


### PR DESCRIPTION
Corrected the manifest size information to the actual 48 pixel square dimensions