### PR TITLE
fix: inner text function behavior on electron browser

### DIFF
--- a/cypress/support/Helpers.js
+++ b/cypress/support/Helpers.js
@@ -26,7 +26,7 @@ export function StringArrayFromElementText(selector, retainMarkup = false) {
   ConLog(`StringArrayFromElementText(${selector})`, elements.length)
   let returnValues = []
   for (let i = 0; i < elements.length; i++)  {
-    let text = retainMarkup ? elements[i].innerHTML : elements[i].innerText
+    let text = retainMarkup ? elements[i].innerHTML : ElementText(elements[i])
     returnValues.push(text)
     ConLog(`StringArrayFromElementText(${selector})`, text)
   }
@@ -36,7 +36,7 @@ export function StringArrayFromElementText(selector, retainMarkup = false) {
 export function NumericArrayFromElementText(selector) {
   let elements = Cypress.$(selector)
   let returnValues = []
-  for (let i = 0; i < elements.length; i++) { returnValues.push(parseInt(elements[i].innerText)) }
+  for (let i = 0; i < elements.length; i++) { returnValues.push(parseInt(ElementText(elements[i]))) }
   return returnValues
 }
 
@@ -49,3 +49,7 @@ export function Moment(dateTime) {
   if (dateTime.includes(':')) return Cypress.moment(dateTime, 'h:mm:ss a')
   return undefined
 }
+
+// The Electron browser is adding newline characters to innerText so
+// this function will remove them.
+export function ElementText(element) { return element.innerText.replace(/\r|\n/g,'') }

--- a/cypress/support/Helpers.js
+++ b/cypress/support/Helpers.js
@@ -26,7 +26,7 @@ export function StringArrayFromElementText(selector, retainMarkup = false) {
   ConLog(`StringArrayFromElementText(${selector})`, elements.length)
   let returnValues = []
   for (let i = 0; i < elements.length; i++)  {
-    let text = retainMarkup ? elements[i].innerHTML : ElementText(elements[i])
+    let text = retainMarkup ? elements[i].innerHTML : elements[i].textContent
     returnValues.push(text)
     ConLog(`StringArrayFromElementText(${selector})`, text)
   }
@@ -36,7 +36,7 @@ export function StringArrayFromElementText(selector, retainMarkup = false) {
 export function NumericArrayFromElementText(selector) {
   let elements = Cypress.$(selector)
   let returnValues = []
-  for (let i = 0; i < elements.length; i++) { returnValues.push(parseInt(ElementText(elements[i]))) }
+  for (let i = 0; i < elements.length; i++) { returnValues.push(parseInt(elements[i].textContent)) }
   return returnValues
 }
 
@@ -49,7 +49,3 @@ export function Moment(dateTime) {
   if (dateTime.includes(':')) return Cypress.moment(dateTime, 'h:mm:ss a')
   return undefined
 }
-
-// The Electron browser is adding newline characters to innerText so
-// this function will remove them.
-export function ElementText(element) { return element.innerText.replace(/\r|\n/g,'') }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -55,8 +55,9 @@ Cypress.Commands.add('UploadFile', (fileName, selector) => {
 Cypress.Commands.add('ExactMatch', { prevSubject: 'element' }, (elements, expectedText) => {
   helpers.ConLog(`ExactMatch('${expectedText}')`, `Start`)
   for (let i = 0; i < elements.length; i++) {
-    helpers.ConLog(`ExactMatch('${expectedText}')`, `elements[${i}].innerText: '${elements[i].innerText}'`)
-    if (elements[i].innerText == expectedText) return elements[i]
+    let elementText = helpers.ElementText(elements[i])
+    helpers.ConLog(`ExactMatch('${expectedText}')`, `elementText: '${elementText}'`)
+    if (elementText === expectedText) return elements[i]
   }
   throw `Exact Match '${expectedText}' NOT Found`
 })
@@ -65,8 +66,9 @@ Cypress.Commands.add('ExactMatches', { prevSubject: 'element' }, (elements, expe
   helpers.ConLog(`ExactMatches('${expectedText}')`, `Start`)
   let returnElements = []
   for (let i = 0; i < elements.length; i++) {
-    helpers.ConLog(`ExactMatches('${expectedText}')`, `elements[${i}].innerText: '${elements[i].innerText}'`)
-    if (elements[i].innerText == expectedText) returnElements.push(elements[i])
+    let elementText = helpers.ElementText(elements[i])
+    helpers.ConLog(`ExactMatches('${expectedText}')`, `elementText: '${elementText}'`)
+    if (elementText === expectedText) returnElements.push(elements[i])
   }
   return returnElements
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -55,7 +55,7 @@ Cypress.Commands.add('UploadFile', (fileName, selector) => {
 Cypress.Commands.add('ExactMatch', { prevSubject: 'element' }, (elements, expectedText) => {
   helpers.ConLog(`ExactMatch('${expectedText}')`, `Start`)
   for (let i = 0; i < elements.length; i++) {
-    let elementText = helpers.ElementText(elements[i])
+    let elementText = elements[i].textContent
     helpers.ConLog(`ExactMatch('${expectedText}')`, `elementText: '${elementText}'`)
     if (elementText === expectedText) return elements[i]
   }
@@ -66,7 +66,7 @@ Cypress.Commands.add('ExactMatches', { prevSubject: 'element' }, (elements, expe
   helpers.ConLog(`ExactMatches('${expectedText}')`, `Start`)
   let returnElements = []
   for (let i = 0; i < elements.length; i++) {
-    let elementText = helpers.ElementText(elements[i])
+    let elementText = elements[i].textContent
     helpers.ConLog(`ExactMatches('${expectedText}')`, `elementText: '${elementText}'`)
     if (elementText === expectedText) returnElements.push(elements[i])
   }

--- a/cypress/support/components/EditDialogModal.js
+++ b/cypress/support/components/EditDialogModal.js
@@ -64,7 +64,7 @@ export function SelectChatTurn(message, index = 0) {
     helpers.ConLog(funcName, `Chat message count: ${elements.length}`)
     for (var i = 0; i < elements.length; i++) {
       helpers.ConLog(funcName, `Chat turn: '${elements[i].innerHTML}'`)
-      if (elements[i].innerText == message) {
+      if (helpers.ElementText(elements[i]) === message) {
         if (index > 0) index--
         else {
           helpers.ConLog(funcName, `FOUND!`)
@@ -160,7 +160,7 @@ export function LabelTextAsEntity(text, entity, itMustNotBeLabeledYet = true) {
 
       // If you need to find a phrase, this part of the code will fail, 
       // you will need to upgrade this code in that case.
-      var element = elements.find(element => element.innerText === text)
+      var element = elements.find(element => helpers.ElementText(element) === text)
       if (element) {
         found = Cypress.$(element).parents('.cl-entity-node--custom').find(`[data-testid="custom-entity-name-button"]:contains('${entity}')`).length == 0
       }

--- a/cypress/support/components/EditDialogModal.js
+++ b/cypress/support/components/EditDialogModal.js
@@ -64,7 +64,7 @@ export function SelectChatTurn(message, index = 0) {
     helpers.ConLog(funcName, `Chat message count: ${elements.length}`)
     for (var i = 0; i < elements.length; i++) {
       helpers.ConLog(funcName, `Chat turn: '${elements[i].innerHTML}'`)
-      if (helpers.ElementText(elements[i]) === message) {
+      if (elements[i].textContent === message) {
         if (index > 0) index--
         else {
           helpers.ConLog(funcName, `FOUND!`)
@@ -160,7 +160,7 @@ export function LabelTextAsEntity(text, entity, itMustNotBeLabeledYet = true) {
 
       // If you need to find a phrase, this part of the code will fail, 
       // you will need to upgrade this code in that case.
-      var element = elements.find(element => helpers.ElementText(element) === text)
+      var element = elements.find(element => element.textContent === text)
       if (element) {
         found = Cypress.$(element).parents('.cl-entity-node--custom').find(`[data-testid="custom-entity-name-button"]:contains('${entity}')`).length == 0
       }

--- a/cypress/support/components/HomePage.js
+++ b/cypress/support/components/HomePage.js
@@ -33,7 +33,7 @@ export function GetModelNameIdList() {
     let listToReturn = []
     let elements = Cypress.$('[data-testid="model-list-model-name"]')
     for (let i = 0; i < elements.length; i++) {
-      let modelName = elements[i].innerText
+      let modelName = helpers.ElementText(elements[i])
       let modelId = elements[i].getAttribute('data-model-id')
       listToReturn.push({ name: modelName, id: modelId })
       helpers.ConLog('GetModelNameIdList', `modelName: ${modelName} - modelId: ${modelId}`)

--- a/cypress/support/components/HomePage.js
+++ b/cypress/support/components/HomePage.js
@@ -33,7 +33,7 @@ export function GetModelNameIdList() {
     let listToReturn = []
     let elements = Cypress.$('[data-testid="model-list-model-name"]')
     for (let i = 0; i < elements.length; i++) {
-      let modelName = helpers.ElementText(elements[i])
+      let modelName = elements[i].textContent
       let modelId = elements[i].getAttribute('data-model-id')
       listToReturn.push({ name: modelName, id: modelId })
       helpers.ConLog('GetModelNameIdList', `modelName: ${modelName} - modelId: ${modelId}`)

--- a/cypress/support/components/ScorerModal.js
+++ b/cypress/support/components/ScorerModal.js
@@ -45,7 +45,7 @@ export function VerifyEndSessionChatMessage(expectedData, expectedIndexOfMessage
   cy.Get('[data-testid="web-chat-utterances"]').then(elements => {
     if (!expectedIndexOfMessage) expectedIndexOfMessage = elements.length - 1
     let element = Cypress.$(elements[expectedIndexOfMessage]).find('div.wc-adaptive-card > div > div > p')[0]
-    expect(element.innerText).to.equal(expectedUtterance)
+    expect(helpers.ElementText(element)).to.equal(expectedUtterance)
   })
 }
 


### PR DESCRIPTION
Fixes a bug that Matt noticed on CircleCI which is using the Electron browser. The element.innerText property contained New Line characters in them in certain situations.