### PR TITLE
chore: change model tag to model version

### DIFF
--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -71,6 +71,8 @@ export enum FM {
     APP_HEADER_DOCS = 'App.header.docs',
     APP_HEADER_SUPPORT = 'App.header.support',
 
+    APP_VERSION = 'App.version',
+
     // TrainingStatus
     APP_TRAINING_STATUS_STATUS = 'TrainingStatus.status.label',
     APP_TRAINING_STATUS_UNKNOWN = 'TrainingStatus.status.unknown',
@@ -248,6 +250,7 @@ export enum FM {
     LOGDIALOGS_SUBTITLE = 'LogDialogs.subtitle',
     LOGDIALOGS_CREATEBUTTONTITLE = 'LogDialogs.createButtonTitle',
     LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION = 'LogDialogs.createButtonAriaDescription',
+    LOGDIALOGS_MODEL_VERSION = 'LogDialogs.modelVersion',
     LOGDIALOGS_FIRSTINPUT = 'LogDialogs.firstInput',
     LOGDIALOGS_LASTINPUT = 'LogDialogs.lastInput',
     LOGDIALOGS_LASTRESPONSE = 'LogDialogs.lastResponse',
@@ -587,6 +590,9 @@ export default {
         [FM.APP_HEADER_DOCS]: 'Docs',
         [FM.APP_HEADER_SUPPORT]: 'Support',
 
+        // Model Metadata
+        [FM.APP_VERSION]: 'Version:',
+
         // TrainingStatus
         [FM.APP_TRAINING_STATUS_STATUS]: 'Training',
         [FM.APP_TRAINING_STATUS_UNKNOWN]: 'Unknown',
@@ -662,6 +668,7 @@ export default {
         [FM.LOGDIALOGS_SUBTITLE]: 'Log Dialogs are records of conversations between users and your Bot. You can make corrections to Log Dialogs to improve the Bot.',
         [FM.LOGDIALOGS_CREATEBUTTONTITLE]: 'New Log Dialog',
         [FM.LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION]: 'Create a New Log Dialog',
+        [FM.LOGDIALOGS_MODEL_VERSION]: 'Model Version',
         [FM.LOGDIALOGS_FIRSTINPUT]: 'First Input',
         [FM.LOGDIALOGS_LASTINPUT]: 'Last Input',
         [FM.LOGDIALOGS_LASTRESPONSE]: 'Last Response',

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -27,6 +27,7 @@ import LogDialogs from './LogDialogs'
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip'
 import TrainingStatus from '../../../components/TrainingStatusContainer'
 import actions from '../../../actions'
+import FormattedMessageId from '../../../components/FormattedMessageId'
 import './Index.css'
 
 // TODO: i18n support would be much easier after proper routing is implemented
@@ -205,7 +206,7 @@ class Index extends React.Component<Props, ComponentState> {
                         </div>
                     </div>
                     <div className={`cl-app-tag-status ${OF.FontClassNames.mediumPlus}`}>
-                        Tag: {tag}
+                        <FormattedMessageId id={FM.APP_VERSION} /> {tag}
                         {editPackageId === app.livePackageId &&
                             <span className="cl-font--warning">LIVE</span>
                         }

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -88,9 +88,9 @@ function getLastResponse(logDialog: CLM.LogDialog, component: LogDialogs): strin
 function getColumns(intl: InjectedIntl): IRenderableColumn[] {
     return [
         {
-            key: 'tag',
-            name: 'Tag',
-            fieldName: 'tag',
+            key: 'version',
+            name: Util.formatMessageId(intl, FM.LOGDIALOGS_MODEL_VERSION),
+            fieldName: 'version',
             minWidth: 80,
             maxWidth: 120,
             isResizable: true,


### PR DESCRIPTION
Renames model Tag to model Version to avoid future confusion with Tags on Train Dialogs and to align with LUIS.

**Below model name:**
Before:
![image](https://user-images.githubusercontent.com/2856501/53375593-88451700-3910-11e9-9402-03aaf2a7840f.png)

After:
![image](https://user-images.githubusercontent.com/2856501/53375548-69468500-3910-11e9-9e10-7389dd59c136.png)

**Log dialog column**
Before:
![image](https://user-images.githubusercontent.com/2856501/53375619-9e52d780-3910-11e9-89b1-4934897e05ca.png)

After:
![image](https://user-images.githubusercontent.com/2856501/53375568-78c5ce00-3910-11e9-954a-cfc10eaee0fb.png)


I named the column "Model Version" instead of "Version" to make sure people new it wasn't a version of the log dialog.