### PR TITLE
chore: remove old/unused Render Action code

### DIFF
--- a/src/components/ToolTips/ToolTips.tsx
+++ b/src/components/ToolTips/ToolTips.tsx
@@ -17,7 +17,6 @@ export enum TipType {
     ACTION_API1 = 'actionAPI1',
     ACTION_API2 = 'actionAPI2',
     ACTION_API3 = 'actionAPI3',
-    ACTION_RENDER = 'actionRender',
     ACTION_ARGUMENTS = 'actionArguments',
     ACTION_CARD = 'actionCard',
     ACTION_END_SESSION = 'actionEndSesion',
@@ -132,20 +131,6 @@ export function wrap(content: JSX.Element, tooltip: string, directionalHint: OF.
     );
 }
 
-const renderCodeSample =
-    `CL.AddRenderCallback("Multiply", async (memoryManager: ReadOnlyClientMemoryManager, num1string: string, num2string: string, result: string) => {
-
-        // convert base and exponent to ints
-        var num1int = parseInt(num1string);
-        var num2int = parseInt(num2string);
-    
-        // compute product
-        var result = num1int * num2int;
-    
-        // save result in entity
-        return \`\${num1String} + \${num2string} = \${result}\`
-    })`
-
 let memoryConverterSample =
     `
     AS_VALUE_LIST       returns MemoryValue[]
@@ -188,18 +173,6 @@ export function getTip(tipType: string) {
             return renderAPIPage2()
         case TipType.ACTION_API3:
             return renderAPIPage3()
-        case TipType.ACTION_RENDER:
-            return (
-                <div>
-                    {render(FM.TOOLTIP_ACTION_RENDER_TITLE, [FM.TOOLTIP_ACTION_RENDER])}
-                    <div><br />cl.AddRenderCallback("<i>[Render name]</i>", async (memoryManager, argArray) => <i>[Render body]</i>)</div>
-                    <div className="cl-tooltop-example"><FormattedMessageId id={FM.TOOLTIP_EXAMPLE} /></div>
-                    <pre>{renderCodeSample}</pre>
-                    <div className="cl-tooltop-example"><FormattedMessageId id={FM.TOOLTIP_ACTION_ARGUMENTS_TITLE} /></div>
-                    <div>$number1 $number2<br /></div>
-                    <div><br />More about the <HelpLink label="Memory Manager" tipType={TipType.MEMORY_MANAGER} /></div>
-                </div>
-            )
         case TipType.ACTION_ARGUMENTS:
             return render(FM.TOOLTIP_ACTION_ARGUMENTS_TITLE, [FM.TOOLTIP_ACTION_ARGUMENTS])
         case TipType.ACTION_CARD:

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -126,7 +126,6 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                         />)
                 }
                 else if (action.actionType === CLM.ActionTypes.API_LOCAL) {
-                    // TODO: Find better way to handle this with CodeActionRenderer?
                     const apiAction = new CLM.ApiAction(action)
                     return (
                         <ActionPayloadRenderers.ApiPayloadRendererContainer

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -357,8 +357,6 @@ export enum FM {
     // ToolTip
     TOOLTIP_ACTION_API = 'ToolTop.ACTION_API',
     TOOLTIP_ACTION_API_TITLE = 'ToolTop.ACTION_API_TITLE',
-    TOOLTIP_ACTION_RENDER = 'ToolTop.ACTION_RENDER',
-    TOOLTIP_ACTION_RENDER_TITLE = 'ToolTop.ACTION_RENDER_TITLE',
     TOOLTIP_ACTION_ARGUMENTS = 'ToolTip.ACTION_ARGUMENTS',
     TOOLTIP_ACTION_ARGUMENTS_TITLE = 'ToolTip.ACTION_ARGUMENTS_TITLE',
     TOOLTIP_ACTION_CARD = 'ToolTip.ACTION_CARD',
@@ -733,8 +731,6 @@ export default {
         // ToolTip
         [FM.TOOLTIP_ACTION_API]: 'APIs exposed in the running Bot of the form:',
         [FM.TOOLTIP_ACTION_API_TITLE]: 'API',
-        [FM.TOOLTIP_ACTION_RENDER]: 'Render exposed in the running Bot of the form:',
-        [FM.TOOLTIP_ACTION_RENDER_TITLE]: 'RENDER',
         [FM.TOOLTIP_ACTION_ARGUMENTS]: `When Action Type is an API call, a list of comma separated arguments passed to the API. Arguments prefixed with a $ refer to Entity values.  For example: "$city"`,
         [FM.TOOLTIP_ACTION_ARGUMENTS_TITLE]: `Arguments`,
         [FM.TOOLTIP_ACTION_CARD]: `When Action Type is a card call, a list of comma separated arguments passed to the Card. Arguments prefixed with a $ refer to Entity values.  For example: "$city"`,


### PR DESCRIPTION
Removes old code left over from when we had the separate RENDER action's.

See: https://github.com/Microsoft/ConversationLearner-UI/pull/684

Originally we kept the api actions and added render actions but as I was implementing we realialized that we needed to support the passing of information between the two and they would often come in pairs. We since merged them into a single Callback the supports logic and render. 

I didn't remove this at the time.