### PR TITLE
fix: bug 1758 - block second "master" tag

### DIFF
--- a/src/components/modals/PackageCreator.tsx
+++ b/src/components/modals/PackageCreator.tsx
@@ -48,14 +48,14 @@ class PackageCreator extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     onClickCreate() {
-        this.props.onSubmit(this.state.tagNameVal, this.state.isLiveVal)
+        this.props.onSubmit(this.state.tagNameVal.trim(), this.state.isLiveVal)
     }
 
     // TODO: Refactor to use default form submission instead of manually listening for keys
     // Also has benefit of native browser validation for required fields
     onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
         // On enter attempt to create the model if required fields are set
-        if (event.keyCode === 13 && this.state.tagNameVal) {
+        if (event.keyCode === 13 && (!(this.onGetNameErrorMessage(this.state.tagNameVal)).length)) {
             this.onClickCreate();
         }
     }


### PR DESCRIPTION
Reworked the name checking logic a bit, and add name checking to ENTER/keydown logic