### PR TITLE
fix: improve entity label conflict modal

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -69,6 +69,10 @@ html {
   color: var(--color-alert);
 }
 
+.cl-text--success {
+  color: var(--color-success);
+}
+
 .cl-action {
   border: none;
   background: none;
@@ -145,6 +149,7 @@ html {
   color: green;
   font-size: 20px;
 }
+
 .cl-icon[data-icon-name="CommentAdd"]{
   color: lightgrey;
   font-size: 18px

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -404,6 +404,10 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                 }))
         const allExtractResponsesValid = extractResponsesForDisplay.every(e => e.isValid)
 
+        // Need to save this to separate variable for typescript control flow
+        const extractConflict = this.props.extractConflict
+        const attemptedExtractResponse = extractConflict && this.props.extractResponses.find(e => e.text.toLowerCase() === extractConflict.text.toLowerCase())
+        
         return (
             <div className="entity-extractor">
                 <OF.Label className={`entity-extractor-help-text ${OF.FontClassNames.smallPlus} cl-label`}>
@@ -537,10 +541,11 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                             <OF.DefaultButton onClick={() => this.onClickSaveCheckNo()} text='No' />
                         </OF.DialogFooter>
                     </OF.Dialog>
-                    {this.props.extractConflict &&
-                        <ExtractConflictModal
+                    {(this.props.extractConflict && attemptedExtractResponse)
+                        && <ExtractConflictModal
                             open={true}
                             entities={this.props.entities}
+                            attemptedExtractResponse={attemptedExtractResponse}
                             extractResponse={this.props.extractConflict}
                             onClose={this.onEntityConflictModalAbandon}
                             onAccept={this.onEntityConflictModalAccept}

--- a/src/components/modals/ExtractConflictModal.css
+++ b/src/components/modals/ExtractConflictModal.css
@@ -1,0 +1,9 @@
+.cl-inconsistent-entity-modal-header {
+    padding: 1em 0 0.5em 0;
+}
+.cl-inconsistent-entity-modal-header [data-icon-name] {
+    transform: translateY(2px);
+}
+.cl-inconsistent-entity-modal-editor {
+    padding-bottom: 0.5em;
+}

--- a/src/components/modals/ExtractConflictModal.tsx
+++ b/src/components/modals/ExtractConflictModal.tsx
@@ -38,48 +38,48 @@ const ExtractConflictModal: React.SFC<Props> = (props) => {
                 <OF.Icon iconName="Warning" />&nbsp;{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_TITLE)}
                 {typeof props.message === 'function' && props.message()}
             </div>
-                <div>
-                    <p>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_SUBTITLE)}</p>
-                    <div>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_REVIEW)}</div>
+            <div>
+                <p>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_SUBTITLE)}</p>
+                <div>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_REVIEW)}</div>
 
-                    <div className="cl-inconsistent-entity-modal-header cl-text--error"><OF.Icon iconName="ChromeClose" />&nbsp;{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CONFLICTING_LABELS)}</div>
-                    <ExtractorResponseEditor.EditorWrapper
-                        render={(editorProps, onChangeCustomEntities) =>
-                            <ExtractorResponseEditor.Editor
-                                readOnly={true}
-                                isValid={true}
-                                entities={props.entities}
-                                {...editorProps}
+                <div className="cl-inconsistent-entity-modal-header cl-text--error"><OF.Icon iconName="ChromeClose" />&nbsp;{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CONFLICTING_LABELS)}</div>
+                <ExtractorResponseEditor.EditorWrapper
+                    render={(editorProps, onChangeCustomEntities) =>
+                        <ExtractorResponseEditor.Editor
+                            readOnly={true}
+                            isValid={true}
+                            entities={props.entities}
+                            {...editorProps}
 
-                                onChangeCustomEntities={onChangeCustomEntities}
-                                onClickNewEntity={() => { }}
-                            />
-                        }
-                        entities={props.entities}
-                        extractorResponse={props.attemptedExtractResponse}
-                        onChange={() => { }}
-                    />
+                            onChangeCustomEntities={onChangeCustomEntities}
+                            onClickNewEntity={() => { }}
+                        />
+                    }
+                    entities={props.entities}
+                    extractorResponse={props.attemptedExtractResponse}
+                    onChange={() => { }}
+                />
 
