### PR TITLE
fix: preserve source dialog instead of new dialog when continuing

### DIFF
--- a/src/actions/teachActions.ts
+++ b/src/actions/teachActions.ts
@@ -9,7 +9,7 @@ import * as ClientFactory from '../services/clientFactory'
 import { setErrorDisplay } from './displayActions'
 import * as CLM from '@conversationlearner/models'
 import { AxiosError } from 'axios'
-import { deleteTrainDialogThunkAsync, fetchAllTrainDialogsThunkAsync, editTrainDialogThunkAsync } from './trainActions'
+import { fetchAllTrainDialogsThunkAsync } from './trainActions'
 import { fetchApplicationTrainingStatusThunkAsync } from './appActions'
 
 // --------------------------
@@ -139,19 +139,31 @@ export const deleteTeachSessionThunkAsync = (
         const clClient = ClientFactory.getInstance(AT.DELETE_TEACH_SESSION_ASYNC)
 
         try {
-            const trainDialogId = await clClient.teachSessionDelete(app.appId, teachSession, save);
+            await clClient.teachSessionDelete(app.appId, teachSession, save);
             dispatch(deleteTeachSessionFulfilled(key, teachSession, sourceLogDialogId, app.appId));
 
             // If saving to a TrainDialog
             if (save) {
-                // If source train dialog exists for new dialog delete it (LogDialogs not deleted)
+                // If source train dialog exists update it with data from new dialog and then delete the new dialog
+                // The new dialog was only created as side effect of new teach session. It was intermediate/temporary and can be discarded.
                 if (sourceTrainDialogId) {
-                    await dispatch(deleteTrainDialogThunkAsync(key, app, sourceTrainDialogId));
+                    const newTrainDialog = await clClient.trainDialog(app.appId, teachSession.trainDialogId)
+                    // Created updated source dialog from new dialogs rounds
+                    const updatedSourceDialog: CLM.TrainDialog = {
+                        ...newTrainDialog,
+                        trainDialogId: sourceTrainDialogId,
+                        tags,
+                        description
+                    }
+                    const deletePromise = clClient.trainDialogsDelete(app.appId, teachSession.trainDialogId)
+                    const editPromise =  clClient.trainDialogEdit(app.appId, updatedSourceDialog)
+                    await Promise.all([deletePromise, editPromise])
+                }
+                else {
+                    // Edit the associated train dialogs tag and description
+                    await clClient.trainDialogEdit(app.appId, { trainDialogId: teachSession.trainDialogId, tags, description })
                 }
 
-                // Edit the associated train dialogs tag and description
-                await dispatch(editTrainDialogThunkAsync(app.appId, { trainDialogId, tags, description }))
-                
                 // If we're adding a new train dialog as consequence of the session save, re-fetch train dialogs and start poll for train status
                 dispatch(fetchAllTrainDialogsThunkAsync(app.appId));
                 dispatch(fetchApplicationTrainingStatusThunkAsync(app.appId));


### PR DESCRIPTION
When continuing instead of editing the original it would remove the original and add the continued/new dialog which was created as side effect of the new teach session.

This caused the created time to update when it shouldn't have.

The other problem is much more complicated but related:
Due to the way the thunk was written, in combination with other thunks and the asynchronous `await`s inside it, the call to delete the source dialog would finish and remove the dialog from the list before the next call refresh the dialogs which implicitly added it to the list.

Due to created date being changed this caused the dialog to jump/shift in place in the list and depending on server response times could look like the dialog was deleted before it would reappear.

After all is done the dialog properly updates in place and preserves the create date.

Fixes ADO#1907
Might fix: ADO#1905 (Still need to confirm this)