### PR TITLE
fix: clear entity constraints from action when switching type

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import * as CLM from '@conversationlearner/models'
 import * as ToolTip from '../ToolTips/ToolTips'
 import * as TC from '../tipComponents'
-import * as OF from 'office-ui-fabric-react';
+import * as OF from 'office-ui-fabric-react'
 import * as ActionPayloadEditor from './ActionPayloadEditor'
 import { Value } from 'slate'
 import { returntypeof } from 'react-redux-typescript'
@@ -838,7 +838,11 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
             slateValuesMap: {
                 [TEXT_SLOT]: Plain.deserialize('')
             },
-            secondarySlateValuesMap: {}
+            secondarySlateValuesMap: {},
+            expectedEntityTags: [],
+            requiredEntityTagsFromPayload: [],
+            requiredEntityTags: [],
+            negativeEntityTags: [],
         })
     }
 


### PR DESCRIPTION
Clears the entities when that were added when switching the action type.

I tried the approach to preserve entities as we switch but it ended up being complicated.  It would probably be doable but difficult so we can implement if users get frustrated.  In the worst case the users just re-add the entity which isn't that bad.

If we wanted to preserve it's something like this:
When switching FROM a TEXT type which has entities in the payload thus `requiredEntityTagsFromPayload` greater than 1 we append them to `requiredEntityTags` and reset `requiredEntityTagsFromPayload`

When switching TO to a TEXT type we would have to look at the payload, extract the entities used in it and take them out of `requiredEntityTags` and move them back to `requiredEntityTagsFromPayload`. However, we already reset the SlateValue so we can't recover this information.

Since we already reset the SlateValue i thought resetting the entity values was similar and sufficient.