### PR TITLE
 chore: change requires to imports

### DIFF
--- a/cypress/integration/(All).spec.js
+++ b/cypress/integration/(All).spec.js
@@ -3,32 +3,32 @@
  * Licensed under the MIT License.
 */
 
-require('./CreateModels/AllEntityTypes.spec.js')
-require('./CreateModels/DisqualifyingEntities.spec.js')
-require('./CreateModels/EndlessLoop.spec.js')
-require('./CreateModels/TagAndFrog.spec.js')
-require('./CreateModels/Travel.spec.js')
-require('./CreateModels/WaitVsNoWaitActions.spec.js')
-require('./CreateModels/WhatsYourName.spec.js')
-require('./EditAndBranching/AddEndSessionAction.spec.js')
-require('./EditAndBranching/Branching.spec.js')
-require('./EditAndBranching/TagAndFrog.spec.js')
-require('./EditAndBranching/VerifyEditTrainingControlsAndLabels.spec.js')
-require('./ErrorHandling/ActionUnavailable.spec.js')
-require('./ErrorHandling/MissingAction.spec.js')
-require('./ErrorHandling/TwoConsecutiveUserInput.spec.js')
-require('./ErrorHandling/WaitNonWait.spec.js')
-require('./Log/EndlessLoop.spec.js')
-require('./Log/WhatsYourName.spec.js')
-require('./Tools/CreateModel.spec.js')
-require('./Tools/DeleteAllTestGeneratedModels.spec.js')
-require('./Tools/VerifyDoesNotContainTestMethod.spec.js')
-require('./Tools/VisitHomePage.spec.js')
-require('./Train/BookMeAFlight.spec.js')
-require('./Train/DisqualifyingEntities.spec.js')
-require('./Train/MyNameIs.spec.js')
-require('./Train/TagAndFrog.spec.js')
-require('./Train/WaitVsNoWaitActions.spec.js')
-require('./Train/WhatsYourName.spec.js')
-require('./UX/BotModelMismatch.spec.js')
-require('./zTemp/zTemp.spec.js')
+import './CreateModels/AllEntityTypes.spec.js'
+import './CreateModels/DisqualifyingEntities.spec.js'
+import './CreateModels/EndlessLoop.spec.js'
+import './CreateModels/TagAndFrog.spec.js'
+import './CreateModels/Travel.spec.js'
+import './CreateModels/WaitVsNoWaitActions.spec.js'
+import './CreateModels/WhatsYourName.spec.js'
+import './EditAndBranching/AddEndSessionAction.spec.js'
+import './EditAndBranching/Branching.spec.js'
+import './EditAndBranching/TagAndFrog.spec.js'
+import './EditAndBranching/VerifyEditTrainingControlsAndLabels.spec.js'
+import './ErrorHandling/ActionUnavailable.spec.js'
+import './ErrorHandling/MissingAction.spec.js'
+import './ErrorHandling/TwoConsecutiveUserInput.spec.js'
+import './ErrorHandling/WaitNonWait.spec.js'
+import './Log/EndlessLoop.spec.js'
+import './Log/WhatsYourName.spec.js'
+import './Tools/CreateModel.spec.js'
+import './Tools/DeleteAllTestGeneratedModels.spec.js'
+import './Tools/VerifyDoesNotContainTestMethod.spec.js'
+import './Tools/VisitHomePage.spec.js'
+import './Train/BookMeAFlight.spec.js'
+import './Train/DisqualifyingEntities.spec.js'
+import './Train/MyNameIs.spec.js'
+import './Train/TagAndFrog.spec.js'
+import './Train/WaitVsNoWaitActions.spec.js'
+import './Train/WhatsYourName.spec.js'
+import './UX/BotModelMismatch.spec.js'
+import './zTemp/zTemp.spec.js'

--- a/cypress/integration/(Regression).spec.js
+++ b/cypress/integration/(Regression).spec.js
@@ -3,32 +3,32 @@
  * Licensed under the MIT License.
 */
 