-                    <div className="cl-inconsistent-entity-modal-header cl-text--success"><OF.Icon iconName="Accept" />&nbsp;{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CORRECT_LABELS)}</div>
-                    <ExtractorResponseEditor.EditorWrapper
-                        render={(editorProps, onChangeCustomEntities) =>
-                            <ExtractorResponseEditor.Editor
-                                readOnly={true}
-                                isValid={true}
-                                entities={props.entities}
-                                {...editorProps}
+                <div className="cl-inconsistent-entity-modal-header cl-text--success"><OF.Icon iconName="Accept" />&nbsp;{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CORRECT_LABELS)}</div>
+                <ExtractorResponseEditor.EditorWrapper
+                    render={(editorProps, onChangeCustomEntities) =>
+                        <ExtractorResponseEditor.Editor
+                            readOnly={true}
+                            isValid={true}
+                            entities={props.entities}
+                            {...editorProps}
 
-                                onChangeCustomEntities={onChangeCustomEntities}
-                                onClickNewEntity={() => { }}
-                            />
-                        }
-                        entities={props.entities}
-                        extractorResponse={props.extractResponse}
-                        onChange={() => { }}
-                    />
+                            onChangeCustomEntities={onChangeCustomEntities}
+                            onClickNewEntity={() => { }}
+                        />
+                    }
+                    entities={props.entities}
+                    extractorResponse={props.extractResponse}
+                    onChange={() => { }}
+                />
 
-                    <p>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CALLTOACTION)}</p>
-                </div>
+                <p>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CALLTOACTION)}</p>
+            </div>
             <div className="cl-modal_footer cl-modal-buttons">
                 <div className="cl-modal-buttons_secondary"></div>
                 <div className="cl-modal-buttons_primary">

--- a/src/components/modals/ExtractConflictModal.tsx
+++ b/src/components/modals/ExtractConflictModal.tsx
@@ -4,11 +4,13 @@
  */
 import * as React from 'react'
 import * as OF from 'office-ui-fabric-react'
+import { Modal } from 'office-ui-fabric-react/lib/Modal'
 import { FM } from '../../react-intl-messages'
 import * as CLM from '@conversationlearner/models'
 import * as ExtractorResponseEditor from '../ExtractorResponseEditor'
 import { formatMessageId } from '../../Utils/util'
 import { injectIntl, InjectedIntlProps } from 'react-intl'
+import './ExtractConflictModal.css'
 
 // Renaming from Props because of https://github.com/Microsoft/tslint-microsoft-contrib/issues/339
 interface ReceivedProps {
@@ -16,6 +18,7 @@ interface ReceivedProps {
     onAccept: Function
     open: boolean
     entities: CLM.EntityBase[]
+    attemptedExtractResponse: CLM.ExtractResponse
     extractResponse: CLM.ExtractResponse
     message?: () => React.ReactNode
 }
@@ -25,59 +28,73 @@ type Props = ReceivedProps & InjectedIntlProps
 const ExtractConflictModal: React.SFC<Props> = (props) => {
     const { intl } = props
     return (
-        <OF.Dialog
-            hidden={!props.open}
+        <Modal
+            isOpen={props.open}
             className={OF.FontClassNames.mediumPlus}
+            containerClassName="cl-modal cl-modal--small"
             onDismiss={() => props.onClose()}
-            dialogContentProps={{
-                type: OF.DialogType.normal,
-                title: formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_TITLE)
-            }}
-            getStyles={() => {
-                return {
-                    main: [{
-                        selectors: {
-                            ['@media (min-width: 480px)']: {
-                                maxWidth: '900px',
-                                minWidth: '800px'
-                            }
-                        }
-                    }]
-                }
-            }
-            }
-            modalProps={{
-                isBlocking: false
-            }}
         >
-            {typeof props.message === 'function' && props.message()}
-            <ExtractorResponseEditor.EditorWrapper
-                render={(editorProps, onChangeCustomEntities) =>
-                    <ExtractorResponseEditor.Editor
-                        readOnly={true}
-                        isValid={true}
-                        entities={props.entities}
-                        {...editorProps}
+            <div className={`cl-modal_header cl-text--error ${OF.FontClassNames.xLarge} `}>
+                <OF.Icon iconName="Warning" />&nbsp;{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_TITLE)}
+                {typeof props.message === 'function' && props.message()}
+            </div>
+                <div>
+                    <p>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_SUBTITLE)}</p>
+                    <div>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_REVIEW)}</div>
 
