### PR TITLE
fix: move validity indicator icon back to first column

### DIFF
--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -142,9 +142,9 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: equalizeColumnWidth,
             isResizable: true,
             render: trainDialog => {
-                return <span className={textClassName(trainDialog)} data-testid="train-dialogs-tags">
+                return <span className={`${OF.FontClassNames.mediumPlus}`} data-testid="train-dialogs-tags">
                     {trainDialog.tags.length === 0
-                        ? <FormattedMessageId id={FM.TRAINDIALOGS_TAGS_EMPTY} />
+                        ? <span  className={textClassName(trainDialog)}><FormattedMessageId id={FM.TRAINDIALOGS_TAGS_EMPTY} /></span>
                         : <TagsReadOnly tags={trainDialog.tags} />}
                 </span>
             },

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -114,7 +114,18 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                 const lastInput = getLastInput(trainDialog)
                 const lastResponse = getLastResponse(trainDialog, component);
                 return <>
-                    <span data-testid="train-dialogs-description" className={textClassName(trainDialog)}>{trainDialog.description || <FormattedMessageId id={FM.TRAINDIALOGS_DESCRIPTION_EMPTY} />}</span>
+                    <span className={textClassName(trainDialog)}>
+                        {trainDialog.validity && trainDialog.validity !== CLM.Validity.VALID &&
+                            <OF.Icon
+                                className={`cl-icon ${ValidityUtils.validityColorClassName(trainDialog.validity)}`}
+                                iconName="IncidentTriangle"
+                                data-testid="train-dialogs-validity-indicator"
+                            />
+                        }
+                        <span data-testid="train-dialogs-description">
+                            {trainDialog.description || <FormattedMessageId id={FM.TRAINDIALOGS_DESCRIPTION_EMPTY} />}
+                        </span>
+                    </span>
                     {/* Keep firstInput and lastInput available in DOM until tests are upgraded */}
                     <span style={{ display: "none" }} data-testid="train-dialogs-first-input">{firstInput ? firstInput : ''}</span>
                     <span style={{ display: "none" }} data-testid="train-dialogs-last-input">{lastInput ? lastInput : ''}</span>
@@ -132,15 +143,9 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             isResizable: true,
             render: trainDialog => {
                 return <span className={textClassName(trainDialog)} data-testid="train-dialogs-tags">
-                    {trainDialog.validity && trainDialog.validity !== CLM.Validity.VALID &&
-                        <OF.Icon
-                            className={`cl-icon ${ValidityUtils.validityColorClassName(trainDialog.validity)}`}
-                            iconName="IncidentTriangle"
-                        />
-                    }
                     {trainDialog.tags.length === 0
-                        ? <span className={textClassName(trainDialog)}><FormattedMessageId id={FM.TRAINDIALOGS_TAGS_EMPTY} /></span>
-                        : <TagsReadOnly className={textClassName(trainDialog)} tags={trainDialog.tags} />}
+                        ? <FormattedMessageId id={FM.TRAINDIALOGS_TAGS_EMPTY} />
+                        : <TagsReadOnly tags={trainDialog.tags} />}
                 </span>
             },
             getSortValue: trainDialog => trainDialog.tags.join(' ')
@@ -994,7 +999,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         };
 
         try {
-            const teachWithHistory = await((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialogWithDefinitions, this.props.user.name, this.props.user.id) as any) as Promise<CLM.TeachWithHistory>)
+            const teachWithHistory = await ((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialogWithDefinitions, this.props.user.name, this.props.user.id) as any) as Promise<CLM.TeachWithHistory>)
             const originalId = this.state.currentTrainDialog
                 ? this.state.currentTrainDialog.trainDialogId
                 : null


### PR DESCRIPTION
Originally the icon was on the first column which was first input, then first input was changed to tags, then tags was moved to be second column instead of first and I forgot to move the triangle back.

This moves it back to the first column like below:
![image](https://user-images.githubusercontent.com/2856501/53669544-437cf100-3c2c-11e9-9e37-9a5db1ec628a.png)

Also added a new attribute:
`data-testid="train-dialogs-validity-indicator"` to help make it easier on tests. Previously they were testing for firstInput and having to know if it was valid or not, but the icon isn't actually part of the input so this was misleading.  Even though the first inputs are still in the DOM they don't including the icon so I think there will need to be new way to test this.

Couple questions for further improvement or future PRs:

- **Dates color**
I noticed that we only colorize the scenario, tags, and turns, but not the dates.  My first instinct thought the whole row should be the same color but maybe it was left this way to make reading the dates easier?
Anyways, want to decision to changes those also or leave them.

- **Tag color**
Current it just uses the same red text coloring as the other fields.  An alternate design might be to preserve text contrast and change tag background like below:
![image](https://user-images.githubusercontent.com/2856501/53669748-01a07a80-3c2d-11e9-871c-e36716e624f5.png)
I thought this was too harsh, but so I left it out but wanted to get other's opinions. If we do it I think it needs to be the consistent red error color everywhere though so just making it a faded red didn't seem like an option.

