### PR TITLE
fix: bugs related to tags

### DIFF
--- a/src/actions/teachActions.ts
+++ b/src/actions/teachActions.ts
@@ -173,7 +173,7 @@ export const deleteTeachSessionThunkAsync = (
         } catch (e) {
             const error = e as AxiosError
             dispatch(clearTeachSession())
-            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? JSON.stringify(error.response, null, '  ') : "", AT.DELETE_TRAIN_DIALOG_REJECTED))
+            dispatch(setErrorDisplay(ErrorType.Error, error.message, error.response ? JSON.stringify(error.response, null, '  ') : "", AT.CREATE_TRAIN_DIALOG_ASYNC))
             dispatch(fetchAllTrainDialogsThunkAsync(app.appId));
             return false;
         }

--- a/src/components/TagsInput.css
+++ b/src/components/TagsInput.css
@@ -87,3 +87,13 @@
     background-color: var(--color-themeLight);
 }
 
+.cl-tags-error {
+    margin-top: 5px;
+    margin-left: 5px;
+    color: var(--color-error);
+}
+
+.cl-tags-error [data-icon-name="Warning"] {
+    transform: translateY(2px);
+}
+

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -290,6 +290,7 @@ class component extends React.Component<Props, State> {
                                 onKeyDown={this.onKeyDownInput}
                                 onBlur={this.onBlurInput}
                                 autoComplete="off"
+                                spellCheck={false}
                                 maxLength={this.props.magTagLength}
                             />
                             <div className="cl-tags__suggested-tags-container">

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -26,6 +26,7 @@ interface State {
     showForm: boolean
     matchedOptions: MatchedOption<ITag>[]
     highlightIndex: number
+    pendingTagIsDuplicate: boolean
 }
 
 const fuseOptions: Fuse.FuseOptions = {
@@ -56,7 +57,8 @@ class component extends React.Component<Props, State> {
         inputValue: '',
         showForm: false,
         matchedOptions: [],
-        highlightIndex: -1
+        highlightIndex: -1,
+        pendingTagIsDuplicate: false
     }
 
     constructor(props: Props) {
@@ -78,7 +80,7 @@ class component extends React.Component<Props, State> {
     componentWillReceiveProps(nextProps: Props) {
         if (this.props.tags.length !== nextProps.tags.length
             || this.props.allUniqueTags.length !== nextProps.allUniqueTags.length) {
-                
+
             const hasMaxTags = nextProps.tags.length >= nextProps.maxTags
             const matchedOptions = this.getSuggestedTags(nextProps.allUniqueTags, nextProps.tags)
             this.setState({
@@ -103,7 +105,8 @@ class component extends React.Component<Props, State> {
         const tag = this.state.inputValue.trim()
 
         // Prevent submitting empty tags
-        if (tag.length === 0) {
+        if (tag.length === 0
+            || this.state.pendingTagIsDuplicate) {
             return
         }
 
@@ -116,14 +119,18 @@ class component extends React.Component<Props, State> {
 
     onChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
         const inputValue = event.target.value
+        const pendingTagIsDuplicate = this.props.tags.some(t => t === inputValue)
         const searchText = inputValue.trim()
         const matchedOptions: MatchedOption<ITag>[] = (searchText.length === 0)
             ? this.getSuggestedTags(this.props.allUniqueTags, this.props.tags)
             : this.fuse.search<FuseResult<ITag>>(searchText)
                 .map(result => convertMatchedTextIntoMatchedOption(result.item.text, result.matches[0].indices, result.item))
+                // Remove matches for tags that are already added
+                .filter(option => !this.props.tags.some(t => t === option.original.text))
 
         this.setState({
             inputValue,
+            pendingTagIsDuplicate,
             matchedOptions
         })
     }
@@ -155,7 +162,8 @@ class component extends React.Component<Props, State> {
 
     onEnter(event: React.KeyboardEvent<HTMLInputElement>) {
         if (event.shiftKey
-            || this.state.highlightIndex === -1) {
+            || this.state.highlightIndex === -1
+            || this.state.pendingTagIsDuplicate) {
             return
         }
 
@@ -185,11 +193,12 @@ class component extends React.Component<Props, State> {
     }
 
     onBlurInput = () => {
-        const tag = this.state.inputValue
+        const tag = this.state.inputValue.trim()
 
         // If user accidentally clicked away before submission still save tag
         // They can delete if unintended
-        if (tag.length > 0) {
+        if (tag.length > 0
+            && !this.state.pendingTagIsDuplicate) {
             this.props.onAdd(tag)
         }
 
@@ -235,6 +244,7 @@ class component extends React.Component<Props, State> {
             inputValue: '',
             showForm: false,
             highlightIndex: -1,
+            pendingTagIsDuplicate: false
         })
     }
 
@@ -251,10 +261,9 @@ class component extends React.Component<Props, State> {
     }
 
     render() {
-        const { matchedOptions, highlightIndex } = this.state
-        const { hasMaxTags, showForm } = this.state
+        const { matchedOptions, highlightIndex, hasMaxTags, showForm, pendingTagIsDuplicate } = this.state
         const dataTestId = this.props['data-testid']
-        
+
         return (
             <div className="cl-tags" data-testid={dataTestId} >
                 {this.props.tags.map((tag, i) =>
@@ -271,33 +280,36 @@ class component extends React.Component<Props, State> {
                             ? <FormattedMessageId id={FM.TAGS_INPUT_ADD} />
                             : <OF.Icon iconName="Add" />}
                     </button>
-                    : <form onSubmit={this.onSubmit} className="cl-tags__form">
-                        <input type="text"
-                            ref={this.inputRef}
-                            id={this.props.id}
-                            value={this.state.inputValue}
-                            onChange={this.onChangeInput}
-                            onKeyDown={this.onKeyDownInput}
-                            onBlur={this.onBlurInput}
-                            autoComplete="off"
-                            maxLength={this.props.magTagLength}
-                        />
-                        <div className="cl-tags__suggested-tags-container">
-                            {matchedOptions.length !== 0
-                                && <div className="cl-tags__suggested-tags" ref={this.suggestedTagsRef}>
-                                    {matchedOptions.map((matchedOption, i) =>
-                                        <div
-                                            key={i}
-                                            className={`cl-tags__suggested-tags__button ${highlightIndex === i ? 'cl-tags__suggested-tags__button--highlight' : ''}`}
-                                            onMouseDown={event => this.onMouseDownSuggestedTag(event, matchedOption.original.text)}
-                                        >
-                                            <FuseMatch matches={matchedOption.matchedStrings} />
-                                        </div>
-                                    )}
-                                </div>
-                            }
-                        </div>
-                    </form>)
+                    : <>
+                        <form onSubmit={this.onSubmit} className="cl-tags__form">
+                            <input type="text"
+                                ref={this.inputRef}
+                                id={this.props.id}
+                                value={this.state.inputValue}
+                                onChange={this.onChangeInput}
+                                onKeyDown={this.onKeyDownInput}
+                                onBlur={this.onBlurInput}
+                                autoComplete="off"
+                                maxLength={this.props.magTagLength}
+                            />
+                            <div className="cl-tags__suggested-tags-container">
+                                {matchedOptions.length !== 0
+                                    && <div className="cl-tags__suggested-tags" ref={this.suggestedTagsRef}>
+                                        {matchedOptions.map((matchedOption, i) =>
+                                            <div
+                                                key={i}
+                                                className={`cl-tags__suggested-tags__button ${highlightIndex === i ? 'cl-tags__suggested-tags__button--highlight' : ''}`}
+                                                onMouseDown={event => this.onMouseDownSuggestedTag(event, matchedOption.original.text)}
+                                            >
+                                                <FuseMatch matches={matchedOption.matchedStrings} />
+                                            </div>
+                                        )}
+                                    </div>
+                                }
+                            </div>
+                        </form>
+                        {pendingTagIsDuplicate && <div className="cl-tags-error"><OF.Icon iconName="Warning" /> <FormattedMessageId id={FM.TAGS_INPUT_ERROR_DUPLICATE} /></div>}
+                    </>)
                 }
             </div>
         )

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -79,7 +79,7 @@ class component extends React.Component<Props, State> {
         if (this.props.tags.length !== nextProps.tags.length
             || this.props.allUniqueTags.length !== nextProps.allUniqueTags.length) {
                 
-            const hasMaxTags = this.props.tags.length > this.props.maxTags
+            const hasMaxTags = nextProps.tags.length >= nextProps.maxTags
             const matchedOptions = this.getSuggestedTags(nextProps.allUniqueTags, nextProps.tags)
             this.setState({
                 hasMaxTags,
@@ -265,7 +265,7 @@ class component extends React.Component<Props, State> {
                         </button>
                     </div>
                 )}
-                {!hasMaxTags && !showForm
+                {!hasMaxTags && (!showForm
                     ? <button className="cl-tags__button-add" id={this.props.id} onClick={() => this.onClickAdd()} >
                         {this.props.tags.length === 0
                             ? <FormattedMessageId id={FM.TAGS_INPUT_ADD} />
@@ -297,7 +297,7 @@ class component extends React.Component<Props, State> {
                                 </div>
                             }
                         </div>
-                    </form>
+                    </form>)
                 }
             </div>
         )

--- a/src/components/modals/TeachSessionAdmin.css
+++ b/src/components/modals/TeachSessionAdmin.css
@@ -2,6 +2,7 @@
     display: grid;
     grid-template: auto / max-content 1fr;
     grid-gap: 0.25em 0.5em;
+    align-items: start;
 }
 
 .cl-dialog-metadata label {
@@ -13,6 +14,6 @@
 
 /* Special to align header, don't repeat this */
 .cl-dialog-metadata label[for="description"] {
-    padding: 0.225em 0;
+    padding: 3px 0;
 }
 

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -346,6 +346,7 @@ export enum FM {
     // Tags and Description
     TAGS_INPUT_LABEL = 'Tags.label',
     TAGS_INPUT_ADD = 'TagsInput.add',
+    TAGS_INPUT_ERROR_DUPLICATE = 'TagsInput.error.duplicate',
     TAGS_READONLY_EMPTY = 'TagsReadOnly.empty',
     DESCRIPTION_LABEL = 'Description.label',
     DESCRIPTION_PLACEHOLDER = 'Description.placeholder',
@@ -977,6 +978,7 @@ export default {
         // Tags and Description
         [FM.TAGS_INPUT_LABEL]: 'Tags',
         [FM.TAGS_INPUT_ADD]: 'Add Tag',
+        [FM.TAGS_INPUT_ERROR_DUPLICATE]: 'The new tag is a duplicate of an existing tag.',
         [FM.TAGS_READONLY_EMPTY]: 'No Tags',
         [FM.DESCRIPTION_LABEL]: 'Description',
         [FM.DESCRIPTION_PLACEHOLDER]: 'Click to add description',


### PR DESCRIPTION
Fixes the following:
- Prevents creating tags which are whitespace
- Prevents adding duplicate tags to the dialog
- Prevents adding more than 20 tags which was the limit on the server
- Ensures "Tags" label stays at top even though tags list may span multiple rows
- Disable spellcheck since most tags may not be words like "myTag" or "yourTag"
- Fixes incorrectly named error when you create a train dialog from "DELETE" to "CREATE"

In order to show people why the submission doesn't work due to duplicate we had to show an error message so that was added to the right since.

![image](https://user-images.githubusercontent.com/2856501/53996800-b4ba1980-40ee-11e9-9295-68e4df4effe5.png)
