### PR TITLE
fix: bug 1819 - info icon hidden until hovered

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -107,6 +107,11 @@ html {
   color: var(--color-themePrimary) !important;
 }
 
+.cl-icon:hover {
+  color: var(--color-orangeLighter) !important;
+  background-color:transparent !important;
+}
+
 .cl-icon--transparent {
   background-color:transparent !important;
   color: #ffffff !important;
@@ -132,7 +137,7 @@ html {
 }
 
 .cl-icon[data-icon-name="Warning"] {
-  color: var(--color-alert);
+  color: var(--color-orangeLighter);
   vertical-align: sub;
   font-size: 1.2em;
 }

--- a/src/components/HelpIcon.tsx
+++ b/src/components/HelpIcon.tsx
@@ -19,12 +19,6 @@ class HelpIcon extends React.Component<Props, {}> {
                 className={className}
                 iconProps={{ iconName: this.props.iconName || 'Info' }}
                 onClick={() => { this.props.setTipType(this.props.tipType) }}
-                styles={{
-                    root: [{ color: "#aa3939 !important" }],
-                    rootHovered: [{ backgroundColor: "transparent !important" }],
-                    rootPressed: [{ backgroundColor: "transparent !important" }],
-                    iconHovered: [{ color: "#ffaaaa !important" }],
-                }}
                 title="More Information"
             />
         )


### PR DESCRIPTION
Reworked app-level icon styling so establish new icon hover state colors, making inline styling rules obsolete