### PR TITLE
chore: ensure component state is readonly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,15 +44,13 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -71,7 +69,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -255,7 +252,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -268,7 +264,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -334,8 +329,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.0",
@@ -352,7 +346,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -362,7 +355,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -373,8 +365,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -2618,7 +2609,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
         "chalk": "^1.1.3",
@@ -3510,7 +3501,7 @@
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "bcrypt-pbkdf": {
@@ -3592,7 +3583,7 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "botframework-directlinejs": {
@@ -3857,7 +3848,7 @@
     },
     "bytes": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
@@ -4092,7 +4083,7 @@
     },
     "cheerio": {
       "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
         "css-select": "~1.2.0",
@@ -4575,7 +4566,7 @@
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compressible": {
@@ -5151,7 +5142,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -5558,7 +5549,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
         "es5-ext": "^0.10.9"
@@ -5688,7 +5679,7 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
@@ -5892,7 +5883,7 @@
     },
     "doctrine": {
       "version": "0.7.2",
-      "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
@@ -5902,7 +5893,7 @@
       "dependencies": {
         "esutils": {
           "version": "1.1.6",
-          "resolved": "http://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
           "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
           "dev": true
         }
@@ -6203,7 +6194,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -6294,12 +6285,12 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
@@ -6651,12 +6642,12 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastparse": {
@@ -7138,8 +7129,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7157,13 +7147,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7176,18 +7164,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7290,8 +7275,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7301,7 +7285,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7314,20 +7297,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7344,7 +7324,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7417,8 +7396,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7428,7 +7406,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7504,8 +7481,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7535,7 +7511,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7553,7 +7528,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7592,13 +7566,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -7636,7 +7608,7 @@
     },
     "fuse.js": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
       "integrity": "sha1-8ESOgGmFW/Kj5oPNwdMg5+KgfvQ="
     },
     "get-caller-file": {
@@ -8830,12 +8802,12 @@
     },
     "intl-format-cache": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
       "integrity": "sha1-BKNp/sv61tpgBbrh8UMzMy3PkxY="
     },
     "intl-messageformat": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
       "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
       "requires": {
         "intl-messageformat-parser": "1.4.0"
@@ -8843,12 +8815,12 @@
     },
     "intl-messageformat-parser": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
       "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
     },
     "intl-relativeformat": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
       "integrity": "sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=",
       "requires": {
         "intl-messageformat": "^2.0.0"
@@ -8869,7 +8841,7 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "http://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
@@ -9632,7 +9604,7 @@
     },
     "js-yaml": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
         "argparse": "^1.0.7",
@@ -9822,7 +9794,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -10005,7 +9977,7 @@
     },
     "load-script": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
       "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-runner": {
@@ -10049,12 +10021,12 @@
     },
     "lodash.assignin": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
       "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
     "lodash.bind": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
     },
     "lodash.camelcase": {
@@ -10069,7 +10041,7 @@
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.endswith": {
@@ -10079,17 +10051,17 @@
     },
     "lodash.filter": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.foreach": {
       "version": "4.5.0",
-      "resolved": "http://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
     "lodash.isfunction": {
@@ -10148,12 +10120,12 @@
     },
     "lodash.reduce": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
       "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
     },
     "lodash.reject": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
       "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
     },
     "lodash.snakecase": {
@@ -10164,7 +10136,7 @@
     },
     "lodash.some": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.sortby": {
@@ -10525,7 +10497,7 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
@@ -11093,7 +11065,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -11286,7 +11258,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
         "deep-is": "~0.1.3",
@@ -12870,7 +12842,7 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
@@ -14087,7 +14059,7 @@
     },
     "redux-thunk": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
       "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
     },
     "regenerate": {
@@ -14302,7 +14274,7 @@
     },
     "replace-ext": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