-                        onChangeCustomEntities={onChangeCustomEntities}
-                        onClickNewEntity={() => { }}
+                    <div className="cl-inconsistent-entity-modal-header cl-text--error"><OF.Icon iconName="ChromeClose" />&nbsp;{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CONFLICTING_LABELS)}</div>
+                    <ExtractorResponseEditor.EditorWrapper
+                        render={(editorProps, onChangeCustomEntities) =>
+                            <ExtractorResponseEditor.Editor
+                                readOnly={true}
+                                isValid={true}
+                                entities={props.entities}
+                                {...editorProps}
+
+                                onChangeCustomEntities={onChangeCustomEntities}
+                                onClickNewEntity={() => { }}
+                            />
+                        }
+                        entities={props.entities}
+                        extractorResponse={props.attemptedExtractResponse}
+                        onChange={() => { }}
                     />
-                }
-                entities={props.entities}
-                extractorResponse={props.extractResponse}
-                onChange={() => { }}
-            />
-            <OF.DialogFooter>
-                <OF.DefaultButton
-                    onClick={() => props.onClose()}
-                    text={formatMessageId(intl, FM.BUTTON_CLOSE)}
-                />
-                <OF.PrimaryButton
-                    onClick={() => props.onAccept()}
-                    text={formatMessageId(intl, FM.BUTTON_ACCEPT)}
-                />
-            </OF.DialogFooter>
-        </OF.Dialog>
+
+                    <div className="cl-inconsistent-entity-modal-header cl-text--success"><OF.Icon iconName="Accept" />&nbsp;{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CORRECT_LABELS)}</div>
+                    <ExtractorResponseEditor.EditorWrapper
+                        render={(editorProps, onChangeCustomEntities) =>
+                            <ExtractorResponseEditor.Editor
+                                readOnly={true}
+                                isValid={true}
+                                entities={props.entities}
+                                {...editorProps}
+
+                                onChangeCustomEntities={onChangeCustomEntities}
+                                onClickNewEntity={() => { }}
+                            />
+                        }
+                        entities={props.entities}
+                        extractorResponse={props.extractResponse}
+                        onChange={() => { }}
+                    />
+
+                    <p>{formatMessageId(intl, FM.EXTRACTCONFLICTMODAL_CALLTOACTION)}</p>
+                </div>
+            <div className="cl-modal_footer cl-modal-buttons">
+                <div className="cl-modal-buttons_secondary"></div>
+                <div className="cl-modal-buttons_primary">
+                    <OF.PrimaryButton
+                        onClick={() => props.onAccept()}
+                        text={formatMessageId(intl, FM.BUTTON_ACCEPT)}
+                    />
+                    <OF.DefaultButton
+                        onClick={() => props.onClose()}
+                        text={formatMessageId(intl, FM.BUTTON_CLOSE)}
+                    />
+                </div>
+            </div>
+        </Modal>
     )
 }
