### PR TITLE
chore: increase type coverage for cypress

### DIFF
--- a/cypress/support/MonitorDocumentChanges.js
+++ b/cypress/support/MonitorDocumentChanges.js
@@ -8,7 +8,7 @@
  * cy.route() commands used only for waiting. It does this by constantly monitoring the
  * DOM for changes and tracking the Milliseconds Since the Last Change and also resetting
  * those Milliseconds to zero when we see the spinner is displayed. Certain cy.commands(),
- * such as cy.Get(), are then modified to prevent execution until this Millisecond count
+ * such as cy.get(), are then modified to prevent execution until this Millisecond count
  * reaches at least 700.
  * 
  * The basic premis this works on is that when the application under test is making API
@@ -60,10 +60,10 @@ var MonitorDocumentChanges = (function()
 
     Cypress.Commands.add('Get', (selector, options) => 
     {   
-      helpers.ConLog(`cy.Get(${selector})`, `Start - Last DOM change was ${MillisecondsSinceLastChange()} milliseconds ago - Selector: \n${selector}`)
+      helpers.ConLog(`cy.get(${selector})`, `Start - Last DOM change was ${MillisecondsSinceLastChange()} milliseconds ago - Selector: \n${selector}`)
       cy.wrap(700, {timeout: 60000}).should('lte', 'MillisecondsSinceLastChange').then(() => 
       {
-        helpers.ConLog(`cy.Get(${selector})`, `DOM Is Stable`)
+        helpers.ConLog(`cy.get(${selector})`, `DOM Is Stable`)
         cy.get(selector, options)
       })
     })
@@ -118,12 +118,12 @@ var MonitorDocumentChanges = (function()
 
     Cypress.Commands.add('Click', { prevSubject: true, element: true}, (subject) => 
     {
-      helpers.ConLog(`cy.Click()`, `Start - Last DOM change was ${MillisecondsSinceLastChange()} milliseconds ago`)
+      helpers.ConLog(`cy.click()`, `Start - Last DOM change was ${MillisecondsSinceLastChange()} milliseconds ago`)
       lastChangeTime = new Date().getTime()
       cy.wrap(subject).click()
         .then(()=> 
         {
-          helpers.ConLog(`cy.Click()`, `done - Last DOM change was ${MillisecondsSinceLastChange()} milliseconds ago`)
+          helpers.ConLog(`cy.click()`, `done - Last DOM change was ${MillisecondsSinceLastChange()} milliseconds ago`)
           lastChangeTime = new Date().getTime()
         })
     })

--- a/cypress/support/Train.js
+++ b/cypress/support/Train.js
@@ -272,7 +272,7 @@ export function BranchChatTurn(originalMessage, newMessage, originalIndex = 0)
 export function SelectAndVerifyEachChatTurn(index = 0)
 {
   if (index == 0) editDialogModal.GetAllChatTurns()
-  cy.Get('@allChatTurns').then(elements => 
+  cy.get('@allChatTurns').then(elements => 
   {
     if (index < elements.length)
     {

--- a/cypress/support/components/ActionModal.js
+++ b/cypress/support/components/ActionModal.js
@@ -2,11 +2,13 @@
 * Copyright (c) Microsoft Corporation. All rights reserved.  
  * Licensed under the MIT License.
 */
-export function VerifyPageTitle()         { cy.Get('[data-testid="create-an-action-title"]').contains('Create an Action').should('be.visible') }
-export function ClickNewAction()          { cy.Get('[data-testid="actions-button-create"]').Click() }
-export function ClickCreateButton()       { cy.Get('[data-testid="actioncreator-button-create"]').Click() }
+/// <reference types="Cypress" />
+
+export function VerifyPageTitle()         { cy.get('[data-testid="create-an-action-title"]').contains('Create an Action').should('be.visible') }
+export function ClickNewAction()          { cy.get('[data-testid="actions-button-create"]').Click() }
+export function ClickCreateButton()       { cy.get('[data-testid="actioncreator-button-create"]').Click() }
 export function CheckWaitForResponse()    { throw 'CheckWaitForResponse is NOT supported'} // Since this is a button and not a real check box it is difficult/ugly to manage the state. This defaults to checked.
-export function UncheckWaitForResponse()  { cy.Get('.cl-modal_body').within(() => { cy.Get('.ms-Checkbox-text').click() })}
+export function UncheckWaitForResponse()  { cy.get('.cl-modal_body').within(() => { cy.get('.ms-Checkbox-text').click() })}
 
 export function TypeExpectedEntity(entityNames)         { TypeMultipleEntities('.cl-action-creator--expected-entities', entityNames) }
 export function TypeRequiredEntities(entityNames)       { TypeMultipleEntities('.cl-action-creator--required-entities', entityNames) }
@@ -14,9 +16,9 @@ export function TypeDisqualifyingEntities(entityNames)  { TypeMultipleEntities('
 
 export function TypeResponse(textToType) 
 {
-  cy.Get('.cl-modal_body').within(() => 
+  cy.get('.cl-modal_body').within(() => 
   {
-    cy.Get('div[data-slate-editor="true"]')
+    cy.get('div[data-slate-editor="true"]')
       .clear()
       .type(textToType)
   })
@@ -28,11 +30,11 @@ function TypeMultipleEntities(selector, entityNames)
   if (!entityNames) entityNames = new Array()
   else if (!Array.isArray(entityNames)) entityNames = [entityNames]
 
-  cy.Get('.cl-modal_body').within(() => 
+  cy.get('.cl-modal_body').within(() => 
   {
-    cy.Get(selector).within(() => 
+    cy.get(selector).within(() => 
     {
-      cy.Get('.ms-BasePicker-input')
+      cy.get('.ms-BasePicker-input')
         .then((element) =>
         {
           for(var i = 0; i < entityNames.length; i++) { cy.wrap(element).type(`$${entityNames[i]}`).wait(1000).type('{enter}') }
@@ -43,7 +45,7 @@ function TypeMultipleEntities(selector, entityNames)
 
 export function SelectTypeText() 
 {
-  cy.Get('[data-testid="dropdown-action-type"]')
+  cy.get('[data-testid="dropdown-action-type"]')
     .should("be.visible")
     .Click()
     .Click()
@@ -52,9 +54,9 @@ export function SelectTypeText()
 export function TypeLetterResponse(letter) 
 {
   //if (letter ==="$") letter = '{shift}4';  //TODO: cypress is not resolving shift^4 to trigger entity finder event.
-  cy.Get('.cl-modal_body').within(() => 
+  cy.get('.cl-modal_body').within(() => 
   {
-    cy.Get('div[data-slate-editor="true"]')
+    cy.get('div[data-slate-editor="true"]')
       //.type(letter, { release: false })   //enable if the key combination works.
       .clear()
       .type(letter)

--- a/cypress/support/components/ActionsGrid.js
+++ b/cypress/support/components/ActionsGrid.js
@@ -5,7 +5,7 @@
 
 const helpers = require('../../support/Helpers')
 
-export function VerifyPageTitle()                       { cy.Get('[data-testid="actions-title"]').contains('Actions').should('be.visible') }
+export function VerifyPageTitle()                       { cy.get('[data-testid="actions-title"]').contains('Actions').should('be.visible') }
 export function ValidateExpectedEntities(entities)      { ValidateEntities('[data-testid="action-details-expected-entity"]', '[data-testid="action-details-empty-expected-entities"]', entities)}
 
 // The UI automatically populates the Required Entities field with entities found in the response text,
@@ -19,14 +19,14 @@ export function ValidateDisqualifyingEntities(expectedEntities, disqualifyingEnt
 // IMPORTANT: Call this method before calling any of the Validate* methods.
 export function GetRowToBeValidated(response)
 {
-  cy.Get('[data-testid="action-scorer-text-response"]')
+  cy.get('[data-testid="action-scorer-text-response"]')
     .contains(response)
     .parents('div.ms-DetailsRow-fields')
     .as('responseDetailsRow')
 }
 
 
-function ValidateEntitiesIsEmpty(selector)              { cy.Get('@responseDetailsRow').find(selector) }
+function ValidateEntitiesIsEmpty(selector)              { cy.get('@responseDetailsRow').find(selector) }
 
 function ValidateEntities(selector, emptySelector, entities1, entities2)
 { 
@@ -47,9 +47,9 @@ function ValidateEntities(selector, emptySelector, entities1, entities2)
   
   if (entities.length == 0) return ValidateEntitiesIsEmpty(emptySelector)
 
-  cy.Get('@responseDetailsRow').find(selector).as('entitiesList')
-  entities.forEach(entity => cy.Get('@entitiesList').contains(entity))
-  cy.Get('@entitiesList').should('have.length', entities.length)
+  cy.get('@responseDetailsRow').find(selector).as('entitiesList')
+  entities.forEach(entity => cy.get('@entitiesList').contains(entity))
+  cy.get('@entitiesList').should('have.length', entities.length)
 }
 
 

--- a/cypress/support/components/EditDialogModal.js
+++ b/cypress/support/components/EditDialogModal.js
@@ -9,34 +9,34 @@ const scorerModal = require('../../support/components/ScorerModal')
 
 export const AllChatMessagesSelector = 'div[data-testid="web-chat-utterances"] > div.wc-message-content > div > div.format-markdown > p'
 
-export function TypeYourMessage(trainMessage)         { cy.Get('input.wc-shellinput').type(`${trainMessage}{enter}`) }  // data-testid NOT possible
-export function TypeAlternativeInput(trainMessage)    { cy.Get('[data-testid="entity-extractor-alternative-input-text"]').type(`${trainMessage}{enter}`) }
-export function ClickSetInitialStateButton()          { cy.Get('[data-testid="teach-session-set-initial-state"]').Click() }
-export function ClickScoreActionsButton()             { cy.Get('[data-testid="score-actions-button"]').Click() }
-export function VerifyEntityMemoryIsEmpty()           { cy.Get('[data-testid="memory-table-empty"]').contains('Empty') }
-export function EntitySearch()                        { cy.Get('[data-testid="entity-picker-entity-search"]') }
-export function ClickAddAlternativeInputButton()      { cy.Get('[data-testid="entity-extractor-add-alternative-input-button"]').Click() }
-export function ClickEntityDetectionToken(tokenValue) { cy.Get('[data-testid="token-node-entity-value"]').contains(tokenValue).Click() }
-export function ClickSubmitChangesButton()            { cy.Get('[data-testid="submit-changes-button"]').Click() }
+export function TypeYourMessage(trainMessage)         { cy.get('input.wc-shellinput').type(`${trainMessage}{enter}`) }  // data-testid NOT possible
+export function TypeAlternativeInput(trainMessage)    { cy.get('[data-testid="entity-extractor-alternative-input-text"]').type(`${trainMessage}{enter}`) }
+export function ClickSetInitialStateButton()          { cy.get('[data-testid="teach-session-set-initial-state"]').Click() }
+export function ClickScoreActionsButton()             { cy.get('[data-testid="score-actions-button"]').Click() }
+export function VerifyEntityMemoryIsEmpty()           { cy.get('[data-testid="memory-table-empty"]').contains('Empty') }
+export function EntitySearch()                        { cy.get('[data-testid="entity-picker-entity-search"]') }
+export function ClickAddAlternativeInputButton()      { cy.get('[data-testid="entity-extractor-add-alternative-input-button"]').Click() }
+export function ClickEntityDetectionToken(tokenValue) { cy.get('[data-testid="token-node-entity-value"]').contains(tokenValue).Click() }
+export function ClickSubmitChangesButton()            { cy.get('[data-testid="submit-changes-button"]').Click() }
 export function GetAllChatMessages()                  { return helpers.StringArrayFromInnerHtml(AllChatMessagesSelector)}
-export function VerifyErrorMessage(expectedMessage)   { cy.Get('div.cl-editdialog-error > div > span').ExactMatch(expectedMessage)}
+export function VerifyErrorMessage(expectedMessage)   { cy.get('div.cl-editdialog-error > div > span').ExactMatch(expectedMessage)}
 export function VerifyNoErrorMessage()                { cy.DoesNotContain('div.cl-editdialog-error > div > span')}
-export function ClickDeleteChatTurn()                 { cy.Get('[data-testid="edit-dialog-modal-delete-turn-button"]').Click() }
+export function ClickDeleteChatTurn()                 { cy.get('[data-testid="edit-dialog-modal-delete-turn-button"]').Click() }
 
-export function ClickSaveCloseButton()                { cy.Get('[data-testid="edit-teach-dialog-close-save-button"]').Click() }
-export function VerifyCloseButtonLabel()              { cy.Get('[data-testid="edit-teach-dialog-close-save-button"]').contains('Close') }
-export function VerifySaveBranchButtonLabel()         { cy.Get('[data-testid="edit-teach-dialog-close-save-button"]').contains('Save Branch') }
-export function ClickAbandonDeleteButton()            { cy.Get('[data-testid="edit-dialog-modal-abandon-delete-button"]').Click() }
-export function VerifyDeleteButtonLabel()             { cy.Get('[data-testid="edit-dialog-modal-abandon-delete-button"]').contains('Delete') }
-export function VerifyAbandonBranchButtonLabel()      { cy.Get('[data-testid="edit-dialog-modal-abandon-delete-button"]').contains('Abandon Branch') }
-export function ClickUndoButton()                     { cy.Get('[data-testid="edit-teach-dialog-undo-button"]').Click() }
+export function ClickSaveCloseButton()                { cy.get('[data-testid="edit-teach-dialog-close-save-button"]').Click() }
+export function VerifyCloseButtonLabel()              { cy.get('[data-testid="edit-teach-dialog-close-save-button"]').contains('Close') }
+export function VerifySaveBranchButtonLabel()         { cy.get('[data-testid="edit-teach-dialog-close-save-button"]').contains('Save Branch') }
+export function ClickAbandonDeleteButton()            { cy.get('[data-testid="edit-dialog-modal-abandon-delete-button"]').Click() }
+export function VerifyDeleteButtonLabel()             { cy.get('[data-testid="edit-dialog-modal-abandon-delete-button"]').contains('Delete') }
+export function VerifyAbandonBranchButtonLabel()      { cy.get('[data-testid="edit-dialog-modal-abandon-delete-button"]').contains('Abandon Branch') }
+export function ClickUndoButton()                     { cy.get('[data-testid="edit-teach-dialog-undo-button"]').Click() }
 
-export function ClickConfirmAbandonDialogButton()     { return cy.Get('.ms-Dialog-main').contains('abandon').parents('.ms-Dialog-main').contains('Confirm').Click() }
+export function ClickConfirmAbandonDialogButton()     { return cy.get('.ms-Dialog-main').contains('abandon').parents('.ms-Dialog-main').contains('Confirm').Click() }
 
 // Verify that the branch button is within the same control group as the message.
 export function VerifyBranchButtonGroupContainsMessage(message)
 {
-  cy.Get('[data-testid="edit-dialog-modal-branch-button"]').as('branchButton')
+  cy.get('[data-testid="edit-dialog-modal-branch-button"]').as('branchButton')
     .parents('div.wc-message-selected').contains('p', message)
 }
 
@@ -90,21 +90,21 @@ export function SelectChatTurn(message, index = 0)
 export function VerifyBranchButtonIsInSameControlGroupAsMessage(message)
 {
   // Verify that the branch button is within the same control group as the originalMessage that was just selected.
-  cy.Get('[data-testid="edit-dialog-modal-branch-button"]').as('branchButton')
+  cy.get('[data-testid="edit-dialog-modal-branch-button"]').as('branchButton')
     .parents('div.wc-message-selected').contains('p', message)
 }
 
 // This depends on the '@branchButton' alias having been created by the VerifyBranchButtonIsInSameControlGroupAsMessage() function.
 export function BranchChatTurn(message)
 {
-  cy.Get('@branchButton').Click()
-  cy.Get('[data-testid="user-input-modal-new-message-input"]').type(`${message}{enter}`)
+  cy.get('@branchButton').Click()
+  cy.get('[data-testid="user-input-modal-new-message-input"]').type(`${message}{enter}`)
 }
 
 // Creates the '@allChatTurns' alias.
 export function GetAllChatTurns()
 {
-  cy.Get('[data-testid="web-chat-utterances"]').as('allChatTurns')  
+  cy.get('[data-testid="web-chat-utterances"]').as('allChatTurns')  
 }
 
 export function VerifyChatTurnControls(element, index)
@@ -123,7 +123,7 @@ export function VerifyChatTurnControls(element, index)
   
   cy.Contains('[data-testid="chat-edit-add-bot-response-button"]', '+')
 
-  if (userMessage) cy.Get('[data-testid="edit-dialog-modal-branch-button"]').Contains('Branch').ConLog(`VerifyChatTurnControls()`, 'Branch Found')
+  if (userMessage) cy.get('[data-testid="edit-dialog-modal-branch-button"]').Contains('Branch').ConLog(`VerifyChatTurnControls()`, 'Branch Found')
   else cy.DoesNotContain('[data-testid="edit-dialog-modal-branch-button"]')
 
   cy.Contains('[data-testid="chat-edit-add-user-input-button"]', '+')
@@ -133,8 +133,8 @@ export function VerifyChatTurnControls(element, index)
 export function VerifyThereAreNoChatEditControls(userMessage, botMessage)
 {
   // These confirm we are looking at the chat history we are expecting to validate.
-  cy.Get('.wc-message-from-me').contains(userMessage)
-  cy.Get('.wc-message-from-bot').contains(botMessage)
+  cy.get('.wc-message-from-me').contains(userMessage)
+  cy.get('.wc-message-from-bot').contains(botMessage)
 
   // These do the actual validation this function is intended to validate.
   cy.DoesNotContain('[data-testid="edit-dialog-modal-delete-turn-button"]')
@@ -145,8 +145,8 @@ export function VerifyThereAreNoChatEditControls(userMessage, botMessage)
 
 export function LabelTextAsEntity(text, entity)
 {
-  cy.Get('body').trigger('Test_SelectWord', {detail: text})
-  cy.Get('[data-testid="entity-picker-entity-search"]').type(`${entity}{enter}`)
+  cy.get('body').trigger('Test_SelectWord', {detail: text})
+  cy.get('[data-testid="entity-picker-entity-search"]').type(`${entity}{enter}`)
 }
 
 // Verify that a specific word of a user utterance has been labeled as an entity.
@@ -156,20 +156,20 @@ export function LabelTextAsEntity(text, entity)
 // *** word that uniquely identifies the labeled text
 export function RemoveEntityLabel(word, entity, index = 0)
 {
-  cy.Get('div.slate-editor').then(elements =>
+  cy.get('div.slate-editor').then(elements =>
   {
     expect(elements.length).to.be.at.least(index - 1)
     cy.wrap(elements[index]).within(() =>
     {
       cy.wrap(elements[index]).click()
-      cy.Get('[data-testid="token-node-entity-value"] > span > span')
+      cy.get('[data-testid="token-node-entity-value"] > span > span')
         .ExactMatch(word)
         .parents('.cl-entity-node--custom')
         .find('[data-testid="custom-entity-name-button"]')
         .contains(entity)
         .Click()
       
-      cy.Get('button[title="Unselect Entity"]').Click()
+      cy.get('button[title="Unselect Entity"]').Click()
     })
   })
 
@@ -182,7 +182,7 @@ export function RemoveEntityLabel(word, entity, index = 0)
 // *** This does NOT work for multiple words. ***
 export function VerifyEntityLabel(word, entity)
 {
-  cy.Get('[data-testid="token-node-entity-value"] > span > span')
+  cy.get('[data-testid="token-node-entity-value"] > span > span')
     .ExactMatch(word)
     .parents('.cl-entity-node--custom')
     .find('[data-testid="custom-entity-name-button"]')
@@ -197,7 +197,7 @@ export function VerifyEntityLabeledDifferentPopupAndAccept(textEntityPairs) {Ver
 
 function VerifyEntityLabeledDifferentPopupAndClickButton(textEntityPairs, buttonLabel) 
 { 
-  cy.Get('.ms-Dialog-main')     // This returns multiple parent objects
+  cy.get('.ms-Dialog-main')     // This returns multiple parent objects
     .contains('Entity is labelled differently in another user utterance') // Narrows it down to 1
     .parents('.ms-Dialog-main') // Back to the single parent object
     .within(() =>
@@ -213,7 +213,7 @@ function VerifyEntityLabeledDifferentPopupAndClickButton(textEntityPairs, button
 
 export function VerifyEntityLabelWithinSpecificInput(textEntityPairs, index)
 {
-  cy.Get('div.slate-editor').then(elements =>
+  cy.get('div.slate-editor').then(elements =>
   {
     expect(elements.length).to.be.at.least(index - 1)
     cy.wrap(elements[index]).within(() =>
@@ -228,7 +228,7 @@ export function InsertUserInputAfter(existingMessage, newMessage)
 {
   SelectChatTurn(existingMessage)
   cy.RunAndExpectDomChange(() => { Cypress.$('[data-testid="chat-edit-add-user-input-button"]')[0].click() })
-  cy.Get('[data-testid="user-input-modal-new-message-input"]').type(`${newMessage}{enter}`)
+  cy.get('[data-testid="user-input-modal-new-message-input"]').type(`${newMessage}{enter}`)
 }
 
 // OPTIONAL index parameter lets you select other than the 1st 

--- a/cypress/support/components/EntitiesGrid.js
+++ b/cypress/support/components/EntitiesGrid.js
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export function VerifyPageTitle()       { cy.Get('[data-testid="entities-title"]').contains('Entities').should('be.visible') }
-export function ClickButtonNewEntity()  { cy.Get('[data-testid="entities-button-create"]').Click() }
-export function VerifyItemInList(name)  { cy.Get('.ms-DetailsRow-cell').should('contain', name) }
+export function VerifyPageTitle()       { cy.get('[data-testid="entities-title"]').contains('Entities').should('be.visible') }
+export function ClickButtonNewEntity()  { cy.get('[data-testid="entities-button-create"]').Click() }
+export function VerifyItemInList(name)  { cy.get('.ms-DetailsRow-cell').should('contain', name) }

--- a/cypress/support/components/EntityModal.js
+++ b/cypress/support/components/EntityModal.js
@@ -4,21 +4,21 @@
  */
 const helpers = require('../Helpers')
 
-export function ClickEntityType(type)                 { cy.Get(`button.ms-Dropdown-item`).contains(type).Click() }
-export function TypeEntityName(entityName)            { cy.Get('[data-testid="entity-creator-entity-name-text"]').type(entityName) } 
-export function ClickEntityTypeDropdown()             { cy.Get('[data-testid="entity-creator-entity-type-dropdown"]').Click() }
-export function ClickCreateButton()                   { cy.Get('[data-testid="entity-creator-button-save"]').Click() }
+export function ClickEntityType(type)                 { cy.get(`button.ms-Dropdown-item`).contains(type).Click() }
+export function TypeEntityName(entityName)            { cy.get('[data-testid="entity-creator-entity-name-text"]').type(entityName) } 
+export function ClickEntityTypeDropdown()             { cy.get('[data-testid="entity-creator-entity-type-dropdown"]').Click() }
+export function ClickCreateButton()                   { cy.get('[data-testid="entity-creator-button-save"]').Click() }
 
-export function ClickMultiValueCheckbox()             { cy.Get('[data-testid="entity-creator-multi-valued-checkbox"] > button.cl-checkbox').Click() }
-export function ClickNegatableCheckbox()              { cy.Get('[data-testid="entity-creator-negatable-checkbox"] > button.cl-checkbox').Click() }
+export function ClickMultiValueCheckbox()             { cy.get('[data-testid="entity-creator-multi-valued-checkbox"] > button.cl-checkbox').Click() }
+export function ClickNegatableCheckbox()              { cy.get('[data-testid="entity-creator-negatable-checkbox"] > button.cl-checkbox').Click() }
 
-export function ClickOkButtonOnNoteAboutPreTrained()  { return cy.Get('.ms-Dialog-main').contains('pre-trained Entity').parents('.ms-Dialog-main').contains('OK').Click() }
+export function ClickOkButtonOnNoteAboutPreTrained()  { return cy.get('.ms-Dialog-main').contains('pre-trained Entity').parents('.ms-Dialog-main').contains('OK').Click() }
 
 export function SelectResolverType(resolverType)
 { 
-  cy.Get('[data-testid="entity-creator-resolver-type-dropdown"]').Click()
+  cy.get('[data-testid="entity-creator-resolver-type-dropdown"]').Click()
   
-  cy.Get('div[role="listbox"].ms-Dropdown-items > button.ms-Dropdown-item > div > div > span.clDropdown--normal')
+  cy.get('div[role="listbox"].ms-Dropdown-items > button.ms-Dropdown-item > div > div > span.clDropdown--normal')
     .ExactMatch(resolverType)
     .parents('button.ms-Dropdown-item')
     .Click()

--- a/cypress/support/components/HomePage.js
+++ b/cypress/support/components/HomePage.js
@@ -8,21 +8,21 @@ const settings = require('../components/Settings')
 const helpers = require('../Helpers')
 
 export function Visit()                         { return cy.visit('http://localhost:5050'); VerifyPageTitle() }
-export function VerifyPageTitle()               { return cy.Get('[data-testid="model-list-title"]').contains('Create and manage your Conversation Learner models').should('be.visible') }
-export function NavigateToModelPage(name)       { return cy.Get('[data-testid="model-list-model-name"]').ExactMatch(`${name}`).Click() }
-export function ClickNewModelButton()           { return cy.Get('[data-testid="model-list-create-new-button"]').Click() }
-export function ClickImportModelButton()        { return cy.Get('[data-testid="model-list-import-model-button"]').Click() }
-export function TypeModelName(name)             { return cy.Get('[data-testid="model-creator-input-name"]').type(name) }
-export function ClickSubmitButton()             { return cy.Get('[data-testid="model-creator-submit-button"]').Click() }
+export function VerifyPageTitle()               { return cy.get('[data-testid="model-list-title"]').contains('Create and manage your Conversation Learner models').should('be.visible') }
+export function NavigateToModelPage(name)       { return cy.get('[data-testid="model-list-model-name"]').ExactMatch(`${name}`).Click() }
+export function ClickNewModelButton()           { return cy.get('[data-testid="model-list-create-new-button"]').Click() }
+export function ClickImportModelButton()        { return cy.get('[data-testid="model-list-import-model-button"]').Click() }
+export function TypeModelName(name)             { return cy.get('[data-testid="model-creator-input-name"]').type(name) }
+export function ClickSubmitButton()             { return cy.get('[data-testid="model-creator-submit-button"]').Click() }
 
 export function UploadImportModelFile(name)     { return cy.UploadFile(name, `[data-testid=model-creator-import-file-picker] > div > input[type="file"]`)}
 
-export function ClickDeleteModelButton(row)     { return cy.Get(`[data-list-index="${row}"] > .ms-FocusZone > .ms-DetailsRow-fields`).find('i[data-icon-name="Delete"]').Click() }
-export function ClickConfirmButton()            { return cy.Get('.ms-Dialog-main').contains('Confirm').Click() }
+export function ClickDeleteModelButton(row)     { return cy.get(`[data-list-index="${row}"] > .ms-FocusZone > .ms-DetailsRow-fields`).find('i[data-icon-name="Delete"]').Click() }
+export function ClickConfirmButton()            { return cy.get('.ms-Dialog-main').contains('Confirm').Click() }
 
 export function GetModelListRowCount() 
 {
-  return cy.Get('[data-automationid="DetailsList"] > [role="grid"]')
+  return cy.get('[data-automationid="DetailsList"] > [role="grid"]')
   .then(gridElement => { var rowCount = +gridElement.attr('aria-rowcount') -1; return rowCount })
 }
 

--- a/cypress/support/components/LogDialogModal.js
+++ b/cypress/support/components/LogDialogModal.js
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-export function CreateNewLogDialogButton()  { cy.Get('[data-testid="log-dialogs-new-button"]').Click() }
-export function ClickDoneTestingButton()    { return cy.Get('[data-testid="chat-session-modal-done-testing-button"]').Click() }
-export function ClickSessionTimeoutButton() { cy.Get('[data-testid="chat-session-modal-session-timeout-button"]').Click() }
-export function TypeYourMessage(message)    { cy.Get('input[placeholder="Type your message..."]').type(`${message}{enter}`) }  // data-testid NOT possible
+export function CreateNewLogDialogButton()  { cy.get('[data-testid="log-dialogs-new-button"]').Click() }
+export function ClickDoneTestingButton()    { return cy.get('[data-testid="chat-session-modal-done-testing-button"]').Click() }
+export function ClickSessionTimeoutButton() { cy.get('[data-testid="chat-session-modal-session-timeout-button"]').Click() }
+export function TypeYourMessage(message)    { cy.get('input[placeholder="Type your message..."]').type(`${message}{enter}`) }  // data-testid NOT possible
 
 export function TypeYourMessageValidateResponse(message, expectedResponse)
 {
-  cy.Get('input[placeholder="Type your message..."]').type(`${message}{enter}`)  // data-testid NOT possible
+  cy.get('input[placeholder="Type your message..."]').type(`${message}{enter}`)  // data-testid NOT possible
 
   // Verify both the input message is reflected back and the response is what we are expecting.
   // This also has the useful side effect of blocking this function from returning until after
   // the response has been returned.
   var messageCount = 0
   var expectedUtterance = message.replace(/'/g, "’")
-  cy.Get('.wc-message-content').then(elements => 
+  cy.get('.wc-message-content').then(elements => 
   {
     messageCount = elements.length;
     cy.wrap(elements[elements.length - 1]).contains(expectedUtterance)
@@ -26,14 +26,14 @@ export function TypeYourMessageValidateResponse(message, expectedResponse)
     if (expectedResponse)
     {
       expectedUtterance = expectedResponse.replace(/'/g, "’")
-      cy.Get('.wc-message-content', {timeout: 60000}).then(elements => 
+      cy.get('.wc-message-content', {timeout: 60000}).then(elements => 
       {
         cy.wrap(elements[messageCount]).contains(expectedUtterance)
       })
     }
     else
     {
-      cy.Get('.wc-message-content', {timeout: 60000}).then(elements => 
+      cy.get('.wc-message-content', {timeout: 60000}).then(elements => 
       {
         cy.wrap(elements[messageCount]).DoesNotContain(expectedUtterance)
       })

--- a/cypress/support/components/LogDialogsGrid.js
+++ b/cypress/support/components/LogDialogsGrid.js
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export function VerifyPageTitle()           { cy.Get('[data-testid="log-dialogs-title"]').contains('Log Dialogs').should('be.visible') }
-export function CreateNewLogDialogButton()  { cy.Get('[data-testid="log-dialogs-new-button"]').Click() }
+export function VerifyPageTitle()           { cy.get('[data-testid="log-dialogs-title"]').contains('Log Dialogs').should('be.visible') }
+export function CreateNewLogDialogButton()  { cy.get('[data-testid="log-dialogs-new-button"]').Click() }

--- a/cypress/support/components/MemoryTableComponent.js
+++ b/cypress/support/components/MemoryTableComponent.js
@@ -7,11 +7,11 @@
 // the "displacedValue" parameter will verify it is displayed.
 export function VerifyEntityInMemory(entityName, entityValues, displacedValue)
 {
-  cy.Get('[data-testid="entity-memory-name"]').contains(entityName)
+  cy.get('[data-testid="entity-memory-name"]').contains(entityName)
 
   if (!Array.isArray(entityValues)) entityValues = [entityValues]
   for (var i = 0; i < entityValues.length; i++) 
-    cy.Get('.cl-font--emphasis,[data-testid="entity-memory-value"]').contains(entityValues[i])
+    cy.get('.cl-font--emphasis,[data-testid="entity-memory-value"]').contains(entityValues[i])
   
-  if (displacedValue) cy.Get('.cl-font--deleted,[data-testid="entity-memory-value"]').contains(displacedValue)
+  if (displacedValue) cy.get('.cl-font--deleted,[data-testid="entity-memory-value"]').contains(displacedValue)
 }

--- a/cypress/support/components/ModelPage.js
+++ b/cypress/support/components/ModelPage.js
@@ -9,19 +9,19 @@ const trainDialogsGrid = require('./TrainDialogsGrid')
 const logDialogsGrid = require('../../support/components/LogDialogsGrid')
 const settings = require('../../support/components/Settings')
  
-export function VerifyModelName(name)     { cy.Get('[data-testid="app-index-model-name"]').should(el => { expect(el).to.contain(name) })}
-export function VerifyPageTitle()         { cy.Get('[data-testid="dashboard-title"]').contains('Log Dialogs').should('be.visible') }
+export function VerifyModelName(name)     { cy.get('[data-testid="app-index-model-name"]').should(el => { expect(el).to.contain(name) })}
+export function VerifyPageTitle()         { cy.get('[data-testid="dashboard-title"]').contains('Log Dialogs').should('be.visible') }
 
-export function NavigateToHome()          { cy.Get('[data-testid="app-index-nav-link-home"]').Click();          VerifyPageTitle() }
-export function NavigateToEntities()      { cy.Get('[data-testid="app-index-nav-link-entities"]').Click();      entitiesGrid.VerifyPageTitle() }
-export function NavigateToActions()       { cy.Get('[data-testid="app-index-nav-link-actions"]').Click();       actionsGrid.VerifyPageTitle() }
-export function NavigateToTrainDialogs()  { cy.Get('[data-testid="app-index-nav-link-train-dialogs"]').Click(); trainDialogsGrid.VerifyPageTitle() }
-export function NavigateToLogDialogs()    { cy.Get('[data-testid="app-index-nav-link-log-dialogs"]').Click();   logDialogsGrid.VerifyPageTitle() }
-export function NavigateToSettings()      { cy.Get('[data-testid="app-index-nav-link-settings"]').Click();      settings.VerifyPageTitle() }
+export function NavigateToHome()          { cy.get('[data-testid="app-index-nav-link-home"]').Click();          VerifyPageTitle() }
+export function NavigateToEntities()      { cy.get('[data-testid="app-index-nav-link-entities"]').Click();      entitiesGrid.VerifyPageTitle() }
+export function NavigateToActions()       { cy.get('[data-testid="app-index-nav-link-actions"]').Click();       actionsGrid.VerifyPageTitle() }
+export function NavigateToTrainDialogs()  { cy.get('[data-testid="app-index-nav-link-train-dialogs"]').Click(); trainDialogsGrid.VerifyPageTitle() }
+export function NavigateToLogDialogs()    { cy.get('[data-testid="app-index-nav-link-log-dialogs"]').Click();   logDialogsGrid.VerifyPageTitle() }
+export function NavigateToSettings()      { cy.get('[data-testid="app-index-nav-link-settings"]').Click();      settings.VerifyPageTitle() }
 export function VerifyNoErrorIconOnPage() { cy.DoesNotContain('i[data-icon-name="IncidentTriangle"].cl-color-error') }
 
 // For the Left Pane "Train Dialogs" link.
-export function VerifyErrorIconForTrainDialogs() { cy.Get('[data-testid="app-index-nav-link-train-dialogs"]').find('i[data-icon-name="IncidentTriangle"].cl-color-error') }
+export function VerifyErrorIconForTrainDialogs() { cy.get('[data-testid="app-index-nav-link-train-dialogs"]').find('i[data-icon-name="IncidentTriangle"].cl-color-error') }
 
 // To validate that this code works, search src\actions\appActions.ts for these and alter them:
 //   fetchApplicationTrainingStatusThunkAsync

--- a/cypress/support/components/ScorerModal.js
+++ b/cypress/support/components/ScorerModal.js
@@ -6,13 +6,13 @@
 const helpers = require('../../support/Helpers')
 
 // data-testid="teach-session-admin-train-status" (Running, Completed, Failed)
-export function ClickRefreshScoreButton()       { cy.Get('[data-testid="teach-session-admin-refresh-score-button"]').Click() }
-export function SelectAnAction()                { cy.Get('[data-testid="action-scorer-button-clickable"]').should("be.visible").Click() }
-export function ClickAddActionButton()          { cy.Get('[data-testid="action-scorer-add-action-button"]').Click() }
+export function ClickRefreshScoreButton()       { cy.get('[data-testid="teach-session-admin-refresh-score-button"]').Click() }
+export function SelectAnAction()                { cy.get('[data-testid="action-scorer-button-clickable"]').should("be.visible").Click() }
+export function ClickAddActionButton()          { cy.get('[data-testid="action-scorer-add-action-button"]').Click() }
 
 export function ClickAction(expectedResponse, expectedIndexForActionPlacement)
 {
-  cy.Get('[data-testid="action-scorer-text-response"]').ExactMatch(expectedResponse)
+  cy.get('[data-testid="action-scorer-text-response"]').ExactMatch(expectedResponse)
     .parents('div.ms-DetailsRow-fields').find('[data-testid="action-scorer-button-clickable"]')
     .Click()
   VerifyChatMessage(expectedResponse, expectedIndexForActionPlacement)
@@ -22,7 +22,7 @@ export function ClickAction(expectedResponse, expectedIndexForActionPlacement)
 export function VerifyChatMessage(expectedMessage, expectedIndexOfMessage)
 {
   var expectedUtterance = expectedMessage.replace(/'/g, "’")
-  cy.Get('[data-testid="web-chat-utterances"]').then(elements => {
+  cy.get('[data-testid="web-chat-utterances"]').then(elements => {
     if(!expectedIndexOfMessage) expectedIndexOfMessage = elements.length - 1
     cy.wrap(elements[expectedIndexOfMessage]).within(e => {
       cy.get('div.format-markdown > p').should('have.text', expectedUtterance)
@@ -31,21 +31,21 @@ export function VerifyChatMessage(expectedMessage, expectedIndexOfMessage)
 
 export function VerifyContainsEnabledAction(expectedResponse)
 {
-    cy.Get('[data-testid="action-scorer-text-response"]').contains(expectedResponse)
+    cy.get('[data-testid="action-scorer-text-response"]').contains(expectedResponse)
     .parents('div.ms-DetailsRow-fields').find('[data-testid="action-scorer-button-clickable"]')
     .should('be.enabled')
 }
 
 export function VerifyContainsDisabledAction(expectedResponse)
 {
-    cy.Get('[data-testid="action-scorer-text-response"]').contains(expectedResponse)
+    cy.get('[data-testid="action-scorer-text-response"]').contains(expectedResponse)
     .parents('div.ms-DetailsRow-fields').find('[data-testid="action-scorer-button-no-click"]')
     .should('be.disabled')
 }
 
 export function VerifyEntityInMemory(entityName, entityValue)
 {
-  cy.Get('[data-testid="entity-memory-name"]').contains(entityName)
-  cy.Get('[data-testid="entity-memory-value"]').contains(entityValue)
+  cy.get('[data-testid="entity-memory-name"]').contains(entityName)
+  cy.get('[data-testid="entity-memory-value"]').contains(entityValue)
 }
 

--- a/cypress/support/components/SetInitialEntityValuesModal.js
+++ b/cypress/support/components/SetInitialEntityValuesModal.js
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export function ClickAddInitialValueButton(entityName)      { cy.Get('[data-testid="teach-session-add-initial-value"]').contains(entityName).Click() }
-export function VerifyEntityValue(expectedValue)            { cy.Get('[data-testid="teach-session-entity-name"]').contains(expectedValue) }
-export function TypeInitialValue(entityName, initialValue)  { cy.Get('[data-testid="teach-session-initial-value"]').contains(entityName).type(`${initialValue}{enter}`) }
-export function ClickDeleteButton(entityName)               { cy.Get('[data-testid="teach-session-delete-button"]').contains(entityName).Click() }
+export function ClickAddInitialValueButton(entityName)      { cy.get('[data-testid="teach-session-add-initial-value"]').contains(entityName).Click() }
+export function VerifyEntityValue(expectedValue)            { cy.get('[data-testid="teach-session-entity-name"]').contains(expectedValue) }
+export function TypeInitialValue(entityName, initialValue)  { cy.get('[data-testid="teach-session-initial-value"]').contains(entityName).type(`${initialValue}{enter}`) }
+export function ClickDeleteButton(entityName)               { cy.get('[data-testid="teach-session-delete-button"]').contains(entityName).Click() }
 
-export function ClickOkButton()                             { cy.Get('[data-testid="teach-session-ok-button"]').Click() }
-export function ClickCancelButton()                         { cy.Get('[data-testid="teach-session-cancel-button"]').Click() }
+export function ClickOkButton()                             { cy.get('[data-testid="teach-session-ok-button"]').Click() }
+export function ClickCancelButton()                         { cy.get('[data-testid="teach-session-cancel-button"]').Click() }

--- a/cypress/support/components/Settings.js
+++ b/cypress/support/components/Settings.js
@@ -5,12 +5,12 @@
 
 const entitiesGrid = require('../../support/components/EntitiesGrid')
 
-export function VerifyPageTitle()         { cy.Get('[data-testid="settings-title"]').contains('Settings').should('be.visible') }
+export function VerifyPageTitle()         { cy.get('[data-testid="settings-title"]').contains('Settings').should('be.visible') }
 
 export function DeleteModel(modelName)       
 { 
   cy.visit('http://localhost:5050')
-  // cy.Get('[data-testId="settings-delete-model-button"]').Click() 
-  // cy.Get('[data-testid="user-input-modal-new-message-input"]').type(`${modelName}{enter}`)
+  // cy.get('[data-testId="settings-delete-model-button"]').Click() 
+  // cy.get('[data-testid="user-input-modal-new-message-input"]').type(`${modelName}{enter}`)
 }
 

--- a/cypress/support/components/TrainDialogsGrid.js
+++ b/cypress/support/components/TrainDialogsGrid.js
@@ -6,16 +6,16 @@
 const helpers = require('../Helpers')
 
 // Path to product code: ConversationLearner-UI\src\routes\Apps\App\TrainDialogs.tsx
-export function VerifyPageTitle()                 { cy.Get('[data-testid="train-dialogs-title"]').contains('Train Dialogs').should('be.visible') }
-export function CreateNewTrainDialog()            { cy.Get('[data-testid="button-new-train-dialog"]').Click()}
-export function SearchBox()                       { cy.Get('label[for="traindialogs-input-search"]').contains('input.ms-SearchBox-field') }
-export function EntityDropDownFilter()            { cy.Get('[data-testid="dropdown-filter-by-entity"]')}
-export function ActionDropDownFilter()            { cy.Get('[data-testid="dropdown-filter-by-action"]')}
-export function ClickTraining(row)                { cy.Get('[data-testid="train-dialogs-first-input"]').then(elements => { cy.wrap(elements[row]).Click() })}
+export function VerifyPageTitle()                 { cy.get('[data-testid="train-dialogs-title"]').contains('Train Dialogs').should('be.visible') }
+export function CreateNewTrainDialog()            { cy.get('[data-testid="button-new-train-dialog"]').Click()}
+export function SearchBox()                       { cy.get('label[for="traindialogs-input-search"]').contains('input.ms-SearchBox-field') }
+export function EntityDropDownFilter()            { cy.get('[data-testid="dropdown-filter-by-entity"]')}
+export function ActionDropDownFilter()            { cy.get('[data-testid="dropdown-filter-by-action"]')}
+export function ClickTraining(row)                { cy.get('[data-testid="train-dialogs-first-input"]').then(elements => { cy.wrap(elements[row]).Click() })}
 
 export function WaitForGridReadyThen(expectedRowCount, functionToRunAfterGridIsReady)  
 { 
-  cy.Get('[data-testid="train-dialogs-turns"]')
+  cy.get('[data-testid="train-dialogs-turns"]')
     .should(elements => { expect(elements).to.have.length(expectedRowCount) })
     .then(() => { functionToRunAfterGridIsReady() }) 
 }
@@ -28,4 +28,4 @@ export function GetTurns()                        { return helpers.NumericArrayF
 export function GetLastModifiedDates()            { return helpers.StringArrayFromInnerHtml('[data-testid="train-dialogs-last-modified"]')}
 export function GetCreatedDates()                 { return helpers.StringArrayFromInnerHtml('[data-testid="train-dialogs-created"]')}
 
-export function VerifyErrorIconForTrainGridRow(rowIndex) { cy.Get(`div.ms-List-cell[data-list-index="${rowIndex}"]`).find('i[data-icon-name="IncidentTriangle"].cl-color-error') }
+export function VerifyErrorIconForTrainGridRow(rowIndex) { cy.get(`div.ms-List-cell[data-list-index="${rowIndex}"]`).find('i[data-icon-name="IncidentTriangle"].cl-color-error') }


### PR DESCRIPTION
Ideally we would have full type coverage because everything would be Typescript but that is more complicated and I'm still investigating. This is preliminary change that still has a lot of value.

Before there were NO types.
See below I'm hovering over `cy` and it says `any` which is not useful
![image](https://user-images.githubusercontent.com/2856501/51351187-03d4be00-1a5f-11e9-9544-fc1fe938ce9b.png)

**1. Add `/// <reference types="Cypress" />` to one of the files.**
I originally thought it had to be added to all files but it seems only one is ok. I only put it one one to minimize changes but we can add it future if needed.

I'm hovering over `cy` but get all the type information
![image](https://user-images.githubusercontent.com/2856501/51351325-72b21700-1a5f-11e9-8a8f-74782b82e432.png)

This is great, but as you can see even with the `/// <reference>` the incorrectly cased method names are not found.
![image](https://user-images.githubusercontent.com/2856501/51351488-d8060800-1a5f-11e9-89c7-512bf71d47e4.png)

**2. Fix the method name casing**
![image](https://user-images.githubusercontent.com/2856501/51351386-9d9c6b00-1a5f-11e9-80cd-0f286c853e05.png)

## Outcome:
- Have type information and standard `cy` chainable method.

## Does NOT cover:
- Commands
There is extensive use of custom commands like `WaitForStableDOM` which is not known about.
After this, I believe everything will be `any`

## Future plans:
- Convert everything to Typescript

## Going forward:
Please use the `camelCased` names the are available with typing information.  I'm not even sure how the Pascal case names worked before. I assume cypress has an alias. Anyways, it is a convention for Typescript / Javascript.  Capital method names are usually reserved for `static` methods.