### PR TITLE
fix: only show log dialog count after model has loaded

### DIFF
--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -266,7 +266,7 @@ class Index extends React.Component<Props, ComponentState> {
                             </NavLink>
                             <NavLink className="cl-nav-link" data-testid="app-index-nav-link-log-dialogs" to={{ pathname: `${match.url}/logDialogs`, state: { app } }}>
                                 <OF.Icon iconName="List" /><span>Log Dialogs</span>
-                                <span className="count">{this.state.modelLoaded && (this.props.logDialogs.length > TRIPLE_DIGIT_LOGDIALOG_COUNT) ? `${TRIPLE_DIGIT_LOGDIALOG_COUNT}+` : this.props.logDialogs.length}</span>
+                                <span className="count">{this.state.modelLoaded && ((this.props.logDialogs.length > TRIPLE_DIGIT_LOGDIALOG_COUNT) ? `${TRIPLE_DIGIT_LOGDIALOG_COUNT}+` : this.props.logDialogs.length)}</span>
                             </NavLink>
                             <NavLink className="cl-nav-link" data-testid="app-index-nav-link-settings" to={{ pathname: `${match.url}/settings`, state: { app } }}>
                                 <OF.Icon iconName="Settings" /><span>Settings</span>


### PR DESCRIPTION
I didn't catch this the first review. The conditional operator evaluated `this.state.modelLoaded && (this.props.logDialogs.length > TRIPLE_DIGIT_LOGDIALOG_COUNT)` as an expression which was false so it displayed the false value of `this.props.logDialogs.length` when it should not have. Wrapping extra parenthasis ensures if the model has not loaded the conditional operator won't evalaute and the whole thing will return false which React won't render.