+
 export default injectIntl(ExtractConflictModal)

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -243,6 +243,11 @@ export enum FM {
 
     // ExtractConflictModal
     EXTRACTCONFLICTMODAL_TITLE = 'ExtractConflictModal.title',
+    EXTRACTCONFLICTMODAL_SUBTITLE = 'ExtractConflictModal.subtitle',
+    EXTRACTCONFLICTMODAL_REVIEW = 'ExtractConflictModal.preview',
+    EXTRACTCONFLICTMODAL_CORRECT_LABELS = 'ExtractConflictModal.existing',
+    EXTRACTCONFLICTMODAL_CONFLICTING_LABELS = 'ExtractConflictModal.conflictingLabels',
+    EXTRACTCONFLICTMODAL_CALLTOACTION = 'ExtractConflictModal.callaction',
 
     // LogDialogModal
     LOGDIALOGMODAL_DEFAULTBUTTON_ARIADESCRIPTION = 'LogDialogModal.defaultButton.ariaDescription',
@@ -946,7 +951,12 @@ export default {
         [FM.ERROR_TOOMANYCHARACTERS]: 'Current value exceeds maximum supported length.',
 
         // ExtractConflictModal
-        [FM.EXTRACTCONFLICTMODAL_TITLE]: 'Entity is labelled differently in another user utterance',
+        [FM.EXTRACTCONFLICTMODAL_TITLE]: 'Inconsistent Entity Labels',
+        [FM.EXTRACTCONFLICTMODAL_SUBTITLE]: 'You attempted to submit an input with entities labelled differently than another input in the current or a previous train dialog. The input must be labelled consistently to ensure the bot will predict them correctly.',
+        [FM.EXTRACTCONFLICTMODAL_REVIEW]: 'Please review the labels below:',
+        [FM.EXTRACTCONFLICTMODAL_CONFLICTING_LABELS]: 'Conflicting Labels',
+        [FM.EXTRACTCONFLICTMODAL_CORRECT_LABELS]: 'Previously Submitted Labels',
+        [FM.EXTRACTCONFLICTMODAL_CALLTOACTION]: `Clicking 'Accept' will replace the conflicting labels with the previously submitted labels.`,
 
         // LogDialogModal
         [FM.LOGDIALOGMODAL_DEFAULTBUTTON_ARIADESCRIPTION]: 'Delete',

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -952,7 +952,7 @@ export default {
 
         // ExtractConflictModal
         [FM.EXTRACTCONFLICTMODAL_TITLE]: 'Inconsistent Entity Labels',
-        [FM.EXTRACTCONFLICTMODAL_SUBTITLE]: 'You attempted to submit an input with entities labelled differently than another input in the current or a previous train dialog. The input must be labelled consistently to ensure the bot will predict them correctly.',
+        [FM.EXTRACTCONFLICTMODAL_SUBTITLE]: 'You attempted to submit an input with entities labelled differently than another input in the current or a previous train dialog. Input labels must be consistent to ensure the Bot processes them correctly.',
         [FM.EXTRACTCONFLICTMODAL_REVIEW]: 'Please review the labels below:',
         [FM.EXTRACTCONFLICTMODAL_CONFLICTING_LABELS]: 'Conflicting Labels',
         [FM.EXTRACTCONFLICTMODAL_CORRECT_LABELS]: 'Previously Submitted Labels',


### PR DESCRIPTION
Adds additional information to entity label conflict modal.  Aims to improve the following

- Shows the current labels they attempted to submit which were rejected due to conflicts so they can compare it with previously submitted labels and see the problem
- Explains why the bot needs consistent labelling
- Explains what clicking Accept will do.

![image](https://user-images.githubusercontent.com/2856501/54056428-e68db780-41a4-11e9-9b19-4b07e4e99d0e.png)

Future improvements:
Out of scope for PR and I had already talked to Lars about it but I think we eventually should let the user continue even if the labels cause a conflict.  If they had labeled the input incorrectly the first time and now try to label the input correctly this time they can't and are stuck. They won't want to accept changes because they're wrong and closing the dialog does nothing.  They could either stop the dialog or accept the incorrect labels and then remember to go back and update all the incorrect labels.  Being able to continue from here is likely not easy operation either.  The service would have to implicitly update all the existing dialogs which now have conflicts to use the new labels and and still ensure they can be replayed correctly with different set of entities labeled.