### PR TITLE
fix: bug 1896 - changing entity types now clears name field

### DIFF
--- a/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
@@ -278,7 +278,7 @@ class Container extends React.Component<Props, ComponentState> {
                     needPrebuiltWarning: needPrebuildWarning,
                     newOrEditedEntity: newOrEditedEntity
                 })
-        } 
+        }
         // Save and close
         else {
             this.saveAndClose(newOrEditedEntity)
@@ -291,7 +291,7 @@ class Container extends React.Component<Props, ComponentState> {
             showValidationWarning: false
         })
         if (this.state.newOrEditedEntity) {
-          this.saveAndClose(this.state.newOrEditedEntity)
+            this.saveAndClose(this.state.newOrEditedEntity)
         }
     }
 
@@ -331,7 +331,7 @@ class Container extends React.Component<Props, ComponentState> {
             isMultivalueVal,
             isNegatableVal,
             entityTypeVal,
-            entityNameVal: isPrebuilt ? Container.GetPrebuiltEntityName(obj.text) : prevState.entityNameVal,
+            entityNameVal: isPrebuilt ? Container.GetPrebuiltEntityName(obj.text) : "",
 
         }))
     }
@@ -493,9 +493,9 @@ class Container extends React.Component<Props, ComponentState> {
     newPrebuilt(newOrEditedEntity: CLM.EntityBase): string | null {
         // Check resolvers
         if (newOrEditedEntity.resolverType && newOrEditedEntity.resolverType !== "none") {
-          
+
             let resolverType = newOrEditedEntity.resolverType
-            let existingBuiltIn = this.props.entities.find(e => 
+            let existingBuiltIn = this.props.entities.find(e =>
                 e.resolverType === resolverType ||
                 e.entityType === resolverType)
 
@@ -506,13 +506,13 @@ class Container extends React.Component<Props, ComponentState> {
 
         // Check prebuilts
         if (this.state.isPrebuilt) {
-     
+
             // If a prebuilt - entity name is prebuilt name
-           let existingBuiltIn = this.props.entities.find(e => 
+            let existingBuiltIn = this.props.entities.find(e =>
                 e.resolverType === newOrEditedEntity.entityType ||
                 e.entityType === newOrEditedEntity.entityType)
 
-            if (!existingBuiltIn) { 
+            if (!existingBuiltIn) {
                 return newOrEditedEntity.entityName
             }
         }
@@ -525,7 +525,7 @@ class Container extends React.Component<Props, ComponentState> {
             console.warn(`You confirmed the edit, but the newOrEditedEntity state was not available. This should not be possible. Contact Support`)
             return
         }
- 
+
         this.setState({
             isConfirmEditModalOpen: false,
             newOrEditedEntity: null
@@ -606,7 +606,7 @@ class Container extends React.Component<Props, ComponentState> {
 
             needPrebuiltWarning={this.state.needPrebuiltWarning}
             onClosePrebuiltWarning={this.onClosePrebuiltWarning}
-        
+
             selectedResolverKey={this.state.entityResolverVal}
             resolverOptions={this.resolverOptions}
             onResolverChanged={this.onChangeResolverType}


### PR DESCRIPTION
Switching away from pre- entity types like the name field with lingering text. We now clear out the (required) field and leverage the existing UI to mark the field as required, directing the user to provide a new name.