### PR TITLE
fix: allow opening model by clicking anywhere in the row

### DIFF
--- a/src/routes/Apps/AppsListComponent.tsx
+++ b/src/routes/Apps/AppsListComponent.tsx
@@ -28,7 +28,7 @@ function getColumns(intl: InjectedIntl): ISortableRenderableColumn[] {
             maxWidth: 200,
             isResizable: true,
             getSortValue: app => app.appName,
-            render: (app, props) => <span className={OF.FontClassNames.mediumPlus}><OF.Link onClick={() => props.onClickApp(app)} data-testid="model-list-model-name" data-model-id={app.appId}>{app.appName}</OF.Link></span>
+            render: (app, props) => <span className={OF.FontClassNames.mediumPlus} data-testid="model-list-model-name" data-model-id={app.appId}>{app.appName}</span>
         },
         {
             key: 'isEditing',
@@ -230,6 +230,7 @@ export class Component extends React.Component<Props, ComponentState> {
                 checkboxVisibility={OF.CheckboxVisibility.hidden}
                 onRenderItemColumn={(app, i, column: ISortableRenderableColumn) => column.render(app, props)}
                 onColumnHeaderClick={this.onClickColumnHeader}
+                onActiveItemChanged={app => this.props.onClickApp(app)}
             />
             <AppCreatorModal
                 open={props.isAppCreateModalOpen}


### PR DESCRIPTION
This makes this list consistent with the other lists.

I still think it's bad that we use `onActiveItemChanged` for the click events but there doesn't seem to be another easy option.  The `DetailsList` that Fabric provides wan't intended to be used this way. They're normal click handler requires double-click which we didn't want. Using `onActiveItemChanged` breaks keyboard navigation because that changes the active item and we open a modal instead of just highlighting. 

I thought about creating our own list component because we don't need all the coloumn resizing stuff that Fabric provides but it doesn't seem worth it at this time.