### PR TITLE
feat: allow interface to be served at /ui path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ package
 .env.test.local
 .env.production.local
 ~*.xlsx
+server.js
 
 npm-debug.log*
 yarn-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -580,6 +580,16 @@
       "integrity": "sha512-OTPWHmsyW18BhrnG5x8F7PzeZ2nFxmHGb42bZn79P9hl+GI5cMzyPgQTwNjbem0lJhoru/8vtjAFCUOu3+gE2w==",
       "dev": true
     },
+    "@types/body-parser": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/chai": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
@@ -596,6 +606,21 @@
         "@types/jquery": "*"
       }
     },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
+      "dev": true
+    },
     "@types/execa": {
       "version": "0.8.1",
       "resolved": "http://registry.npmjs.org/@types%2fexeca/-/execa-0.8.1.tgz",
@@ -603,6 +628,28 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.0.tgz",
+      "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
+      "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/file-saver": {
@@ -648,6 +695,12 @@
       "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
       "dev": true
     },
+    "@types/mime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -669,6 +722,12 @@
       "version": "15.5.6",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
       "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
     },
     "@types/react": {
@@ -737,6 +796,16 @@
         "@types/history": "*",
         "@types/react": "*",
         "redux": "^3.7.2"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "@types/sinon": {
@@ -1215,7 +1284,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
         "chalk": "^1.1.3",
@@ -2107,7 +2176,7 @@
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "bcrypt-pbkdf": {
@@ -2189,7 +2258,7 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "botframework-directlinejs": {
@@ -2454,7 +2523,7 @@
     },
     "bytes": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
@@ -2675,7 +2744,7 @@
     },
     "cheerio": {
       "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
         "css-select": "~1.2.0",
@@ -3158,7 +3227,7 @@
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compressible": {
@@ -3734,7 +3803,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -4175,7 +4244,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
         "es5-ext": "^0.10.9"
@@ -4300,7 +4369,7 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
@@ -4504,7 +4573,7 @@
     },
     "doctrine": {
       "version": "0.7.2",
-      "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
@@ -4514,7 +4583,7 @@
       "dependencies": {
         "esutils": {
           "version": "1.1.6",
-          "resolved": "http://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
           "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
           "dev": true
         }
@@ -4807,7 +4876,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -4898,12 +4967,12 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
@@ -5275,7 +5344,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastparse": {
@@ -6230,7 +6299,7 @@
     },
     "fuse.js": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
       "integrity": "sha1-8ESOgGmFW/Kj5oPNwdMg5+KgfvQ="
     },
     "get-caller-file": {
@@ -7222,12 +7291,12 @@
     },
     "intl-format-cache": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
       "integrity": "sha1-BKNp/sv61tpgBbrh8UMzMy3PkxY="
     },
     "intl-messageformat": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
       "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
       "requires": {
         "intl-messageformat-parser": "1.4.0"
@@ -7235,12 +7304,12 @@
     },
     "intl-messageformat-parser": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
       "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
     },
     "intl-relativeformat": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
       "integrity": "sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=",
       "requires": {
         "intl-messageformat": "^2.0.0"
@@ -7261,7 +7330,7 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "http://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
@@ -8018,7 +8087,7 @@
     },
     "js-yaml": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
         "argparse": "^1.0.7",
@@ -8208,7 +8277,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -8391,7 +8460,7 @@
     },
     "load-script": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
       "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-runner": {
@@ -8435,12 +8504,12 @@
     },
     "lodash.assignin": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
       "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
     "lodash.bind": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
     },
     "lodash.camelcase": {
@@ -8455,7 +8524,7 @@
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.endswith": {
@@ -8465,17 +8534,17 @@
     },
     "lodash.filter": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.foreach": {
       "version": "4.5.0",
-      "resolved": "http://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
     "lodash.isfunction": {
@@ -8534,12 +8603,12 @@
     },
     "lodash.reduce": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
       "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
     },
     "lodash.reject": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
       "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
     },
     "lodash.snakecase": {
@@ -8550,7 +8619,7 @@
     },
     "lodash.some": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.sortby": {
