### PR TITLE
 fix: add requests for model training to missing cases

### DIFF
--- a/src/actions/trainActions.ts
+++ b/src/actions/trainActions.ts
@@ -22,6 +22,7 @@ export const createTrainDialogThunkAsync = (appId: string, trainDialog: TrainDia
         try {
             let createdTrainDialog = await clClient.trainDialogsCreate(appId, trainDialog)
             dispatch(createTrainDialogFulfilled(createdTrainDialog))
+            dispatch(fetchApplicationTrainingStatusThunkAsync(appId))
             return createdTrainDialog
         }
         catch (e) {

--- a/src/components/modals/EditDialogModal.tsx
+++ b/src/components/modals/EditDialogModal.tsx
@@ -555,7 +555,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
     @OF.autobind
     onClickConvert() {
         if (this.props.editType !== EditDialogType.LOG_ORIGINAL) {
-            throw Error("Invoalid Edit Type for onClickConvert")
+            throw Error("Invalid Edit Type for onClickConvert")
         }
         this.props.onSaveDialog(this.props.trainDialog, this.trainDialogValidity())
     }


### PR DESCRIPTION
Added request for model training status in `createTrainDialogThunkAsync`

It seemed like this thunk was on two different modal: `EditModalDialog` and `TeachSessionModal`

In my searching it seems we create train dialogs in three cases.

1. New Train Dialog button
TeachSession -> prop.onClose -> onCloseTeachSession(true) -> deleteTeachSession (Implicitly creates train dialog and does polling)

2. Branch train dialog
If you click branch, enter new input, and immediately click save without adding new scorer rounds we didn't poll for training either which I think was another related bug. This also used the `createTrainDialogThunkAsync` so this fix also addressed that issue.

3. Convert Log Dialog to Train Dialog
onClickConvert -> onSave -> createTrainDialogThunkAsync

Even if this some times adds request for polling unnecessarily it will just extend the existing poll.