-require('./CreateModels/AllEntityTypes.spec.js')
-require('./CreateModels/DisqualifyingEntities.spec.js')
-require('./CreateModels/EndlessLoop.spec.js')
-require('./CreateModels/TagAndFrog.spec.js')
-require('./CreateModels/Travel.spec.js')
-require('./CreateModels/WaitVsNoWaitActions.spec.js')
-require('./CreateModels/WhatsYourName.spec.js')
-require('./EditAndBranching/AddEndSessionAction.spec.js')
-require('./EditAndBranching/Branching.spec.js')
-require('./EditAndBranching/TagAndFrog.spec.js')
-require('./EditAndBranching/VerifyEditTrainingControlsAndLabels.spec.js')
-require('./ErrorHandling/ActionUnavailable.spec.js')
-require('./ErrorHandling/MissingAction.spec.js')
-require('./ErrorHandling/TwoConsecutiveUserInput.spec.js')
-require('./ErrorHandling/WaitNonWait.spec.js')
-// require('./Log/EndlessLoop.spec.js')
-require('./Log/WhatsYourName.spec.js')
-// require('./Tools/CreateModel.spec.js')
-// require('./Tools/DeleteAllTestGeneratedModels.spec.js')
-// require('./Tools/VerifyDoesNotContainTestMethod.spec.js')
-// require('./Tools/VisitHomePage.spec.js')
-require('./Train/BookMeAFlight.spec.js')
-require('./Train/DisqualifyingEntities.spec.js')
-require('./Train/MyNameIs.spec.js')
-require('./Train/TagAndFrog.spec.js')
-require('./Train/WaitVsNoWaitActions.spec.js')
-require('./Train/WhatsYourName.spec.js')
-require('./UX/BotModelMismatch.spec.js')
-// require('./zTemp/zTemp.spec.js')
+import './CreateModels/AllEntityTypes.spec.js'
+import './CreateModels/DisqualifyingEntities.spec.js'
+import './CreateModels/EndlessLoop.spec.js'
+import './CreateModels/TagAndFrog.spec.js'
+import './CreateModels/Travel.spec.js'
+import './CreateModels/WaitVsNoWaitActions.spec.js'
+import './CreateModels/WhatsYourName.spec.js'
+import './EditAndBranching/AddEndSessionAction.spec.js'
+import './EditAndBranching/Branching.spec.js'
+import './EditAndBranching/TagAndFrog.spec.js'
+import './EditAndBranching/VerifyEditTrainingControlsAndLabels.spec.js'
+import './ErrorHandling/ActionUnavailable.spec.js'
+import './ErrorHandling/MissingAction.spec.js'
+import './ErrorHandling/TwoConsecutiveUserInput.spec.js'
+import './ErrorHandling/WaitNonWait.spec.js'
+// import './Log/EndlessLoop.spec.js'
+import './Log/WhatsYourName.spec.js'
+// import './Tools/CreateModel.spec.js'
+// import './Tools/DeleteAllTestGeneratedModels.spec.js'
+// import './Tools/VerifyDoesNotContainTestMethod.spec.js'
+// import './Tools/VisitHomePage.spec.js'
+import './Train/BookMeAFlight.spec.js'
+import './Train/DisqualifyingEntities.spec.js'
+import './Train/MyNameIs.spec.js'
+import './Train/TagAndFrog.spec.js'
+import './Train/WaitVsNoWaitActions.spec.js'
+import './Train/WhatsYourName.spec.js'
+import './UX/BotModelMismatch.spec.js'
+// import './zTemp/zTemp.spec.js'

--- a/cypress/integration/(RunTestsFromList).spec.js
+++ b/cypress/integration/(RunTestsFromList).spec.js
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
 */
 
-require('./Tools/VisitHomePage.spec.js')
-require('./Tools/CreateModel.spec.js')
+import './Tools/VisitHomePage.spec.js'
+import './Tools/CreateModel.spec.js'

