### PR TITLE
fix: ensure slate placeholder cursor is centered

### DIFF
--- a/src/routes/App.css
+++ b/src/routes/App.css
@@ -198,4 +198,8 @@
     color: var(--cl-color-error);
 }
 
+[data-slate-editor="true"] span[contenteditable="false"] {
+    float: left
+}
+
 


### PR DESCRIPTION
The correct fix is for Slate to update and fix the bug, but in the mean time this appears to work.

See: https://github.com/ianstormtaylor/slate/issues/1436

Action Creator Editor on TEXT:

Before:
![image](https://user-images.githubusercontent.com/2856501/53350859-e3f1af00-38d4-11e9-8c27-3eb7b3f63336.png)

After:
![image](https://user-images.githubusercontent.com/2856501/53279372-acacb380-36c4-11e9-9304-f822f6dbe988.png)

on END_SESSION
Before:
![image](https://user-images.githubusercontent.com/2856501/53350905-0257aa80-38d5-11e9-8642-9c01fc52d7e1.png)

After:
![image](https://user-images.githubusercontent.com/2856501/53279365-9dc60100-36c4-11e9-877b-8e36f6d7c0cc.png)
