### PR TITLE
chore: restore ability for entity picker to show above selected text

### DIFF
--- a/src/components/ExtractorResponseEditor/EntityPicker.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPicker.tsx
@@ -55,7 +55,7 @@ export default class EntityPicker extends React.Component<MenuProps, ComponentSt
 
     render() {
         const style: any = {
-            left: this.props.isVisible ? `1em` : null,
+            left: this.props.isVisible ? `${this.props.position.left}px` : null,
             bottom: this.props.isVisible ? `${this.props.position.bottom}px` : null,
             height: !this.props.isOverlappingOtherEntities ? "14em" : "4em",
             marginBottom: !this.props.isOverlappingOtherEntities ? "0" : "1em"


### PR DESCRIPTION
Somehow the entity picker positioning was hard coded to 1em here: https://github.com/Microsoft/ConversationLearner-UI/pull/811/files#diff-47973b78c930c57d97813243b9a3f668R31

I don't know why this was done but it's a bad experience.  The picker is supposed to show up near the selection so it looks like it is related to it and the effect of clicking a entity will do something with the selection.

Before:
![image](https://user-images.githubusercontent.com/2856501/53598570-f6c8e580-3b59-11e9-99ff-b16bcd0efce8.png)

After:
![image](https://user-images.githubusercontent.com/2856501/53598579-fa5c6c80-3b59-11e9-946b-d68f1878639b.png)