--- a/cypress/integration/CreateModels/AllEntityTypes.spec.js
+++ b/cypress/integration/CreateModels/AllEntityTypes.spec.js
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const entities = require('../../support/Entities')
+import * as models from '../../support/Models'
+import * as entities from '../../support/Entities'
 
 describe('CreateModels', () => {
   it('All Entity Types', () => {

--- a/cypress/integration/CreateModels/DisqualifyingEntities.spec.js
+++ b/cypress/integration/CreateModels/DisqualifyingEntities.spec.js
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const entities = require('../../support/Entities')
-const actions = require('../../support/Actions')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as entities from '../../support/Entities'
+import * as actions from '../../support/Actions'
+import * as common from '../../support/Common'
 
 describe('CreateModels', () => {
   it('Disqualifying Entities', () => {

--- a/cypress/integration/CreateModels/EndlessLoop.spec.js
+++ b/cypress/integration/CreateModels/EndlessLoop.spec.js
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const actions = require('../../support/Actions')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const train = require('../../support/Train')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as actions from '../../support/Actions'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as train from '../../support/Train'
+import * as common from '../../support/Common'
 
 describe('CreateModels', () => {
   it('Endless Loop', () => {

--- a/cypress/integration/CreateModels/TagAndFrog.spec.js
+++ b/cypress/integration/CreateModels/TagAndFrog.spec.js
@@ -3,14 +3,14 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const entities = require('../../support/Entities')
-const actions = require('../../support/Actions')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const train = require('../../support/Train')
-const memoryTableComponent = require('../../support/components/MemoryTableComponent')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as entities from '../../support/Entities'
+import * as actions from '../../support/Actions'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as train from '../../support/Train'
+import * as memoryTableComponent from '../../support/components/MemoryTableComponent'
+import * as common from '../../support/Common'
 
 describe('CreateModels', () => {
   it('Tag And Frog', () => {

--- a/cypress/integration/CreateModels/Travel.spec.js
+++ b/cypress/integration/CreateModels/Travel.spec.js
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const entities = require('../../support/Entities')
-const actions = require('../../support/Actions')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as entities from '../../support/Entities'
+import * as actions from '../../support/Actions'
+import * as common from '../../support/Common'
 
 describe('CreateModels', () => {
   it('Travel', () => {

--- a/cypress/integration/CreateModels/WaitVsNoWaitActions.spec.js
+++ b/cypress/integration/CreateModels/WaitVsNoWaitActions.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const actions = require('../../support/Actions')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const train = require('../../support/Train')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as actions from '../../support/Actions'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as train from '../../support/Train'
 
 describe('CreateModels', () => {
   it('Wait vs Non-Wait Actions', () => {

--- a/cypress/integration/CreateModels/WhatsYourName.spec.js
+++ b/cypress/integration/CreateModels/WhatsYourName.spec.js
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const entities = require('../../support/Entities')
-const actions = require('../../support/Actions')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as entities from '../../support/Entities'
+import * as actions from '../../support/Actions'
+import * as common from '../../support/Common'
 
 describe('CreateModels', () => {
   it("What's Your Name", () => {

--- a/cypress/integration/EditAndBranching/AddEndSessionAction.spec.js
+++ b/cypress/integration/EditAndBranching/AddEndSessionAction.spec.js
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
 
 describe('EditAndBranching', () => {
   it('Add End Session Action', () => {

--- a/cypress/integration/EditAndBranching/Branching.spec.js
+++ b/cypress/integration/EditAndBranching/Branching.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const scorerModal = require('../../support/components/ScorerModal')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as scorerModal from '../../support/components/ScorerModal'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
 
 describe('EditAndBranching', () => {
   it('Branching', () => {

--- a/cypress/integration/EditAndBranching/TagAndFrog.spec.js
+++ b/cypress/integration/EditAndBranching/TagAndFrog.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const scorerModal = require('../../support/components/ScorerModal')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as scorerModal from '../../support/components/ScorerModal'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
 
 describe('EditAndBranching', () => {
   it('Tag And Frog', () => {

--- a/cypress/integration/EditAndBranching/VerifyEditTrainingControlsAndLabels.spec.js
+++ b/cypress/integration/EditAndBranching/VerifyEditTrainingControlsAndLabels.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const scorerModal = require('../../support/components/ScorerModal')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as scorerModal from '../../support/components/ScorerModal'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
 
 describe('EditAndBranching', () => {
   it('Verify Edit Training Controls And Labels', () => {

--- a/cypress/integration/ErrorHandling/ActionUnavailable.spec.js
+++ b/cypress/integration/ErrorHandling/ActionUnavailable.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('ErrorHandling', () => {
   it('Action Unavailable', () => {

--- a/cypress/integration/ErrorHandling/MissingAction.spec.js
+++ b/cypress/integration/ErrorHandling/MissingAction.spec.js
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
-const actions = require('../../support/Actions')
-const scorerModal = require('../../support/components/ScorerModal')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
+import * as actions from '../../support/Actions'
+import * as scorerModal from '../../support/components/ScorerModal'
 
 describe('ErrorHandling', () => {
   it('Missing Action', () => {

--- a/cypress/integration/ErrorHandling/TwoConsecutiveUserInput.spec.js
+++ b/cypress/integration/ErrorHandling/TwoConsecutiveUserInput.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('ErrorHandling', () => {
   it('Two Consecutive User Input', () => {

--- a/cypress/integration/ErrorHandling/WaitNonWait.spec.js
+++ b/cypress/integration/ErrorHandling/WaitNonWait.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('ErrorHandling', () => {
   it('Wait Non Wait', () => {

--- a/cypress/integration/Log/EndlessLoop.spec.js
+++ b/cypress/integration/Log/EndlessLoop.spec.js
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
 */
 
-const homePage = require('../../support/components/HomePage')
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const logDialogsGrid = require('../../support/components/LogDialogsGrid')
-const logDialogModal = require('../../support/components/LogDialogModal')
-const helpers = require('../../support/Helpers')
+import * as homePage from '../../support/components/HomePage'
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as logDialogsGrid from '../../support/components/LogDialogsGrid'
+import * as logDialogModal from '../../support/components/LogDialogModal'
+import * as helpers from '../../support/Helpers'
 
 describe('Log', () => {
   it('Endless Loop', () => {

--- a/cypress/integration/Log/WhatsYourName.spec.js
+++ b/cypress/integration/Log/WhatsYourName.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const logDialogsGrid = require('../../support/components/LogDialogsGrid')
-const logDialogModal = require('../../support/components/LogDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as logDialogsGrid from '../../support/components/LogDialogsGrid'
+import * as logDialogModal from '../../support/components/LogDialogModal'
+import * as common from '../../support/Common'
 
 describe('Log', () => {
   it(common.whatsYourName, () => {

--- a/cypress/integration/Tools/CreateModel.spec.js
+++ b/cypress/integration/Tools/CreateModel.spec.js
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const homePage = require('../../support/components/HomePage')
+import * as models from '../../support/Models'
+import * as homePage from '../../support/components/HomePage'
 
 describe('Tools', () => {
   it('Create Model', () => {

--- a/cypress/integration/Tools/DeleteAllTestGeneratedModels.spec.js
+++ b/cypress/integration/Tools/DeleteAllTestGeneratedModels.spec.js
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
 */
 
-const homePage = require('../../support/components/HomePage')
-const helpers = require('../../support/Helpers')
+import * as homePage from '../../support/components/HomePage'
+import * as helpers from '../../support/Helpers'
 
 describe('Tools', () => {
   it('Delete All Test Generated Models', () => {

--- a/cypress/integration/Tools/VerifyDoesNotContainTestMethod.spec.js
+++ b/cypress/integration/Tools/VerifyDoesNotContainTestMethod.spec.js
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
 
 // This is a test case to test one of our test methods, cy.DoesNotContain.
 // The problem with that method is that if it has a bug and does not find

--- a/cypress/integration/Tools/VisitHomePage.spec.js
+++ b/cypress/integration/Tools/VisitHomePage.spec.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
 */
 
-const homePage = require('../../support/components/HomePage')
+import * as homePage from '../../support/components/HomePage'
 
 describe('Tools', () => {
   it('Visit Home Page', () => {

--- a/cypress/integration/Train/BookMeAFlight.spec.js
+++ b/cypress/integration/Train/BookMeAFlight.spec.js
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const memoryTableComponent = require('../../support/components/MemoryTableComponent')
-const scorerModal = require('../../support/components/ScorerModal')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as memoryTableComponent from '../../support/components/MemoryTableComponent'
+import * as scorerModal from '../../support/components/ScorerModal'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('Train', () => {
   it('Book Me A Flight', () => {

--- a/cypress/integration/Train/DisqualifyingEntities.spec.js
+++ b/cypress/integration/Train/DisqualifyingEntities.spec.js
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const memoryTableComponent = require('../../support/components/MemoryTableComponent')
-const scorerModal = require('../../support/components/ScorerModal')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as memoryTableComponent from '../../support/components/MemoryTableComponent'
+import * as scorerModal from '../../support/components/ScorerModal'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('Train', () => {
   it('Disqualifying Entities', () => {

--- a/cypress/integration/Train/MyNameIs.spec.js
+++ b/cypress/integration/Train/MyNameIs.spec.js
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const memoryTableComponent = require('../../support/components/MemoryTableComponent')
-const scorerModal = require('../../support/components/ScorerModal')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as memoryTableComponent from '../../support/components/MemoryTableComponent'
+import * as scorerModal from '../../support/components/ScorerModal'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('Train', () => {
   it('My Name Is', () => {

--- a/cypress/integration/Train/TagAndFrog.spec.js
+++ b/cypress/integration/Train/TagAndFrog.spec.js
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('Train', () => {
   it('Tag And Frog', () => {

--- a/cypress/integration/Train/WaitVsNoWaitActions.spec.js
+++ b/cypress/integration/Train/WaitVsNoWaitActions.spec.js
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const scorerModal = require('../../support/components/ScorerModal')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as scorerModal from '../../support/components/ScorerModal'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('Train', () => {
   it('Wait vs Non-Wait Actions', () => {

--- a/cypress/integration/Train/WhatsYourName.spec.js
+++ b/cypress/integration/Train/WhatsYourName.spec.js
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const modelPage = require('../../support/components/ModelPage')
-const memoryTableComponent = require('../../support/components/MemoryTableComponent')
-const scorerModal = require('../../support/components/ScorerModal')
-const train = require('../../support/Train')
-const editDialogModal = require('../../support/components/EditDialogModal')
-const common = require('../../support/Common')
+import * as models from '../../support/Models'
+import * as modelPage from '../../support/components/ModelPage'
+import * as memoryTableComponent from '../../support/components/MemoryTableComponent'
+import * as scorerModal from '../../support/components/ScorerModal'
+import * as train from '../../support/Train'
+import * as editDialogModal from '../../support/components/EditDialogModal'
+import * as common from '../../support/Common'
 
 describe('Train', () => {
   it('Whats Your Name', () => {

--- a/cypress/integration/UX/BotModelMismatch.spec.js
+++ b/cypress/integration/UX/BotModelMismatch.spec.js
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
 */
 
-const models = require('../../support/Models')
-const helpers = require('../../support/Helpers')
+import * as models from '../../support/Models'
+import * as helpers from '../../support/Helpers'
 
 describe('UX', () => {
   it('Bot Model Mismatch', () => {

--- a/cypress/integration/zTemp/zTemp.spec.js
+++ b/cypress/integration/zTemp/zTemp.spec.js
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
 */
 
-const helpers = require('../../support/Helpers')
-const homePage = require('../../support/components/HomePage')
-const modelPage = require('../../support/components/ModelPage')
-const train = require('../../support/Train')
-const trainDialogsGrid = require('../../support/components/TrainDialogsGrid')
-const editDialogModal = require('../../support/components/EditDialogModal')
+import * as helpers from '../../support/Helpers'
+import * as homePage from '../../support/components/HomePage'
+import * as modelPage from '../../support/components/ModelPage'
+import * as train from '../../support/Train'
+import * as trainDialogsGrid from '../../support/components/TrainDialogsGrid'
+import * as editDialogModal from '../../support/components/EditDialogModal'
 
 describe('zTemp', () => {
   it('Temporary Experimental Test', () => {

--- a/cypress/support/Actions.js
+++ b/cypress/support/Actions.js
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-const actionModal = require('../support/components/ActionModal')
-const actionsGrid = require('../support/components/ActionsGrid')
-const modelPage = require('../support/components/ModelPage')
-const helpers = require('../support/Helpers')
+import * as actionModal from '../support/components/ActionModal'
+import * as actionsGrid from '../support/components/ActionsGrid'
+import * as modelPage from '../support/components/ModelPage'
+import * as helpers from '../support/Helpers'
 
 // ------------------------------------------------------------------------------------------------
 // The UI automatically populates the Required Entities field with entities found in the response 

--- a/cypress/support/Entities.js
+++ b/cypress/support/Entities.js
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-const modelPage = require('../support/components/ModelPage')
-const entitiesGrid = require('./components/EntitiesGrid')
-const entityModal = require('../support/components/EntityModal')
+import * as modelPage from '../support/components/ModelPage'
+import * as entitiesGrid from './components/EntitiesGrid'
+import * as entityModal from '../support/components/EntityModal'
 
 export function CreateNewEntity({ name, multiValued, negatable, resolverType, type = 'Custom Trained', expectPopup = false }) {
   modelPage.NavigateToEntities()

--- a/cypress/support/Models.js
+++ b/cypress/support/Models.js
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-const homePage = require('./components/HomePage')
-const modelPage = require('./components/ModelPage')
+import * as homePage from './components/HomePage'
+import * as modelPage from './components/ModelPage'
 
 // The test defined prefix can be up to 17 characters.
 // The dash and time suffix takes 13 characters. 

--- a/cypress/support/MonitorDocumentChanges.js
+++ b/cypress/support/MonitorDocumentChanges.js
@@ -18,7 +18,7 @@
  * within 700 milliseconds since the last change, or another one occures to reset the count.
 */
 
-const helpers = require('./Helpers.js')
+import * as helpers from './Helpers.js'
 
 var MonitorDocumentChanges = (function () {
   let lastMonitorTime = 0

--- a/cypress/support/Train.js
+++ b/cypress/support/Train.js
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-const scorerModal = require('./components/ScorerModal')
-const trainDialogsGrid = require('./components/TrainDialogsGrid')
-const editDialogModal = require('./components/EditDialogModal')
-const helpers = require('./Helpers')
+import * as scorerModal from './components/ScorerModal'
+import * as trainDialogsGrid from './components/TrainDialogsGrid'
+import * as editDialogModal from './components/EditDialogModal'
+import * as helpers from './Helpers'
 
 function Today() { return Cypress.moment().format("MM/DD/YYYY") }
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,5 +1,5 @@
-const helpers = require('./Helpers.js')
-const modelPage = require('./components/ModelPage')
+import * as helpers from './Helpers.js'
+import * as modelPage from './components/ModelPage'
 
 // **********************************************************************************************
 // OTHER cy.* COMMANDS are defined in MonitorDocumentChanges.js

--- a/cypress/support/components/ActionsGrid.js
+++ b/cypress/support/components/ActionsGrid.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
 */
 
-const helpers = require('../../support/Helpers')
+import * as helpers from '../../support/Helpers'
 
 export function VerifyPageTitle() { cy.Get('[data-testid="actions-title"]').contains('Actions').should('be.visible') }
 export function ValidateExpectedEntities(entities) { ValidateEntities('[data-testid="action-details-expected-entity"]', '[data-testid="action-details-empty-expected-entities"]', entities) }

--- a/cypress/support/components/EditDialogModal.js
+++ b/cypress/support/components/EditDialogModal.js
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-const homePage = require('../../support/components/HomePage')
-const helpers = require('../../support/Helpers')
-const scorerModal = require('../../support/components/ScorerModal')
+import * as homePage from '../../support/components/HomePage'
+import * as helpers from '../../support/Helpers'
+import * as scorerModal from '../../support/components/ScorerModal'
 
 export const AllChatMessagesSelector = 'div[data-testid="web-chat-utterances"] > div.wc-message-content > div > div.format-markdown > p'
 export const TypeYourMessageSelector = 'input.wc-shellinput[placeholder="Type your message..."]' // data-testid NOT possible

--- a/cypress/support/components/EntityModal.js
+++ b/cypress/support/components/EntityModal.js
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.  
  * Licensed under the MIT License.
  */
-const helpers = require('../Helpers')
+import * as helpers from '../Helpers'
 
 export function ClickEntityType(type) { cy.Get(`button.ms-Dropdown-item`).contains(type).Click() }
 export function TypeEntityName(entityName) { cy.Get('[data-testid="entity-creator-entity-name-text"]').type(entityName) }

--- a/cypress/support/components/HomePage.js
+++ b/cypress/support/components/HomePage.js
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-const modelPage = require('../components/ModelPage')
-const settings = require('../components/Settings')
-const helpers = require('../Helpers')
+import * as modelPage from '../components/ModelPage'
+import * as settings from '../components/Settings'
+import * as helpers from '../Helpers'
 
 export function Visit() { return cy.visit('http://localhost:5050'); VerifyPageTitle() }
 export function VerifyPageTitle() { return cy.Get('[data-testid="model-list-title"]').contains('Create and manage your Conversation Learner models').should('be.visible') }

--- a/cypress/support/components/ModelPage.js
+++ b/cypress/support/components/ModelPage.js
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-const entitiesGrid = require('../../support/components/EntitiesGrid')
-const actionsGrid = require('../../support/components/ActionsGrid')
-const trainDialogsGrid = require('./TrainDialogsGrid')
-const logDialogsGrid = require('../../support/components/LogDialogsGrid')
-const settings = require('../../support/components/Settings')
-const helpers = require('../Helpers')
+import * as entitiesGrid from '../../support/components/EntitiesGrid'
+import * as actionsGrid from '../../support/components/ActionsGrid'
+import * as trainDialogsGrid from './TrainDialogsGrid'
+import * as logDialogsGrid from '../../support/components/LogDialogsGrid'
+import * as settings from '../../support/components/Settings'
+import * as helpers from '../Helpers'
 
 export function VerifyModelName(name) { cy.Get('[data-testid="app-index-model-name"]').should(el => { expect(el).to.contain(name) }) }
 export function VerifyPageTitle() { cy.Get('[data-testid="dashboard-title"]').contains('Log Dialogs').should('be.visible') }

--- a/cypress/support/components/ScorerModal.js
+++ b/cypress/support/components/ScorerModal.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const helpers = require('../../support/Helpers')
+import * as helpers from '../../support/Helpers'
 
 // data-testid="teach-session-admin-train-status" (Running, Completed, Failed)
 export function ClickRefreshScoreButton() { cy.Get('[data-testid="teach-session-admin-refresh-score-button"]').Click() }

--- a/cypress/support/components/Settings.js
+++ b/cypress/support/components/Settings.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const entitiesGrid = require('../../support/components/EntitiesGrid')
+import * as entitiesGrid from '../../support/components/EntitiesGrid'
 
 export function VerifyPageTitle() { cy.Get('[data-testid="settings-title"]').contains('Settings').should('be.visible') }
 

--- a/cypress/support/components/TrainDialogsGrid.js
+++ b/cypress/support/components/TrainDialogsGrid.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const helpers = require('../Helpers')
+import * as helpers from '../Helpers'
 
 // Path to product code: ConversationLearner-UI\src\routes\Apps\App\TrainDialogs.tsx
 export function VerifyPageTitle() { cy.Get('[data-testid="train-dialogs-title"]').contains('Train Dialogs').should('be.visible') }


### PR DESCRIPTION
Update tests to use newer ES2015 syntax for importing.

From cypress website.
> Cypress also supports ES2015 out of the box. You can use either ES2015 modules or CommonJS modules. This means you can import or require both npm packages and local relative modules.