@@ -8911,7 +8980,7 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
@@ -9470,7 +9539,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -9663,7 +9732,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
         "deep-is": "~0.1.3",
@@ -11227,7 +11296,7 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
@@ -12384,7 +12453,7 @@
     },
     "redux-thunk": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
       "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
     },
     "regenerate": {
@@ -12590,7 +12659,7 @@
     },
     "replace-ext": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
@@ -13264,7 +13333,7 @@
     },
     "slick": {
       "version": "1.12.2",
-      "resolved": "http://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
       "integrity": "sha1-vQSN23TefRymkV+qSldXCzVQwtc="
     },
     "smart-buffer": {
@@ -13452,7 +13521,7 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-loader": {
@@ -13980,7 +14049,7 @@
     },
     "symbol-observable": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "symbol-tree": {
@@ -14208,7 +14277,7 @@
     },
     "trim": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
@@ -14754,7 +14823,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -14857,7 +14926,7 @@
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -15125,7 +15194,7 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
@@ -15350,7 +15419,7 @@
     },
     "vfile": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
         "is-buffer": "^1.1.4",
@@ -16672,7 +16741,7 @@
     },
     "x-is-string": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@conversationlearner/ui",
   "version": "0.0.0-development",
   "description": "Administration user interface for creating, training, and testing bots created using Conversation Learner",
