### PR TITLE
fix: feature 1698 - block non empty Required fields

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -923,6 +923,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
 
         return areInputsInvalid
             || (this.state.isEditing && !this.state.hasPendingChanges)
+            || (!this.state.isTerminal && (this.state.expectedEntityTags.length > 0))
     }
 
     @OF.autobind
@@ -1191,7 +1192,6 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                     onResolveSuggestions={(text, tags) => this.onResolveExpectedEntityTags(text, tags)}
                                     onRenderItem={this.onRenderExpectedTag}
                                     getTextFromItem={item => item.name}
-                                    disabled={!this.state.isTerminal}
                                     onChange={this.onChangeExpectedEntityTags}
                                     pickerSuggestionsProps={
                                         {
@@ -1253,6 +1253,10 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                 disabled={this.state.selectedActionTypeOptionKey === CLM.ActionTypes.END_SESSION}
                                 tipType={ToolTip.TipType.ACTION_WAIT}
                             />
+                        </div>
+                        <div className="cl-error-message-label"
+                            style={{ display: !this.state.isTerminal && this.state.expectedEntityTags.length ? "block" : "none", gridGap: "0" }}>
+                            {formatMessageId(intl, FM.ACTIONCREATOREDITOR_WARNING_NONEMPTYFIELD)}
                         </div>
                     </div>
                 </div>

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -45,6 +45,7 @@ export enum FM {
     ACTIONCREATOREDITOR_CONFIRM_MISSINGLABEL_WARNING = 'ActionCreatorEditor.confirmMissingLabelWarning',
     ACTIONCREATOREDITOR_WARNING_ENTITY = 'ActionCreatorEditor.warningEntity',
     ACTIONCREATOREDITOR_WARNING_PAYLOAD = 'ActionCreatorEditor.warningPayload',
+    ACTIONCREATOREDITOR_WARNING_NONEMPTYFIELD = 'ActionCreatorEditor.warningNonEmptyFields',
 
     // ActionDetails
     ACTIONDETAILSLIST_COLUMNS_RESPONSE = 'ActionDetailsList.columns.response',
@@ -530,7 +531,7 @@ export default {
         [FM.ACTIONCREATOREDITOR_CONFIRM_MISSINGLABEL_WARNING]: 'is a plain string not attached to an Entity',
         [FM.ACTIONCREATOREDITOR_WARNING_PAYLOAD]: 'Bot Response is Required',
         [FM.ACTIONCREATOREDITOR_WARNING_ENTITY]: 'Removed reference to undefined Entity',
-
+        [FM.ACTIONCREATOREDITOR_WARNING_NONEMPTYFIELD]: `Non-wait Actions can't have Expected Entities`,
 
         // ActionScorer
         [FM.ACTIONSCORER_COLUMNS_RESPONSE]: 'Response',


### PR DESCRIPTION
Now display an error message if the wait checkbox is unchecked yet Required Entities is non-empty