### PR TITLE
fix: show correct number of log dialogs

### DIFF
--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -192,6 +192,7 @@ class Index extends React.Component<Props, ComponentState> {
 
         const trainDialogValidity = this.getTrainDialogValidity();
         const invalidBot = this.state.botValidationErrors && this.state.botValidationErrors.length > 0;
+        const filteredLogDialogs = this.props.logDialogs.filter(l => !l.targetTrainDialogIds || l.targetTrainDialogIds.length === 0)
         const TRIPLE_DIGIT_LOGDIALOG_COUNT = 99;
 
         return (
@@ -266,7 +267,7 @@ class Index extends React.Component<Props, ComponentState> {
                             </NavLink>
                             <NavLink className="cl-nav-link" data-testid="app-index-nav-link-log-dialogs" to={{ pathname: `${match.url}/logDialogs`, state: { app } }}>
                                 <OF.Icon iconName="List" /><span>Log Dialogs</span>
-                                <span className="count">{this.state.modelLoaded && ((this.props.logDialogs.length > TRIPLE_DIGIT_LOGDIALOG_COUNT) ? `${TRIPLE_DIGIT_LOGDIALOG_COUNT}+` : this.props.logDialogs.length)}</span>
+                                <span className="count">{this.state.modelLoaded && ((filteredLogDialogs.length > TRIPLE_DIGIT_LOGDIALOG_COUNT) ? `${TRIPLE_DIGIT_LOGDIALOG_COUNT}+` : filteredLogDialogs.length)}</span>
                             </NavLink>
                             <NavLink className="cl-nav-link" data-testid="app-index-nav-link-settings" to={{ pathname: `${match.url}/settings`, state: { app } }}>
                                 <OF.Icon iconName="Settings" /><span>Settings</span>

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -949,7 +949,6 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     render() {
-        const { logDialogs } = this.props
         const computedLogDialogs = this.getFilteredAndSortedDialogs()
         const editState = (this.props.editingPackageId !== this.props.app.devPackageId)
             ? EditState.INVALID_PACKAGE
@@ -996,7 +995,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                     />
                 </div>
                 {
-                    logDialogs.length === 0
+                    computedLogDialogs.length === 0
                         ? <div className="cl-page-placeholder">
                             <div className="cl-page-placeholder__content">
                                 <div className={`cl-page-placeholder__description ${OF.FontClassNames.xxLarge}`}>Create a Log Dialog</div>


### PR DESCRIPTION
On the actual log dialogs page we were excluding dialogs that had been saved as train dialogs.

The meant the count displayed would be incorrect.
There was also bug of the logic to show the empty list placeholder list using a different set of items than the actual list.

Fixes ADO#1943