@@ -14988,7 +14960,7 @@
     },
     "slick": {
       "version": "1.12.2",
-      "resolved": "http://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
       "integrity": "sha1-vQSN23TefRymkV+qSldXCzVQwtc="
     },
     "smart-buffer": {
@@ -15177,7 +15149,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-loader": {
       "version": "0.2.4",
@@ -15704,7 +15676,7 @@
     },
     "symbol-observable": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "symbol-tree": {
@@ -15932,7 +15904,7 @@
     },
     "trim": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
@@ -16478,7 +16450,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -16581,7 +16553,7 @@
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -16877,7 +16849,7 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
@@ -17103,7 +17075,7 @@
     "vfile": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-      "integrity": "sha1-5i2OcrIOg8MkvGxnJ47ickiL+Eo=",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
         "is-buffer": "^1.1.4",
         "replace-ext": "1.0.0",
@@ -18424,7 +18396,7 @@
     },
     "x-is-string": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xdg-basedir": {

--- a/src/components/ExtractorResponseEditor/EntityPicker.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPicker.tsx
@@ -18,7 +18,7 @@ interface MenuProps {
     onChangeSearchText: (value: string) => void
     onClickOption: (o: IOption) => void
     onClickNewEntity: (entityTypeFilter: string) => void
-    position: IPosition
+    position: IPosition | null
     menuRef: any
     searchText: string
     value: any,
@@ -56,8 +56,8 @@ export default class EntityPicker extends React.Component<MenuProps, ComponentSt
 
     render() {
         const style = {
-            left: this.props.isVisible ? `${this.props.position.left}px` : undefined,
-            top: this.props.isVisible ? `${this.props.position.top}px` : undefined,
+            left: (this.props.position && this.props.isVisible) ? `${this.props.position.left}px` : undefined,
+            top: (this.props.position && this.props.isVisible) ? `${this.props.position.top}px` : undefined,
             height: !this.props.isOverlappingOtherEntities ? "auto" : "4em",
             marginBottom: !this.props.isOverlappingOtherEntities ? "0" : "1em"
         }

--- a/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
@@ -34,7 +34,7 @@ interface Props {
     options: IOption[]
     maxDisplayedOptions: number
     menuRef: any
-    position: IPosition
+    position: IPosition | null
     value: any
     entityTypeFilter: string
 
@@ -49,7 +49,7 @@ interface State {
     matchedOptions: MatchedOption<IOption>[]
 }
 
-const initialState: State = {
+const initialState: Readonly<State> = {
     highlightIndex: 0,
     searchText: '',
     matchedOptions: []
@@ -67,8 +67,6 @@ export default class EntityPickerContainer extends React.Component<Props, State>
     element: HTMLElement
     resultsElement: HTMLDivElement | null
 
-    state = initialState
-
     constructor(props: Props) {
         super(props)
 
@@ -81,7 +79,11 @@ export default class EntityPickerContainer extends React.Component<Props, State>
                 matchedStrings: [{ text: option.name, matched: false }],
                 original: option
             }))
-        this.state.matchedOptions = this.defaultMatchedOptions
+            
+        this.state = {
+            ...initialState,
+            matchedOptions: this.defaultMatchedOptions
+        }
     }
 
     componentWillReceiveProps(nextProps: Props) {

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -42,6 +42,21 @@ interface State {
     builtInTypeFilter: string | null
 }
 
+const initialState: Readonly<State> = {
+    isSelectionOverlappingOtherEntities: false,
+    isMenuVisible: false,
+    isDeleteButtonVisible: false,
+    isPreBuiltExpandoOpen: true,
+    menuPosition: {
+        top: 0,
+        left: 0,
+        bottom: 0
+    },
+    value: Plain.deserialize(''),
+    preBuiltEditorValues: [{}],
+    builtInTypeFilter: null
+}
+
 const disallowedOperations = ['insert_text', 'remove_text']
 const externalChangeOperations = ['insert_node', 'remove_node']
 
@@ -59,29 +74,19 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
     menu: HTMLElement
     editor: React.RefObject<any>
 
-    state = {
-        isSelectionOverlappingOtherEntities: false,
-        isMenuVisible: false,
-        isDeleteButtonVisible: false,
-        isPreBuiltExpandoOpen: true,
-        menuPosition: {
-            top: 0,
-            left: 0,
-            bottom: 0
-        },
-        value: Plain.deserialize(''),
-        preBuiltEditorValues: [{}],
-        builtInTypeFilter: null
-    }
-
     constructor(props: Props) {
         super(props)
 
         this.editor = React.createRef();
 
-        this.state.value = convertEntitiesAndTextToTokenizedEditorValue(props.text, props.customEntities, NodeType.CustomEntityNodeType)
-        this.state.preBuiltEditorValues = props.preBuiltEntities.map<any[]>(preBuiltEntity => convertEntitiesAndTextToEditorValue(props.text, [preBuiltEntity], NodeType.PreBuiltEntityNodeType))
-        this.state.isPreBuiltExpandoOpen = this.state.preBuiltEditorValues.length <= 4
+        const preBuiltEditorValues = props.preBuiltEntities.map<any[]>(preBuiltEntity => convertEntitiesAndTextToEditorValue(props.text, [preBuiltEntity], NodeType.PreBuiltEntityNodeType))
+
+        this.state = {
+            ...initialState,
+            value: convertEntitiesAndTextToTokenizedEditorValue(props.text, props.customEntities, NodeType.CustomEntityNodeType),
+            preBuiltEditorValues,
+            isPreBuiltExpandoOpen: preBuiltEditorValues.length <= 4
+        }
     }
 
     componentWillReceiveProps(nextProps: Props) {

--- a/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
@@ -32,7 +32,7 @@ interface State {
 }
 
 export default class Component extends React.Component<Props, State> {
-    state = {
+    state: Readonly<State> = {
         isOriginalVisible: false
     }
 

--- a/src/components/actionPayloadRenderers/CardPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/CardPayloadRenderer.tsx
@@ -30,7 +30,7 @@ interface State {
 }
 
 export default class Component extends React.Component<Props, State> {
-    state = {
+    state: Readonly<State> = {
         isOriginalVisible: false
     }
 

--- a/src/components/actionPayloadRenderers/TextPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/TextPayloadRenderer.tsx
@@ -16,7 +16,7 @@ interface State {
 }
 
 export default class Component extends React.Component<Props, State> {
-    state = {
+    state: Readonly<State> = {
         isOriginalVisible: false
     }
 

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -250,7 +250,7 @@ interface ComponentState {
     isTerminal: boolean
 }
 
-const initialState: ComponentState = {
+const initialState: Readonly<ComponentState> = {
     apiOptions: [],
     renderOptions: [],
     cardOptions: [],

--- a/src/components/modals/ActionPayloadEditor/PayloadEditor.tsx
+++ b/src/components/modals/ActionPayloadEditor/PayloadEditor.tsx
@@ -48,23 +48,26 @@ interface State {
     menuProps: IPickerProps
 }
 
+const initialState: Readonly<State> = {
+    highlightIndex: 0,
+    matchedOptions: [] as MatchedOption<IOption>[],
+    maxDisplayedOptions: 4,
+    menuProps: defaultPickerProps,
+}
+
 export default class PayloadEditor extends React.Component<Props, State> {
     fuse: Fuse
     menu: HTMLElement
     plugins: any[]
 
-    state = {
-        highlightIndex: 0,
-        matchedOptions: [] as MatchedOption<IOption>[],
-        maxDisplayedOptions: 4,
-        menuProps: defaultPickerProps,
-    }
-
     constructor(props: Props) {
         super(props)
 
         this.fuse = new Fuse(this.props.options, fuseOptions)
-        this.state.matchedOptions = this.getDefaultMatchedOptions()
+        this.state = {
+            ...initialState,
+            matchedOptions: this.getDefaultMatchedOptions(initialState.highlightIndex)
+        }
 
         this.plugins = [
             OptionalPlugin(),
@@ -80,10 +83,10 @@ export default class PayloadEditor extends React.Component<Props, State> {
         }
     }
 
-    getDefaultMatchedOptions() {
+    getDefaultMatchedOptions(highlightIndex: number) {
         return this.props.options
             .map<MatchedOption<IOption>>((option, i) => ({
-                highlighted: this.state.highlightIndex === i,
+                highlighted: highlightIndex === i,
                 matchedStrings: [{ text: option.name, matched: false }],
                 original: option
             }))
@@ -328,7 +331,7 @@ export default class PayloadEditor extends React.Component<Props, State> {
         // console.log(`onChangePickerProps: `, menuProps)
 
         const matchedOptions = (typeof menuProps.searchText !== 'string' || menuProps.searchText === "")
-            ? this.getDefaultMatchedOptions()
+            ? this.getDefaultMatchedOptions(this.state.highlightIndex)
             : this.fuse.search<FuseResult<IOption>>(menuProps.searchText)
                 .map(result => convertMatchedTextIntoMatchedOption(result.item.name, result.matches[0].indices, result.item))
 

--- a/src/routes/Apps/App/Dashboard.tsx
+++ b/src/routes/Apps/App/Dashboard.tsx
@@ -22,7 +22,7 @@ interface ComponentState {
 }
 
 class Dashboard extends React.Component<Props, ComponentState> {
-    state = {
+    state: Readonly<ComponentState> = {
         retrying: false
     }
 

--- a/src/routes/Apps/AppsList.tsx
+++ b/src/routes/Apps/AppsList.tsx
@@ -16,15 +16,15 @@ import { autobind } from 'office-ui-fabric-react'
 import AppsListComponent from './AppsListComponent'
 
 interface ComponentState {
-    readonly isAppCreateModalOpen: boolean
-    readonly appCreatorType: AppCreatorType
-    readonly isImportTutorialsOpen: boolean
-    readonly appToDelete: AppBase | null
-    readonly tutorials: AppBase[] | null
+    isAppCreateModalOpen: boolean
+    appCreatorType: AppCreatorType
+    isImportTutorialsOpen: boolean
+    appToDelete: AppBase | null
+    tutorials: AppBase[] | null
 }
 
 class AppsList extends React.Component<Props, ComponentState> {
-    state: ComponentState = {
+    state: Readonly<ComponentState> = {
         isAppCreateModalOpen: false,
         appCreatorType: AppCreatorType.NEW,
         isImportTutorialsOpen: false,


### PR DESCRIPTION
**Shouldn't change any functionality only adding some more protections through Typescript**

In some cases we were assigning the `state` of a component an object of initial values.  
React tried tries to ensure state is `Readonly` here
![image](https://user-images.githubusercontent.com/2856501/53591988-27088800-3b4a-11e9-953d-d3e2ea056f27.png)
but when we assign the property directly it seeming overwrote the `Readonly<S>` type inside the component and made it a literal type of the object.


Example of how we would assign state:
![image](https://user-images.githubusercontent.com/2856501/53591587-3509d900-3b49-11e9-98c2-eaa1a5eeb23b.png)

This allowed you to assign to the state because it implicitly dropped the `Readonly`. See:
![image](https://user-images.githubusercontent.com/2856501/53591578-30ddbb80-3b49-11e9-943d-bff662194980.png)

In some cases we explicitly add the `Readonly<ComponentState>` back.
In other cases we have to make sure if any of initialization happens in constructor it all must happen in constructor. Instead of partial initializing and then reassignment properties later which would be violation of `Readonly`.

Anyways, this type of code should now cause as compile error.  In worse case, I think react would throw a runtime warning and tell you not to assign to state but this should protect earlier.

![image](https://user-images.githubusercontent.com/2856501/53591568-2b807100-3b49-11e9-9970-76df69c9296b.png)

Update: I forgot to mention I only added that line `this.state.isMenuVisible = false` temporarily to test the solution, it wasn't actually written that way.