+  "homepage": "http://localhost:3978/ui",
   "keywords": [
     "Microsoft",
     "bots",
@@ -59,32 +60,34 @@
     "@commitlint/cli": "7.0.0",
     "@commitlint/config-conventional": "7.0.1",
     "@types/execa": "^0.8.1",
+    "@types/express": "^4.16.0",
     "@types/fs-extra": "^5.0.4",
     "@types/history": "4.7.0",
     "@types/jest": "^20.0.8",
     "@types/node": "^8.10.36",
     "@types/prop-types": "^15.5.6",
     "@types/react": "^16.4.18",
-    "@types/react-router-dom": "^4.3.1",
     "@types/react-dom": "^16.0.9",
     "@types/react-intl": "^2.3.11",
     "@types/react-redux": "^5.0.21",
+    "@types/react-router-dom": "^4.3.1",
     "@types/redux-auth-wrapper": "^2.0.8",
     "commitizen": "2.10.1",
     "cross-env": "^5.2.0",
     "cypress": "3.0.3",
     "execa": "^0.9.0",
+    "express": "^4.16.4",
     "fs-extra": "^5.0.0",
     "husky": "0.14.3",
     "mocha": "5.2.0",
     "mocha-junit-reporter": "1.17.0",
     "mocha-multi-reporters": "1.1.7",
+    "path-parse": "^1.0.6",
     "tslint": "5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-config-standard": "^7.1.0",
     "tslint-microsoft-contrib": "^5.2.1",
-    "typescript": "3.0.3",
-    "path-parse": "^1.0.6"
+    "typescript": "3.0.3"
   },
   "scripts": {
     "lint": "tslint -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
@@ -101,7 +104,8 @@
     "tsc": "tsc",
     "builduipackage": "tsc -p ./publish/tsconfig.json --listFiles && tsc -p ./scripts/tsconfig.json --listFiles && node ./scripts/publish.js",
     "commit": "git-cz",
-    "commitmsg": "commitlint -E GIT_PARAMS"
+    "commitmsg": "commitlint -E GIT_PARAMS",
+    "servebuild": "tsc -p ./server/tsconfig.json && node ./server/server.js"
   },
   "config": {
     "commitizen": {

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="%PUBLIC_URL%/index.css">
     <link rel="stylesheet" href="%PUBLIC_URL%/botchat.css">
+    <base href="%PUBLIC_URL%/">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,0 +1,17 @@
+import * as express from 'express'
+import * as path from 'path'
+
+const buildPath = path.join(__dirname, '..', 'build')
+const indexPath = path.join(buildPath, 'index.html')
+
+const router = express.Router({ caseSensitive: false })
+router.use('/ui', express.static(buildPath));
+router.get('/ui/*', function(_, res) {
+    res.sendFile(indexPath)
+})
+
+const app = express()
+app.use(router)
+app.listen(9000, () => {
+    console.log(`Testing ${buildPath} on port 9000`)
+});

--- a/server/server.ts
+++ b/server/server.ts
@@ -12,6 +12,6 @@ router.get('/ui/*', function(_, res) {
 
 const app = express()
 app.use(router)
-app.listen(9000, () => {
-    console.log(`Testing ${buildPath} on port 9000`)
+const listener = app.listen(9000, () => {
+    console.log(`Testing ${buildPath} on port: ${listener.address().port}`)
 });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,63 @@
+{
+    "compilerOptions": {
+      /* Basic Options */
+      "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+      "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+      "lib": [
+          "es2015",
+          "webworker"
+      ],                             /* Specify library files to be included in the compilation:  */
+      // "allowJs": true,                       /* Allow javascript files to be compiled. */
+      // "checkJs": true,                       /* Report errors in .js files. */
+      // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+      // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+      // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+      // "outFile": "./",                       /* Concatenate and emit output to single file. */
+      // "outDir": "./lib",                        /* Redirect output structure to the directory. */
+      // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+      // "removeComments": true,                /* Do not emit comments to output. */
+      // "noEmit": true,                        /* Do not emit outputs. */
+      // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+      // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+      // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+  
+      /* Strict Type-Checking Options */
+      "strict": true,                           /* Enable all strict type-checking options. */
+      // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+      // "strictNullChecks": true,              /* Enable strict null checks. */
+      // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+      // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+      // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+  
+      /* Additional Checks */
+      "noUnusedLocals": true,                /* Report errors on unused locals. */
+      "noUnusedParameters": true,            /* Report errors on unused parameters. */
+      "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+      "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+  
+      /* Module Resolution Options */
+      "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+      // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+      // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+      "typeRoots": [],                       /* List of folders to include type definitions from. */
+      "types": [
+        "node"
+      ]                          /* Type declaration files to be included in compilation. */
+      // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+      // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+  
+      /* Source Map Options */
+      // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+      // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+      // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+      // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+  
+      /* Experimental Options */
+      // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+      // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    },
+    "include": [
+      "./server.ts"
+    ]
+  }

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -100,14 +100,14 @@ class App extends React.Component<Props, ComponentState> {
   render() {
     const banner = this.props.botInfo ? this.props.botInfo.banner : null
     return (
-      <Router>
+      <Router basename={process.env.PUBLIC_URL}>
         <div className="cl-app">
           <div className="cl-app_header-placeholder" />
           <header className={`cl-app_header cl-header`}>
             <nav className="cl-header_links">
-              <img className="cl-header-logo" src="/Microsoft-logo_rgb_c-wht.png" alt="Microsoft Logo" />
+              <img className="cl-header-logo" src="Microsoft-logo_rgb_c-wht.png" alt="Microsoft Logo" />
               <span className="cl-header-text">
-                <img className="cl-header-icon" src="/icon.svg" alt="ConversationLearner Logo" />
+                <img className="cl-header-icon" src="icon.svg" alt="ConversationLearner Logo" />
                 Project Conversation Learner
               </span>
               <NavLink to="/home">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     "node_modules",
     "build",
     "scripts",
+    "server",
     "acceptance-tests",
     "webpack",
     "jest",


### PR DESCRIPTION
Currently we require a separate command to serve the UI. This runs the bot on a separate port from the bot and serves it at the root.

Goals:
- This PR will change the package output so the UI can be served at `/ui` path.
- Development remains unchanged! You can still `npm start` and view at `localhost:5050/`
- Tests run from CircleCI should remain unchanged because they use 

Also added a `server` folder which allows testing the built package and seeing that it works on the `/ui` path.