### PR TITLE
fix: task 1699 - require model name typed for deletion

### DIFF
--- a/src/components/modals/TextboxRestrictable.tsx
+++ b/src/components/modals/TextboxRestrictable.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Licensed under the MIT License.
+ */
+import * as React from 'react';
+import { returntypeof } from 'react-redux-typescript';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { Modal } from 'office-ui-fabric-react/lib/Modal';
+import * as OF from 'office-ui-fabric-react'
+import { State } from '../../types'
+import { injectIntl, InjectedIntlProps } from 'react-intl'
+
+interface ComponentState {
+    value: string
+}
+
+class TextboxRestrictableModal extends React.Component<Props, ComponentState> {
+    state: ComponentState = {
+        value: '',
+    }
+
+    userInputChanged(text: string) {
+        this.setState({
+            value: text
+        })
+    }
+
+    isContinueDisabled() {
+        return (this.props.matched_text != null) && this.props.matched_text !== this.state.value
+    }
+
+    @OF.autobind
+    onClickOK() {
+        this.setState({
+            value: ""
+        })
+        this.props.onOK(this.state.value)
+    }
+
+    @OF.autobind
+    onClickCancel() {
+        this.setState({
+            value: ""
+        })
+        this.props.onCancel()
+    }
+
+    @OF.autobind
+    onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
+        if ((event.key === 'Enter') && !this.isContinueDisabled()) {
+            this.onClickOK();
+        }
+    }
+
+    render() {
+        return (
+            <Modal
+                isOpen={this.props.open}
+                onDismiss={() => this.onClickCancel()}
+                isBlocking={false}
+                containerClassName='cl-modal cl-modal--small'
+            >
+                <div className='cl-modal_header'>
+                    <span className={OF.FontClassNames.mediumPlus}>
+                        {this.props.message}
+                    </span>
+                </div>
+                <div className="cl-action-creator-fieldset">
+                    <OF.TextField
+                        data-testid="user-input-modal-new-message-input"
+                        onChanged={text => this.userInputChanged(text)}
+                        placeholder={this.props.placeholder}
+                        onKeyDown={key => this.onKeyDown(key)}
+                        value={this.state.value}
+                    />
+                </div>
+                <div className='cl-modal_footer'>
+                    <div className="cl-modal-buttons">
+                        <div className="cl-modal-buttons_secondary" />
+                        <div className="cl-modal-buttons_primary">
+
+                            <OF.PrimaryButton
+                                disabled={this.isContinueDisabled()}
+                                data-testid="app-modal-continue-button"
+                                onClick={this.onClickOK}
+                                ariaDescription={this.props.button_ok}
+                                text={this.props.button_ok}
+                            />
+                            <OF.DefaultButton
+                                onClick={this.onClickCancel}
+                                ariaDescription={this.props.button_cancel}
+                                text={this.props.button_cancel}
+                            />
+                        </div>
+                    </div>
+                </div>
+            </Modal>
+        )
+    }
+}
+
+const mapDispatchToProps = (dispatch: any) => {
+    return bindActionCreators({
+    }, dispatch);
+}
+const mapStateToProps = (state: State) => {
+    return {
+        apps: state.apps.all
+    }
+}
+
+export interface ReceivedProps {
+    open: boolean
+    message: string
+    placeholder: string
+    matched_text: any
+    button_ok: string
+    button_cancel: string
+    onOK: (userInput: string) => void
+    onCancel: () => void
+}
+
+// Props types inferred from mapStateToProps & dispatchToProps
+const stateProps = returntypeof(mapStateToProps);
+const dispatchProps = returntypeof(mapDispatchToProps);
+type Props = typeof stateProps & typeof dispatchProps & ReceivedProps & InjectedIntlProps
+
+export default connect<typeof stateProps, typeof dispatchProps, ReceivedProps>(mapStateToProps, mapDispatchToProps)(injectIntl(TextboxRestrictableModal))

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -604,7 +604,7 @@ export default {
         [FM.APPSLIST_IMPORTAPP_BUTTONTEXT]: 'Import Model',
         [FM.APPSLIST_IMPORTTUTORIALS_BUTTONARIADESCRIPTION]: 'Import Tutorials Models',
         [FM.APPSLIST_IMPORTTUTORIALS_BUTTONTEXT]: 'Import Tutorials',
-        [FM.APPSLIST_CONFIRMCANCELMODALTITLE]: 'Are you sure you want to delete the {appName} model?',
+        [FM.APPSLIST_CONFIRMCANCELMODALTITLE]: `Confirm the deletion by entering the Model's name`,
         [FM.APPSLIST_COLUMN_NAME]: 'Name',
         [FM.APPSLIST_COLUMNS_LOCALE]: 'Locale',
         [FM.APPSLIST_COLUMNS_LINKEDBOTS]: 'Linked Bots',

--- a/src/routes/Apps/AppsListComponent.tsx
+++ b/src/routes/Apps/AppsListComponent.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import * as React from 'react'
-import { AppCreator as AppCreatorModal, TutorialImporterModal, ConfirmCancelModal } from '../../components/modals'
+import { AppCreator as AppCreatorModal, TutorialImporterModal } from '../../components/modals'
 import * as OF from 'office-ui-fabric-react';
 import { AppBase, AppDefinition } from '@conversationlearner/models'
 import FormattedMessageId from '../../components/FormattedMessageId'
@@ -12,6 +12,7 @@ import { FM } from '../../react-intl-messages'
 import * as Util from '../../Utils/util'
 import { User, AppCreatorType } from '../../types';
 import * as moment from 'moment'
+import TextboxRestrictableModal from '../../components/modals/TextboxRestrictable'
 
 export interface ISortableRenderableColumn extends OF.IColumn {
     render: (app: AppBase, props: Props) => JSX.Element
@@ -253,16 +254,15 @@ export class Component extends React.Component<Props, ComponentState> {
                 onCancel={props.onCancelAppCreateModal}
                 creatorType={props.appCreatorType}
             />
-            <ConfirmCancelModal
+            <TextboxRestrictableModal
                 open={props.isConfirmDeleteAppModalOpen}
+                message={Util.getDefaultText(FM.APPSLIST_CONFIRMCANCELMODALTITLE)}
+                placeholder={""}
+                matched_text={props.appToDelete ? props.appToDelete.appName : null}
+                button_ok={Util.getDefaultText(FM.ACTIONCREATOREDITOR_DELETEBUTTON_TEXT)}
+                button_cancel={Util.getDefaultText(FM.ACTIONCREATOREDITOR_CANCELBUTTON_TEXT)}
+                onOK={props.onConfirmDeleteApp}
                 onCancel={props.onCancelDeleteModal}
-                onConfirm={props.onConfirmDeleteApp}
-                title={props.intl.formatMessage({
-                    id: FM.APPSLIST_CONFIRMCANCELMODALTITLE,
-                    defaultMessage: Util.getDefaultText(FM.APPSLIST_CONFIRMCANCELMODALTITLE)
-                }, {
-                        appName: props.appToDelete ? props.appToDelete.appName : ''
-                    })}
             />
             <TutorialImporterModal
                 open={props.isImportTutorialsOpen}


### PR DESCRIPTION
Created new textbox-centric modal to support model name typing to confirm model deletion. New modal better supports generic modal dialog box-ing by abstracting away strings and button event handling