### PR TITLE
chore: use const when applicable

### DIFF
--- a/src/Utils/ErrorHandler.ts
+++ b/src/Utils/ErrorHandler.ts
@@ -15,7 +15,7 @@ export class ErrorHandler {
     private static callbacks: ErrorCallback[] = [];
 
     public static registerCallbacks(callbacks: ErrorCallback[]): string {
-        let guid = CLM.ModelUtils.generateGUID();
+        const guid = CLM.ModelUtils.generateGUID();
 
         callbacks.forEach(cb => {
             cb.guid = guid;
@@ -30,7 +30,7 @@ export class ErrorHandler {
     }
 
     public static handleError(actionType: AT) {
-        let callbacks = this.callbacks.filter(cb => cb.actionType === actionType);
+        const callbacks = this.callbacks.filter(cb => cb.actionType === actionType);
         callbacks.forEach(cb => cb.callback(actionType));
     }
 }

--- a/src/Utils/RenderReplayError.tsx
+++ b/src/Utils/RenderReplayError.tsx
@@ -132,7 +132,7 @@ export function renderReplayError(replayError: CLM.ReplayError): JSX.Element {
             )
         /* Currently not used, but may when check for API changes
         case CLM.ReplayErrorType.EntityDiscrepancy:
-            let entityDiscrepancy = replayError as CLM.ReplayErrorEntityDiscrepancy;
+            const entityDiscrepancy = replayError as CLM.ReplayErrorEntityDiscrepancy;
             return (
                     <OF.TooltipHost  
                         id='myID' 

--- a/src/Utils/dialogUtils.ts
+++ b/src/Utils/dialogUtils.ts
@@ -21,7 +21,7 @@ export function getReplayError(activity: Activity | null): CLM.ReplayError | nul
     if (!activity || !activity.channelData || !activity.channelData.clData) {
         return null
     }
-    let clData: CLM.CLChannelData = activity.channelData.clData
+    const clData: CLM.CLChannelData = activity.channelData.clData
     return clData.replayError
 }
 
@@ -29,7 +29,7 @@ export function getReplayError(activity: Activity | null): CLM.ReplayError | nul
 export function internalConflict(textVariation: CLM.TextVariation, trainDialog: CLM.TrainDialog, roundIndex: number | null): CLM.ExtractResponse | null {
     for (let i = 0; i < trainDialog.rounds.length; i = i + 1) {
         if (roundIndex === null || i !== roundIndex) {
-            for (let tv of trainDialog.rounds[i].extractorStep.textVariations) {
+            for (const tv of trainDialog.rounds[i].extractorStep.textVariations) {
                 // If text is same, labels must match
                 if (textVariation.text === tv.text) {
                     if (!CLM.ModelUtils.areEqualTextVariations(textVariation, tv)) {
@@ -47,9 +47,9 @@ export function matchedActivityIndex(selectedActivity: Activity, activities: Act
         return null
     }
     else {
-        let clDataSelected: CLM.CLChannelData = selectedActivity.channelData.clData
-        let index = activities.findIndex(a => {
-            let clData: CLM.CLChannelData = a.channelData.clData
+        const clDataSelected: CLM.CLChannelData = selectedActivity.channelData.clData
+        const index = activities.findIndex(a => {
+            const clData: CLM.CLChannelData = a.channelData.clData
             return (
                 clData.senderType === clDataSelected.senderType &&
                 clData.roundIndex === clDataSelected.roundIndex &&
@@ -90,11 +90,11 @@ export function hasEndSession(trainDialog: CLM.TrainDialog, allActions: CLM.Acti
 // Return best action from ScoreResponse 
 export function getBestAction(scoreResponse: CLM.ScoreResponse, allActions: CLM.ActionBase[], canEndSession: boolean): CLM.ScoredAction | undefined {
 
-    let scoredActions = scoreResponse.scoredActions
+    const scoredActions = scoreResponse.scoredActions
 
     // Get highest scoring Action 
     let best
-    for (let test of scoredActions) {
+    for (const test of scoredActions) {
 
         const action = allActions.find(a => a.actionId === test.actionId)
         if (action) {

--- a/src/Utils/util.test.ts
+++ b/src/Utils/util.test.ts
@@ -109,13 +109,13 @@ describe('util', () => {
 
             test('if similar yet different in termination to existing actions return true', () => {
                 actionSet = [sampleAction]
-                let similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
+                const similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
                 expect(isActionUnique(similar, actionSet)).toBe(true)
             })
 
             test('if similar yet different by required entities to existing actions return true', () => {
                 actionSet = [sampleAction]
-                let similar = { ...sampleAction, requiredEntities: ["85eccbec-7d01-4aea-a704-b2fdab09cf32"] }
+                const similar = { ...sampleAction, requiredEntities: ["85eccbec-7d01-4aea-a704-b2fdab09cf32"] }
                 expect(isActionUnique(similar, actionSet)).toBe(true)
             })
 
@@ -153,13 +153,13 @@ describe('util', () => {
 
             test('if similar yet different in termination to existing actions return true', () => {
                 actionSet = [{ ...sampleAction }]
-                let similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
+                const similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
                 expect(isActionUnique(similar, actionSet)).toBe(true)
             })
 
             test('if similar yet different by required entities to existing actions return true', () => {
                 actionSet = [sampleAction]
-                let similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
+                const similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
                 expect(isActionUnique(similar, actionSet)).toBe(true)
             })
 
@@ -197,13 +197,13 @@ describe('util', () => {
 
             test('if similar yet different in termination to existing actions return true', () => {
                 actionSet = [{ ...sampleAction }]
-                let similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
+                const similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
                 expect(isActionUnique(similar, actionSet)).toEqual(true)
             })
 
             test('if similar yet different by required entities to existing actions return true', () => {
                 actionSet = [sampleAction]
-                let similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
+                const similar = { ...sampleAction, isTerminal: !sampleAction.isTerminal }
                 expect(isActionUnique(similar, actionSet)).toEqual(true)
             })
         })

--- a/src/actions/actionActions.ts
+++ b/src/actions/actionActions.ts
@@ -66,7 +66,7 @@ export const editActionThunkAsync = (appId: string, action: ActionBase) => {
         dispatch(editActionAsync(appId, action))
 
         try {
-            let deleteEditResponse = await clClient.actionsUpdate(appId, action)
+            const deleteEditResponse = await clClient.actionsUpdate(appId, action)
             dispatch(editActionFulfilled(action))
 
             // Fetch train dialogs if any train dialogs were impacted

--- a/src/actions/appActions.ts
+++ b/src/actions/appActions.ts
@@ -90,7 +90,7 @@ export const editAppLiveTagThunkAsync = (app: AppBase, tagId: string) => {
 
         try {
             await clClient.appSetLiveTag(app.appId, tagId)
-            let newApp = { ...app, livePackageId: tagId }
+            const newApp = { ...app, livePackageId: tagId }
             dispatch(editAppLiveTagFulfilled(newApp))
             return newApp
         }

--- a/src/actions/teachActions.ts
+++ b/src/actions/teachActions.ts
@@ -332,7 +332,7 @@ export const getScoresThunkAsync = (key: string, appId: string, sessionId: strin
         dispatch(getScoresAsync(key, appId, sessionId, scoreInput))
 
         try {
-            let uiScoreResponse = await clClient.teachSessionRescore(appId, sessionId, scoreInput)
+            const uiScoreResponse = await clClient.teachSessionRescore(appId, sessionId, scoreInput)
             dispatch(getScoresFulfilled(key, appId, sessionId, uiScoreResponse))
             return uiScoreResponse
         }
@@ -371,7 +371,7 @@ export const runScorerThunkAsync = (key: string, appId: string, teachId: string,
         dispatch(runScorerAsync(key, appId, teachId, uiScoreInput))
 
         try {
-            let uiScoreResponse = await clClient.teachSessionUpdateScorerStep(appId, teachId, uiScoreInput)
+            const uiScoreResponse = await clClient.teachSessionUpdateScorerStep(appId, teachId, uiScoreInput)
             dispatch(runScorerFulfilled(key, appId, teachId, uiScoreResponse))
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId))
             return uiScoreResponse
@@ -418,7 +418,7 @@ export const postScorerFeedbackThunkAsync = (key: string, appId: string, teachId
         dispatch(postScorerFeedbackAsync(key, appId, teachId, uiTrainScorerStep, waitForUser, uiScoreInput))
 
         try {
-            let uiPostScoreResponse = await clClient.teachSessionAddScorerStep(appId, teachId, uiTrainScorerStep)
+            const uiPostScoreResponse = await clClient.teachSessionAddScorerStep(appId, teachId, uiTrainScorerStep)
 
             if (!waitForUser) {
                 // Don't re-send predicted entities on subsequent score call
@@ -427,7 +427,7 @@ export const postScorerFeedbackThunkAsync = (key: string, appId: string, teachId
                 dispatch(postScorerFeedbackFulfilled(key, appId, teachId, CLM.DialogMode.Scorer, uiPostScoreResponse, uiScoreInput))
             }
             else {
-                let dialogMode = uiPostScoreResponse.isEndTask ? CLM.DialogMode.EndSession : CLM.DialogMode.Wait
+                const dialogMode = uiPostScoreResponse.isEndTask ? CLM.DialogMode.EndSession : CLM.DialogMode.Wait
                 dispatch(postScorerFeedbackFulfilled(key, appId, teachId, dialogMode, uiPostScoreResponse, null))
             }
             return uiPostScoreResponse

--- a/src/actions/trainActions.ts
+++ b/src/actions/trainActions.ts
@@ -21,7 +21,7 @@ export const createTrainDialogThunkAsync = (appId: string, trainDialog: TrainDia
         dispatch(createTrainDialogAsync(appId, trainDialog))
 
         try {
-            let createdTrainDialog = await clClient.trainDialogsCreate(appId, trainDialog)
+            const createdTrainDialog = await clClient.trainDialogsCreate(appId, trainDialog)
             dispatch(createTrainDialogFulfilled(createdTrainDialog))
             dispatch(fetchApplicationTrainingStatusThunkAsync(appId))
             return createdTrainDialog
@@ -131,7 +131,7 @@ export const scoreFromHistoryThunkAsync = (appId: string, trainDialog: TrainDial
         dispatch(scoreFromHistoryAsync(appId, trainDialog))
 
         try {
-            let uiScoreResponse = await clClient.trainDialogScoreFromHistory(appId, trainDialog)
+            const uiScoreResponse = await clClient.trainDialogScoreFromHistory(appId, trainDialog)
             dispatch(scoreFromHistoryFulfilled(uiScoreResponse))
             return uiScoreResponse
         }
@@ -167,7 +167,7 @@ export const extractFromHistoryThunkAsync = (appId: string, trainDialog: TrainDi
         dispatch(extractFromHistoryAsync(appId, trainDialog, userInput))
 
         try {
-            let extractResponse = await clClient.trainDialogExtractFromHistory(appId, trainDialog, userInput)
+            const extractResponse = await clClient.trainDialogExtractFromHistory(appId, trainDialog, userInput)
             dispatch(extractFromHistoryFulfilled(extractResponse))
             return extractResponse
         }
@@ -204,7 +204,7 @@ export const trainDialogReplayThunkAsync = (appId: string, trainDialog: TrainDia
         dispatch(trainDialogReplayAsync(appId, trainDialog))
 
         try {
-            let updatedTrainDialog = await clClient.trainDialogReplay(appId, trainDialog)
+            const updatedTrainDialog = await clClient.trainDialogReplay(appId, trainDialog)
             dispatch(trainDialogReplayFulfilled(updatedTrainDialog))
             return updatedTrainDialog
         }
@@ -240,7 +240,7 @@ export const fetchTextVariationConflictThunkAsync = (appId: string, trainDialogI
         dispatch(fetchTextVariationConflictAsync(appId, trainDialogId, textVariation))
 
         try {
-            let conflict = await clClient.fetchTextVariationConflict(appId, trainDialogId, textVariation, filteredDialogId)
+            const conflict = await clClient.fetchTextVariationConflict(appId, trainDialogId, textVariation, filteredDialogId)
             dispatch(fetchTextVariationConflictFulfilled(conflict))
             return conflict
         }

--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -27,7 +27,7 @@ interface ComponentState {
 class ActionDetailsList extends React.Component<Props, ComponentState> {
     constructor(p: any) {
         super(p);
-        let columns = getColumns(this.props.intl)
+        const columns = getColumns(this.props.intl)
         this.state = {
             columns: columns,
             sortColumn: columns[0],
@@ -69,7 +69,7 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
     }
 
     sortActions(): CLM.ActionBase[] {
-        let actions = [...this.props.actions];
+        const actions = [...this.props.actions];
         // If column header selected sort the items
         if (this.state.sortColumn) {
             actions
@@ -87,8 +87,8 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
     }
 
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
-        let { columns } = this.state;
-        let isSortedDescending = !clickedColumn.isSortedDescending;
+        const { columns } = this.state;
+        const isSortedDescending = !clickedColumn.isSortedDescending;
 
         // Reset the items and columns to match the state.
         this.setState({
@@ -122,7 +122,7 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
     }
 
     render() {
-        let sortedActions = this.sortActions();
+        const sortedActions = this.sortActions();
 
         let template: CLM.Template | undefined
         let renderedActionArguments: CLM.RenderedActionArgument[] = []
@@ -250,7 +250,7 @@ function renderConditions(entityIds: string[], conditions: CLM.Condition[], allE
         ])
     }
     
-    let elements: JSX.Element[] = []
+    const elements: JSX.Element[] = []
     entityIds.forEach(entityId => {
         const entity = allEntities.find(e => e.entityId === entityId)
         if (!entity) {

--- a/src/components/ExtractorResponseEditor/CustomEntityNode.tsx
+++ b/src/components/ExtractorResponseEditor/CustomEntityNode.tsx
@@ -33,7 +33,7 @@ export class CustomEntityContainer extends React.Component<Props, State> {
             return
         }
 
-        let isDeleteButtonOpen = !this.state.isDeleteButtonOpen
+        const isDeleteButtonOpen = !this.state.isDeleteButtonOpen
 
         this.setState({isDeleteButtonOpen})
         this.props.onDeleteButtonVisible(isDeleteButtonOpen)

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -229,7 +229,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
     // selection to pick the charater
     onSelectChar = () => {
         // Make selection
-        let selection = window.getSelection();
+        const selection = window.getSelection();
         const parentNode = selection 
             && selection.anchorNode 
             && selection.anchorNode.parentElement 
@@ -240,7 +240,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
 
             if (sibling && sibling.firstChild && sibling.firstChild.firstChild && sibling.firstChild.firstChild.firstChild) {
                 const newSelection = sibling.firstChild.firstChild.firstChild
-                let range = document.createRange();
+                const range = document.createRange();
                 range.selectNode(newSelection)
                 selection.removeAllRanges();
                 selection.addRange(range)
@@ -255,7 +255,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
         // console.log(`operationsJs: `, operationsJs.map((o:any) => o.type))
         // console.log(`disallowedOperations: `, disallowedOperations)
 
-        let ignoreOperations = [...disallowedOperations]
+        const ignoreOperations = [...disallowedOperations]
 
         // If delete button is up, disallow any new selection
         if (this.state.isDeleteButtonVisible) {
@@ -362,7 +362,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
             case NodeType.TokenNodeType: 
                 return <TokenNode {...props} />
             case NodeType.CustomEntityNodeType: 
-                let cenProps = {...props, onDeleteButtonVisible: this.onDeleteButtonVisible}
+                const cenProps = {...props, onDeleteButtonVisible: this.onDeleteButtonVisible}
                 return <CustomEntityNode {...cenProps} />
             case NodeType.PreBuiltEntityNodeType:   
                 return <PreBuiltEntityNode {...props} />
@@ -411,19 +411,19 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
     @OF.autobind
     onTestSelectWord(val: any) {
 
-        let words = val.detail.split(" ")
+        const words = val.detail.split(" ")
 
         // Get start div
-        let arr = Array.from(document.querySelectorAll(".cl-token-node"))
+        const arr = Array.from(document.querySelectorAll(".cl-token-node"))
 
-        let firstDiv = arr.filter(element => element.children[0].textContent === words[0])[0].children[0].children[0]
-        let lastDiv = arr.filter(element => element.children[0].textContent === words[words.length - 1])[0].children[0].children[0]
+        const firstDiv = arr.filter(element => element.children[0].textContent === words[0])[0].children[0].children[0]
+        const lastDiv = arr.filter(element => element.children[0].textContent === words[words.length - 1])[0].children[0].children[0]
 
-        let slateEditor = firstDiv!.parentElement!.parentElement!.parentElement!.parentElement
+        const slateEditor = firstDiv!.parentElement!.parentElement!.parentElement!.parentElement
 
         // Events are special, can't use spread or Object.keys
-        let selectEvent: any = {}
-        for (let key in val) { 
+        const selectEvent: any = {}
+        for (const key in val) { 
             if (key === 'currentTarget') {
                 
                 selectEvent['currentTarget'] = slateEditor
@@ -437,8 +437,8 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
         }
   
         // Make selection
-        let selection = window.getSelection();        
-        let range = document.createRange();
+        const selection = window.getSelection();        
+        const range = document.createRange();
 
         range.setStartBefore(firstDiv)
         range.setEndAfter(lastDiv)
@@ -479,7 +479,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
                             isOverlappingOtherEntities={this.state.isSelectionOverlappingOtherEntities}
                             isVisible={this.state.isMenuVisible}
                             options={this.props.options.filter(option => option.type === EntityType.LUIS).sort((a, b) => {
-                                let nameCompare = (x: IOption, y: IOption) => x.name > y.name ? 1 : (x.name < y.name ? -1 : 0)
+                                const nameCompare = (x: IOption, y: IOption) => x.name > y.name ? 1 : (x.name < y.name ? -1 : 0)
                                 if (a.resolverType === this.state.builtInTypeFilter) {
                                     if (b.resolverType === this.state.builtInTypeFilter) {
                                         return nameCompare(a, b)

--- a/src/components/ExtractorResponseEditor/utilities.ts
+++ b/src/components/ExtractorResponseEditor/utilities.ts
@@ -165,7 +165,7 @@ export const wrapTokensWithEntities = (tokens: IToken[], customEntitiesWithToken
     const firstCet = sortedCustomEntities[0]
     const tokenArray: TokenArray = [...tokens.slice(0, firstCet.startTokenIndex)]
 
-    for (let [i, cet] of Array.from(sortedCustomEntities.entries())) {
+    for (const [i, cet] of Array.from(sortedCustomEntities.entries())) {
         // push labeled tokens
         tokenArray.push({
             entity: cet,
@@ -211,7 +211,7 @@ export const convertToSlateNodes = (tokensWithEntities: TokenArray): any[] => {
     }
 
     // TODO: Find better way to iterate over the nested array and determine based on flow-control / property types without casting
-    for (let tokenOrEntity of tokensWithEntities) {
+    for (const tokenOrEntity of tokensWithEntities) {
         if ((tokenOrEntity as IEntityPlaceholder).entity) {
             const entityPlaceholder: IEntityPlaceholder = tokenOrEntity as any
             const nestedNodes = convertToSlateNodes(entityPlaceholder.tokens)
@@ -411,7 +411,7 @@ export const convertMatchedTextIntoMatchedOption = <T>(inputText: string, matche
     const matchedStrings = matches.reduce<models.ISegement[]>((segements, [startIndex, originalEndIndex]) => {
         // TODO: For some reason the Fuse.io library returns the end index before the last character instead of after
         // I opened issue here for explanation: https://github.com/krisk/Fuse/issues/212
-        let endIndex = originalEndIndex + 1
+        const endIndex = originalEndIndex + 1
         const segementIndexWhereEntityBelongs = segements.findIndex(seg => seg.startIndex <= startIndex && endIndex <= seg.endIndex)
         const prevSegements = segements.slice(0, segementIndexWhereEntityBelongs)
         const nextSegements = segements.slice(segementIndexWhereEntityBelongs + 1, segements.length)

--- a/src/components/ToolTips/ToolTipAPI.tsx
+++ b/src/components/ToolTips/ToolTipAPI.tsx
@@ -50,7 +50,7 @@ const apiCorrect =
     
             // CORRECT
             // Set called before APICallback has returned
-            let response = await requestpromise(options)
+            const response = await requestpromise(options)
             memoryManager.Set("RandomMessage", response.body);
         },
         render: async (logicResult: any, memoryManager: ReadOnlyClientMemoryManager, ...args: string[]) => {
@@ -80,11 +80,11 @@ const resultAsEntity =
         name: "ResultAsEntity",
         logic: async (memoryManager : ClientMemoryManager) => {
             var options = { method: 'GET', uri: 'https://jsonplaceholder.typicode.com/posts/1', json: true }
-            let response = await requestpromise(options)
+            const response = await requestpromise(options)
             memoryManager.Set("RandomMessage", response.body);
         },
         render: async (logicResult: any, memoryManager: ReadOnlyClientMemoryManager, ...args: string[]) => {
-            let value = memoryManager.Get("RandomMessage", ClientMemoryManager.AS_STRING)
+            const value = memoryManager.Get("RandomMessage", ClientMemoryManager.AS_STRING)
             return value || ""
         }
     })`;
@@ -94,7 +94,7 @@ const resultPassed =
         name: "ResultAsLogicResult",
         logic: async (memoryManager : ClientMemoryManager) => {
             var options = { method: 'GET', uri: 'https://jsonplaceholder.typicode.com/posts/1', json: true }
-            let response = await requestpromise(options)
+            const response = await requestpromise(options)
             memoryManager.Set("RandomMessage", response.body);
         },
         render: async (logicResult: any, memoryManager: ReadOnlyClientMemoryManager, ...args: string[]) => {

--- a/src/components/ToolTips/ToolTips.tsx
+++ b/src/components/ToolTips/ToolTips.tsx
@@ -82,10 +82,10 @@ export function onRenderDetailsHeader(detailsHeaderProps: OF.IDetailsHeaderProps
                     ...detailsHeaderProps,
                     onRenderColumnHeaderTooltip: (tooltipHostProps: OF.ITooltipHostProps) => {
 
-                        let id = tooltipHostProps.id ? tooltipHostProps.id.split('-')[1] : 'unknown-tip-id'
-                        let tip = getTip(id);
+                        const id = tooltipHostProps.id ? tooltipHostProps.id.split('-')[1] : 'unknown-tip-id'
+                        const tip = getTip(id);
                         if (tip) {
-                            let ttHP = {
+                            const ttHP = {
                                 ...tooltipHostProps,
                                 directionalHint: OF.DirectionalHint.topLeftEdge
                             };
@@ -131,7 +131,7 @@ export function wrap(content: JSX.Element, tooltip: string, directionalHint: OF.
     );
 }
 
-let memoryConverterSample =
+const memoryConverterSample =
     `
     AS_VALUE_LIST       returns MemoryValue[]
     AS_STRING           returns string
@@ -141,7 +141,7 @@ let memoryConverterSample =
     AS_BOOLEAN          returns boolean
     AS_BOOLEAN_LIST     returns boolean[]`
 
-let memoryManagerSample =
+const memoryManagerSample =
     `
     // GET - Values currently in bot memory
     memoryManager.Get(entityName: string, converter: (memoryValues: MemoryValue[])

--- a/src/components/Webchat.tsx
+++ b/src/components/Webchat.tsx
@@ -23,7 +23,7 @@ export function renderActivity(
     shouldRenderHighlight: boolean,
 ): JSX.Element {
 
-    let timeLine = <span> {activityProps.fromMe ? "User" : "Bot"}</span>;
+    const timeLine = <span> {activityProps.fromMe ? "User" : "Bot"}</span>;
 
     const isLogDialog = editType === EditDialogType.LOG_ORIGINAL || editType === EditDialogType.LOG_EDITED
     const who = activityProps.fromMe ? 'me' : 'bot'
@@ -33,7 +33,7 @@ export function renderActivity(
             (activityProps.activity as Message).attachmentLayout || 'list',
             activityProps.onClickActivity && 'clickable'].filter(Boolean).join(' ')
 
-    let contentClassName = 'wc-message-content'
+    const contentClassName = 'wc-message-content'
     const clData: CLM.CLChannelData | null = activityProps.activity.channelData ? activityProps.activity.channelData.clData : null
 
     let messageColor = `wc-message-color-${activityProps.fromMe ? (isLogDialog ? 'log' : 'train') : 'bot'}`
@@ -222,7 +222,7 @@ class Webchat extends React.Component<Props, {}> {
         }
 
         // TODO: This call has side-affects and should be moved to componentDidMount
-        let chatProps = this.getChatProps();
+        const chatProps = this.getChatProps();
 
         chatProps.hideInput = this.props.hideInput
         chatProps.focusInput = this.props.focusInput

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -72,9 +72,9 @@ const toConditionName = (entity: CLM.EntityBase, enumValue: CLM.EnumValue): stri
 }
 
 const convertConditionalsToTags = (conditions: CLM.Condition[], entities: CLM.EntityBase[]): IConditionalTag[] => {
-    let tags: IConditionalTag[] = []
+    const tags: IConditionalTag[] = []
     conditions.forEach(c => {
-        let entity = entities.find(e => e.entityId === c.entityId)
+        const entity = entities.find(e => e.entityId === c.entityId)
         if (!entity) {
             console.log(`ERROR: Condition refers to non-existant Entity ${c.entityId}`)
         }
@@ -82,7 +82,7 @@ const convertConditionalsToTags = (conditions: CLM.Condition[], entities: CLM.En
             console.log(`ERROR: Condition refers to Entity without Enums ${entity.entityName}`)
         }
         else {
-            let enumValue = entity.enumValues.find(e => e.enumValueId === c.valueId)
+            const enumValue = entity.enumValues.find(e => e.enumValueId === c.valueId)
             if (!enumValue) {
                 console.log(`ERROR: Condition refers to non-existant EnumValue: ${c.valueId}`)
             }
@@ -104,10 +104,10 @@ const conditionalEntityTags = (entities: CLM.EntityBase[]): IConditionalTag[] =>
     // Ignore resolvers and negative entities
     const filteredEntities = entities.filter(e => !e.doNotMemorize && !e.positiveId)
 
-    let tags: IConditionalTag[] = []
+    const tags: IConditionalTag[] = []
     filteredEntities.forEach(e => {
         if (e.entityType === CLM.EntityType.ENUM && e.enumValues) {
-            for (let enumValue of e.enumValues) {
+            for (const enumValue of e.enumValues) {
                 tags.push({
                     key: enumValue.enumValueId!,
                     name: toConditionName(e, enumValue),
@@ -155,7 +155,7 @@ const isConditionMutuallyExclusive = (tag1: OF.ITag, tag2: OF.ITag): boolean => 
 }
 
 const getSuggestedTags = (filterText: string, allTags: OF.ITag[], tagsToExclude: OF.ITag[], mutuallyExclusive: OF.ITag[] = []): OF.ITag[] => {
-    let fText = (filterText.startsWith(ActionPayloadEditor.triggerCharacter) ? filterText.substring(1) : filterText).trim()
+    const fText = (filterText.startsWith(ActionPayloadEditor.triggerCharacter) ? filterText.substring(1) : filterText).trim()
 
     let availableTags = allTags
         .filter(tag => !tagsToExclude.some(t => t.key === tag.key))
@@ -370,7 +370,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                     }
                     catch {
                         // Default to raw value
-                        let contentString: string = JSON.parse(textAction.payload).text
+                        const contentString: string = JSON.parse(textAction.payload).text
                         slateValuesMap[TEXT_SLOT] = Plain.deserialize(contentString)
                         entityWarning = true
                     }
@@ -384,12 +384,12 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                     selectedApiOptionKey = apiAction.name
                     const callback = this.props.botInfo.callbacks.find(t => t.name === selectedApiOptionKey)
                     if (callback) {
-                        for (let actionArgumentName of callback.logicArguments) {
+                        for (const actionArgumentName of callback.logicArguments) {
                             const argument = apiAction.logicArguments.find(a => a.parameter === actionArgumentName)
                             const initialValue = argument ? argument.value : ''
                             slateValuesMap[actionArgumentName] = tryCreateSlateValue(CLM.ActionTypes.API_LOCAL, actionArgumentName, initialValue, payloadOptions)
                         }
-                        for (let actionArgumentName of callback.renderArguments) {
+                        for (const actionArgumentName of callback.renderArguments) {
                             const argument = apiAction.renderArguments.find(a => a.parameter === actionArgumentName)
                             const initialValue = argument ? argument.value : ''
                             secondarySlateValuesMap[actionArgumentName] = tryCreateSlateValue(CLM.ActionTypes.API_LOCAL, actionArgumentName, initialValue, payloadOptions)
@@ -403,7 +403,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                     const template = this.props.botInfo.templates.find(t => t.name === selectedCardOptionKey)
                     if (template) {
                         // For each template variable initialize to the associated argument value or default to empty string
-                        for (let cardTemplateVariable of template.variables) {
+                        for (const cardTemplateVariable of template.variables) {
                             const argument = cardAction.arguments.find(a => a.parameter === cardTemplateVariable.key)
                             const initialValue = argument ? argument.value : ''
                             slateValuesMap[cardTemplateVariable.key] = tryCreateSlateValue(CLM.ActionTypes.CARD, cardTemplateVariable.key, initialValue, payloadOptions)
@@ -495,11 +495,11 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         const primaryEntries = Object.entries(this.state.slateValuesMap)
         const secondaryEntries = Object.entries(this.state.secondarySlateValuesMap)
 
-        let unattachedEntities: string[] = []
+        const unattachedEntities: string[] = []
         primaryEntries.forEach(([k, v]) => {
-            let text: string = v.document.text
-            let tags = text.split(/[^0-9A-Za-z$-]/).filter(t => t.startsWith("$"))
-            let entities = ActionPayloadEditor.Utilities.getAllEntitiesFromValue(v)
+            const text: string = v.document.text
+            const tags = text.split(/[^0-9A-Za-z$-]/).filter(t => t.startsWith("$"))
+            const entities = ActionPayloadEditor.Utilities.getAllEntitiesFromValue(v)
                 .map(e => `$${e.name}`)
             tags.forEach(tag => {
                 if (!entities.find(e => e === tag)) {
@@ -509,9 +509,9 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         })
 
         secondaryEntries.forEach(([k, v]) => {
-            let text: string = v.document.text
-            let tags = text.split(" ").filter(t => t.startsWith("$"))
-            let entities = ActionPayloadEditor.Utilities.getAllEntitiesFromValue(v)
+            const text: string = v.document.text
+            const tags = text.split(" ").filter(t => t.startsWith("$"))
+            const entities = ActionPayloadEditor.Utilities.getAllEntitiesFromValue(v)
                 .map(e => `$${e.name}`)
             tags.forEach(tag => {
                 if (!entities.find(e => e === tag)) {
@@ -734,8 +734,8 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     async onClickSaveCreate() {
-        let newOrEditedAction = this.convertStateToModel()
-        let validationWarnings: string[] = []
+        const newOrEditedAction = this.convertStateToModel()
+        const validationWarnings: string[] = []
 
         if (!isActionUnique(newOrEditedAction, this.props.actions)) {
             this.setState({
@@ -761,7 +761,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
             }
 
             // Note any untagged entities
-            let untaggedEntities = this.untaggedEntities()
+            const untaggedEntities = this.untaggedEntities()
             untaggedEntities.forEach(e =>
                 validationWarnings.push(`"${e}" ${formatMessageId(this.props.intl, FM.ACTIONCREATOREDITOR_CONFIRM_MISSINGLABEL_WARNING)}`)
             )
@@ -797,7 +797,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         try {
             const invalidTrainingDialogIds = await ((this.props.fetchActionDeleteValidationThunkAsync(this.props.app.appId, this.props.editingPackageId, this.props.action.actionId) as any) as Promise<string[]>)
             if (invalidTrainingDialogIds) {
-                let validationWarnings = (invalidTrainingDialogIds.length > 0)
+                const validationWarnings = (invalidTrainingDialogIds.length > 0)
                     ? [formatMessageId(this.props.intl, FM.ACTIONCREATOREDITOR_CONFIRM_EDIT_WARNING)]
                     : []
 
@@ -844,7 +844,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
             return
         }
 
-        let validationWarnings = [...this.state.validationWarnings]
+        const validationWarnings = [...this.state.validationWarnings]
         validationWarnings.pop()
         // Move to next validation warning if there is one
         if (validationWarnings.length > 0) {
@@ -889,7 +889,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
 
     onChangedActionType = (actionTypeOption: OF.IDropdownOption) => {
         const textPayload = this.state.slateValuesMap[TEXT_SLOT]
-        let isPayloadMissing = (actionTypeOption.key === CLM.ActionTypes.TEXT && textPayload && textPayload.document.text.length === 0)
+        const isPayloadMissing = (actionTypeOption.key === CLM.ActionTypes.TEXT && textPayload && textPayload.document.text.length === 0)
 
         this.setState({
             isPayloadMissing,
@@ -1024,7 +1024,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         // If we added entity to a payload which was already in the list of required entities remove it to avoid duplicates.
         const requiredEntityTags = this.state.requiredEntityTags.filter(tag => !requiredEntityTagsFromPayload.some(t => t.key === tag.key))
 
-        let isPayloadMissing = (this.state.selectedActionTypeOptionKey === CLM.ActionTypes.TEXT && value.document.text.length === 0)
+        const isPayloadMissing = (this.state.selectedActionTypeOptionKey === CLM.ActionTypes.TEXT && value.document.text.length === 0)
 
         const nextState: Partial<ComponentState> = {
             entityWarning: false,
@@ -1072,7 +1072,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         if (!this.props.action) {
             return false
         }
-        let tdString = JSON.stringify(this.props.trainDialogs)
+        const tdString = JSON.stringify(this.props.trainDialogs)
         return tdString.indexOf(this.props.action.actionId) > -1
     }
 

--- a/src/components/modals/ActionPayloadEditor/OptionalPlugin.tsx
+++ b/src/components/modals/ActionPayloadEditor/OptionalPlugin.tsx
@@ -17,7 +17,7 @@ const defaultOptions: IOptions = {
 }
 
 export default function optionalPlugin(inputOptions: Partial<IOptions> = {}) {
-    let options: IOptions = { ...defaultOptions, ...inputOptions }
+    const options: IOptions = { ...defaultOptions, ...inputOptions }
 
     return {
         onKeyDown(event: React.KeyboardEvent<HTMLInputElement>, change: any): boolean | void {

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -181,7 +181,7 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                     if (scoredBase['reason'] === CLM.ScoreReason.NotAvailable) {
                         return -100;
                     } else {
-                        let isAvailable = component.isUnscoredActionAvailable(scoredBase as CLM.UnscoredAction);
+                        const isAvailable = component.isUnscoredActionAvailable(scoredBase as CLM.UnscoredAction);
                         return isAvailable
                             ? -1
                             : -10
@@ -197,7 +197,7 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                 } else if (component.isMasked(action.actionId)) {
                     fieldContent = "Masked"
                 } else {
-                    let isAvailable = component.isUnscoredActionAvailable(action as CLM.UnscoredAction);
+                    const isAvailable = component.isUnscoredActionAvailable(action as CLM.UnscoredAction);
                     if (isAvailable) {
                         fieldContent = (component.props.dialogType !== CLM.DialogType.TEACH || component.props.historyItemSelected)
                             ? '-' : "Training...";
@@ -346,11 +346,11 @@ class ActionScorer extends React.Component<Props, ComponentState> {
     async onClickSubmitActionEditor(action: CLM.ActionBase) {
         await Util.setStateAsync(this, { actionModalOpen: false })
 
-        let newAction = await ((this.props.createActionThunkAsync(this.props.app.appId, action) as any) as Promise<CLM.ActionBase>)
+        const newAction = await ((this.props.createActionThunkAsync(this.props.app.appId, action) as any) as Promise<CLM.ActionBase>)
 
         if (newAction) {
             // See if new action is available, then take it
-            let isAvailable = this.isAvailable(newAction);
+            const isAvailable = this.isAvailable(newAction);
             if (isAvailable) {
                 this.handleActionSelection(newAction.actionId);
             }
@@ -363,7 +363,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
         })
     }
     onColumnClick(event: any, column: any) {
-        let { columns } = this.state;
+        const { columns } = this.state;
         let isSortedDescending = column.isSortedDescending;
 
         // If we've sorted this column, flip it.
@@ -393,7 +393,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
         if (scoreResponse.scoredActions && scoreResponse.scoredActions.length > 0) {
             actionId = scoreResponse.scoredActions[0].actionId;
         } else if (scoreResponse.unscoredActions) {
-            for (let unscoredAction of scoreResponse.unscoredActions) {
+            for (const unscoredAction of scoreResponse.unscoredActions) {
                 if (unscoredAction.reason === CLM.ScoreReason.NotScorable) {
                     actionId = unscoredAction.actionId;
                     break;
@@ -408,7 +408,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
         const { scoredActions, unscoredActions } = this.props.scoreResponse
         let scoredAction = scoredActions.find(a => a.actionId === actionId);
         if (!scoredAction) {
-            let unscoredAction = unscoredActions.find(a => a.actionId === actionId);
+            const unscoredAction = unscoredActions.find(a => a.actionId === actionId);
             if (unscoredAction) {
                 const { reason, ...scoredBase } = unscoredAction
                 // This is hack to create scored action without a real score
@@ -442,7 +442,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
             throw new Error(`Scored action could not be found in list of available actions`)
         }
 
-        let trainScorerStep: CLM.TrainScorerStep = {
+        const trainScorerStep: CLM.TrainScorerStep = {
             input: this.props.scoreInput,
             labelAction: actionId,
             logicResult: undefined,
@@ -454,16 +454,16 @@ class ActionScorer extends React.Component<Props, ComponentState> {
     }
 
     isConditionMet(condition: CLM.Condition): { match: boolean, name: string } {
-        let entity = this.props.entities.filter(e => e.entityId === condition.entityId)[0];
+        const entity = this.props.entities.filter(e => e.entityId === condition.entityId)[0];
 
         // If entity is null - there's a bug somewhere
         if (!entity) {
             return { match: false, name: 'ERROR' };
         }
 
-        let enumValue = entity.enumValues && entity.enumValues.find(ev => ev.enumValueId === condition.valueId)
-        let memory = this.props.memories.filter(m => m.entityName === entity.entityName)[0];
-        let match = memory !== undefined
+        const enumValue = entity.enumValues && entity.enumValues.find(ev => ev.enumValueId === condition.valueId)
+        const memory = this.props.memories.filter(m => m.entityName === entity.entityName)[0];
+        const match = memory !== undefined
             && memory.entityValues[0]
             && memory.entityValues[0].enumValueId === condition.valueId
         return { match, name: `${entity.entityName} = ${enumValue ? enumValue.enumValue : "NOT FOUND"}` };
@@ -471,28 +471,28 @@ class ActionScorer extends React.Component<Props, ComponentState> {
 
     // Check if entity is in memory and return it's name 
     entityInMemory(entityId: string): { match: boolean, name: string } {
-        let entity = this.props.entities.filter(e => e.entityId === entityId)[0];
+        const entity = this.props.entities.filter(e => e.entityId === entityId)[0];
 
         // If entity is null - there's a bug somewhere
         if (!entity) {
             return { match: false, name: 'ERROR' };
         }
 
-        let memory = this.props.memories.filter(m => m.entityName === entity.entityName)[0];
+        const memory = this.props.memories.filter(m => m.entityName === entity.entityName)[0];
         return { match: (memory !== undefined), name: entity.entityName };
     }
 
     renderEntityRequirements(actionId: string) {
-        let action = this.props.actions.filter(a => a.actionId === actionId)[0];
+        const action = this.props.actions.filter(a => a.actionId === actionId)[0];
 
         // If action is null - there's a bug somewhere
         if (!action) {
             return <div>ERROR: Missing Action</div>
         }
 
-        let items = [];
-        for (let entityId of action.requiredEntities) {
-            let found = this.entityInMemory(entityId)
+        const items = [];
+        for (const entityId of action.requiredEntities) {
+            const found = this.entityInMemory(entityId)
             items.push({
                 name: found.name,
                 neg: false,
@@ -501,8 +501,8 @@ class ActionScorer extends React.Component<Props, ComponentState> {
                     : 'cl-entity cl-entity--mismatch',
             });
         }
-        for (let entityId of action.negativeEntities) {
-            let found = this.entityInMemory(entityId)
+        for (const entityId of action.negativeEntities) {
+            const found = this.entityInMemory(entityId)
             items.push({
                 name: found.name,
                 neg: true,
@@ -512,8 +512,8 @@ class ActionScorer extends React.Component<Props, ComponentState> {
             });
         }
         if (action.requiredConditions) {
-            for (let condition of action.requiredConditions) {
-                let result = this.isConditionMet(condition)
+            for (const condition of action.requiredConditions) {
+                const result = this.isConditionMet(condition)
                 items.push({
                     name: result.name,
                     neg: false,
@@ -524,8 +524,8 @@ class ActionScorer extends React.Component<Props, ComponentState> {
             }
         }
         if (action.negativeConditions) {
-            for (let condition of action.negativeConditions) {
-                let result = this.isConditionMet(condition)
+            for (const condition of action.negativeConditions) {
+                const result = this.isConditionMet(condition)
                 items.push({
                     name: result.name,
                     neg: true,
@@ -559,7 +559,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
 
     // Returns true if ActionId is available in actions
     isActionIdAvailable(actionId: string): boolean {
-        let action = this.props.actions.find(a => a.actionId === actionId);
+        const action = this.props.actions.find(a => a.actionId === actionId);
         if (!action) {
             return false;
         }
@@ -569,29 +569,29 @@ class ActionScorer extends React.Component<Props, ComponentState> {
     // Returns true if Action is available given Entities in Memory
     isAvailable(action: CLM.ActionBase): boolean {
 
-        for (let entityId of action.requiredEntities) {
-            let found = this.entityInMemory(entityId)
+        for (const entityId of action.requiredEntities) {
+            const found = this.entityInMemory(entityId)
             if (!found.match) {
                 return false
             }
         }
-        for (let entityId of action.negativeEntities) {
-            let found = this.entityInMemory(entityId)
+        for (const entityId of action.negativeEntities) {
+            const found = this.entityInMemory(entityId)
             if (found.match) {
                 return false
             }
         }
         if (action.requiredConditions) {
-            for (let condition of action.requiredConditions) {
-                let result = this.isConditionMet(condition)
+            for (const condition of action.requiredConditions) {
+                const result = this.isConditionMet(condition)
                 if (!result.match) {
                     return false
                 }
             }
         }
         if (action.negativeConditions) {
-            for (let condition of action.negativeConditions) {
-                let result = this.isConditionMet(condition)
+            for (const condition of action.negativeConditions) {
+                const result = this.isConditionMet(condition)
                 if (result.match) {
                     return false
                 }
@@ -605,14 +605,14 @@ class ActionScorer extends React.Component<Props, ComponentState> {
             || !unscoredAction.reason
             || unscoredAction.reason === CLM.ScoreReason.NotCalculated) {
 
-            let action = this.props.actions.filter((a: CLM.ActionBase) => a.actionId === unscoredAction.actionId)[0];
+            const action = this.props.actions.filter((a: CLM.ActionBase) => a.actionId === unscoredAction.actionId)[0];
 
             // If action is null - there's a bug somewhere
             if (!action) {
                 return CLM.ScoreReason.NotAvailable;
             }
 
-            let isAvailable = this.isAvailable(action);
+            const isAvailable = this.isAvailable(action);
             return isAvailable ? CLM.ScoreReason.NotScorable : CLM.ScoreReason.NotAvailable;
         }
         return unscoredAction.reason as CLM.ScoreReason;
@@ -646,7 +646,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
         // Handle deleted actions
         else if (action.actionId === MISSING_ACTION) {
             if (column.key === 'select') {
-                let buttonText = (this.props.dialogType !== CLM.DialogType.TEACH && index === 0) ? "Selected" : "Select";
+                const buttonText = (this.props.dialogType !== CLM.DialogType.TEACH && index === 0) ? "Selected" : "Select";
                 return (
                     <OF.PrimaryButton
                         disabled={true}
@@ -688,9 +688,9 @@ class ActionScorer extends React.Component<Props, ComponentState> {
 
         // Need to reassemble to scored item has full action info and reason
         scoredItems = scoredItems.map(e => {
-            let action = this.props.actions.find(ee => ee.actionId === e.actionId);
-            let score = (e as CLM.ScoredAction).score;
-            let reason = score ? null : this.calculateReason(e as CLM.UnscoredAction);
+            const action = this.props.actions.find(ee => ee.actionId === e.actionId);
+            const score = (e as CLM.ScoredAction).score;
+            const reason = score ? null : this.calculateReason(e as CLM.UnscoredAction);
             if (action) {
                 return { ...action, reason: reason, score: score }
             }

--- a/src/components/modals/AdaptiveCardViewer/AdaptiveCardViewer.tsx
+++ b/src/components/modals/AdaptiveCardViewer/AdaptiveCardViewer.tsx
@@ -26,7 +26,7 @@ class AdaptiveCardViewer extends React.Component<Props, {}> {
         let templateString = template.body || ''
 
         // Substitute argument values
-        for (let actionArgument of this.props.actionArguments) {
+        for (const actionArgument of this.props.actionArguments) {
             if (actionArgument && actionArgument.value) {
                 templateString = templateString.replace(new RegExp(`{{${actionArgument.parameter}}}`, 'g'), actionArgument.value)
             }
@@ -37,7 +37,7 @@ class AdaptiveCardViewer extends React.Component<Props, {}> {
             templateString = templateString.replace(/{{\s*[\w\.]+\s*}}/g, '');
         } else {
             // Now replace any images that haven't been substituted with a dummy image
-            for (let templateVar of template.variables) {
+            for (const templateVar of template.variables) {
                 if (templateVar.type === 'Image') {
                     templateString = templateString.replace(new RegExp(`{{${templateVar.key}}}`, 'g'), 'https://c1.staticflickr.com/9/8287/29517736620_3184b66ec8.jpg');
                 }

--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -61,7 +61,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
     componentWillReceiveProps(nextProps: Props) {
         // Reset when opening modal
         if (this.props.open === false && nextProps.open === true) {
-            let firstValue = this.state.localeOptions[0].text
+            const firstValue = this.state.localeOptions[0].text
             this.setState({
                 appNameVal: '',
                 localeVal: firstValue,

--- a/src/components/modals/EditDialogAdmin.tsx
+++ b/src/components/modals/EditDialogAdmin.tsx
@@ -39,7 +39,7 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
     componentWillReceiveProps(newProps: Props) {
 
         if (newProps.selectedActivity && newProps.trainDialog) {
-            let clData: CLM.CLChannelData = newProps.selectedActivity.channelData.clData
+            const clData: CLM.CLChannelData = newProps.selectedActivity.channelData.clData
             // If rounds were trimmed, selectedActivity could have been in deleted rounds
 
             if (clData.roundIndex === null) {
@@ -105,7 +105,7 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
         // Generate list of textVariations that have changed
         const renderData = this.getRenderData()
         const originalTextVariations = renderData.textVariations
-        let changedTextVariations: CLM.TextVariation[] = []
+        const changedTextVariations: CLM.TextVariation[] = []
         textVariations.map(tv => {
             const found = originalTextVariations.find(otv => CLM.ModelUtils.areEqualTextVariations(tv, otv))
             if (!found) {
@@ -116,18 +116,18 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
         // Check the changed ones for conflicts
 
         // First check for internal conflics
-        for (let changedTextVariation of changedTextVariations) {
-            let extractConflict = DialogUtils.internalConflict(changedTextVariation, this.props.trainDialog, renderData.roundIndex)
+        for (const changedTextVariation of changedTextVariations) {
+            const extractConflict = DialogUtils.internalConflict(changedTextVariation, this.props.trainDialog, renderData.roundIndex)
             if (extractConflict) {
                 this.props.setTextVariationConflict(extractConflict)
                 return true
             }
         }
 
-        let dialogId = this.props.editingLogDialogId || this.props.trainDialog.trainDialogId
+        const dialogId = this.props.editingLogDialogId || this.props.trainDialog.trainDialogId
         // Next against other TrainDialogs
-        for (let changedTextVariation of changedTextVariations) {
-            let conflict = await this.props.fetchTextVariationConflictThunkAsync(
+        for (const changedTextVariation of changedTextVariations) {
+            const conflict = await this.props.fetchTextVariationConflictThunkAsync(
                 this.props.app.appId,
                 dialogId,
                 changedTextVariation,
@@ -159,11 +159,11 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
         }
 
         let memories: CLM.Memory[] = [];
-        let prevIndex = this.state.roundIndex - 1;
+        const prevIndex = this.state.roundIndex - 1;
         if (prevIndex >= 0) {
-            let round = this.props.trainDialog.rounds[prevIndex];
+            const round = this.props.trainDialog.rounds[prevIndex];
             if (round.scorerSteps.length > 0) {
-                let scorerStep = round.scorerSteps[round.scorerSteps.length - 1];
+                const scorerStep = round.scorerSteps[round.scorerSteps.length - 1];
                 memories = scorerStep.input.filledEntities.map<CLM.Memory>(fe => {
                     const entity = this.props.entities.find(e => e.entityId === fe.entityId)
                     if (!entity) {
@@ -205,8 +205,8 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
         }
 
         return filledEntities.map<CLM.Memory>((fe) => {
-            let entity = this.props.entities.find(e => e.entityId === fe.entityId);
-            let entityName = entity ? entity.entityName : 'UNKNOWN ENTITY'
+            const entity = this.props.entities.find(e => e.entityId === fe.entityId);
+            const entityName = entity ? entity.entityName : 'UNKNOWN ENTITY'
             return {
                 entityName: entityName,
                 entityValues: fe.values
@@ -253,13 +253,13 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
                         }
                     }
 
-                    let filledEntities = scorerStep.logicResult
+                    const filledEntities = scorerStep.logicResult
                         ? [...scorerStep.input.filledEntities, ...scorerStep.logicResult.changedFilledEntities]
                         : [...scorerStep.input.filledEntities]
 
                     memories = filledEntities.map<CLM.Memory>((fe) => {
-                        let entity = this.props.entities.find(e => e.entityId === fe.entityId);
-                        let entityName = entity ? entity.entityName : 'UNKNOWN ENTITY'
+                        const entity = this.props.entities.find(e => e.entityId === fe.entityId);
+                        const entityName = entity ? entity.entityName : 'UNKNOWN ENTITY'
                         return {
                             entityName: entityName,
                             entityValues: fe.values
@@ -275,7 +275,7 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
                     }
                     // Otherwise generate it
                     else {
-                        let scoredAction: CLM.ScoredAction = {
+                        const scoredAction: CLM.ScoredAction = {
                             actionId: selectedAction.actionId,
                             payload: selectedAction.payload,
                             isTerminal: selectedAction.isTerminal,
@@ -284,7 +284,7 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
                         }
 
                         // Generate list of all actions (apart from selected) for ScoreResponse as I have no scores
-                        let unscoredActions = this.props.actions
+                        const unscoredActions = this.props.actions
                             .filter(a => !selectedAction || a.actionId !== selectedAction.actionId)
                             .map<CLM.UnscoredAction>(action =>
                                 ({
@@ -308,8 +308,8 @@ class EditDialogAdmin extends React.Component<Props, ComponentState> {
                 else {
                     scorerStep = round.scorerSteps[0];
                     memories = scorerStep.input.filledEntities.map<CLM.Memory>((fe) => {
-                        let entity = this.props.entities.find(e => e.entityId === fe.entityId);
-                        let entityName = entity ? entity.entityName : 'UNKNOWN ENTITY'
+                        const entity = this.props.entities.find(e => e.entityId === fe.entityId);
+                        const entityName = entity ? entity.entityName : 'UNKNOWN ENTITY'
                         return {
                             entityName: entityName,
                             entityValues: fe.values

--- a/src/components/modals/EditDialogModal.tsx
+++ b/src/components/modals/EditDialogModal.tsx
@@ -342,7 +342,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
         if (this.props.history.length === 0) {
             return false
         }
-        for (let activity of this.props.history) {
+        for (const activity of this.props.history) {
             const clData: CLM.CLChannelData = activity.channelData.clData
             if (clData &&
                 clData.replayError &&
@@ -361,7 +361,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
 
         // Return most severe error level found
         let replayErrorLevel: CLM.ReplayErrorLevel | null = null
-        for (let h of this.props.history) {
+        for (const h of this.props.history) {
             const clData: CLM.CLChannelData = h.channelData.clData
             if (clData && clData.replayError) {
                 if (clData.replayError.errorLevel === CLM.ReplayErrorLevel.BLOCKING) {
@@ -583,7 +583,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
 
     trainDialogValidity(): CLM.Validity | undefined {
         // Look for individual replay errors
-        let replayErrorLevel = this.replayErrorLevel()
+        const replayErrorLevel = this.replayErrorLevel()
         if (replayErrorLevel) {
             if (replayErrorLevel === CLM.ReplayErrorLevel.BLOCKING || replayErrorLevel === CLM.ReplayErrorLevel.ERROR) {
                 return CLM.Validity.INVALID
@@ -819,7 +819,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
         }
 
         // No Activity selected, but Replay error on an Activity
-        let replayErrorLevel = this.replayErrorLevel()
+        const replayErrorLevel = this.replayErrorLevel()
         if (this.replayErrorLevel()) {
             if (replayErrorLevel === CLM.ReplayErrorLevel.WARNING) {
                 // Only show activity based warning if no trainDialog level warning

--- a/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
@@ -166,9 +166,9 @@ class Container extends React.Component<Props, ComponentState> {
             } else {
                 this.entityOptions = [...this.staticEntityOptions, ...localePreBuiltOptions]
                 this.resolverOptions = [...this.staticResolverOptions, ...localePreBuiltOptions]
-                let entityType = nextProps.entity.entityType
-                let isPrebuilt = CLM.isPrebuilt(nextProps.entity)
-                let resolverType = nextProps.entity.resolverType === null ? this.NONE_RESOLVER : nextProps.entity.resolverType
+                const entityType = nextProps.entity.entityType
+                const isPrebuilt = CLM.isPrebuilt(nextProps.entity)
+                const resolverType = nextProps.entity.resolverType === null ? this.NONE_RESOLVER : nextProps.entity.resolverType
 
                 this.setState({
                     entityNameVal: nextProps.entity.entityName,
@@ -209,8 +209,8 @@ class Container extends React.Component<Props, ComponentState> {
         const isResolverChanged = entity.entityType === CLM.EntityType.LUIS && this.state.entityResolverVal !== entity.resolverType
         let hasPendingEnumChanges = false
         if (entity.entityType === CLM.EntityType.ENUM) {
-            let newEnums = this.state.enumValues.filter(v => v !== null) as CLM.EnumValue[]
-            let oldEnums = entity.enumValues || [] 
+            const newEnums = this.state.enumValues.filter(v => v !== null) as CLM.EnumValue[]
+            const oldEnums = entity.enumValues || [] 
             hasPendingEnumChanges = !this.areEnumsIdentical(newEnums, oldEnums)
         }
         const hasPendingChanges = isNameChanged || isMultiValueChanged || isNegatableChanged || isResolverChanged || hasPendingEnumChanges
@@ -226,7 +226,7 @@ class Container extends React.Component<Props, ComponentState> {
         // If any new enums, or old ones changed or deleted
         return newEnums.every(ev => ev.enumValueId !== undefined) &&
             oldEnums.every(oldEnum => {
-            let newEnum = newEnums.find(ne => ne.enumValueId === oldEnum.enumValueId)
+            const newEnum = newEnums.find(ne => ne.enumValueId === oldEnum.enumValueId)
             return (newEnum !== undefined && newEnum.enumValue === oldEnum.enumValue)
         })
     }
@@ -235,14 +235,14 @@ class Container extends React.Component<Props, ComponentState> {
         if (!this.props.entity || !this.props.entity.enumValues) {
             return undefined
         }
-        let enumEntity = this.props.entity.enumValues.find(e => e && e.enumValue === value)
+        const enumEntity = this.props.entity.enumValues.find(e => e && e.enumValue === value)
         return enumEntity ? enumEntity.enumValueId : undefined
     }
 
     convertStateToEntity(state: ComponentState): CLM.EntityBase {
         let entityName = this.state.entityNameVal
-        let entityType = this.state.entityTypeVal
-        let resolverType = this.state.entityResolverVal
+        const entityType = this.state.entityTypeVal
+        const resolverType = this.state.entityResolverVal
         if (this.state.isPrebuilt) {
             entityName = getPrebuiltEntityName(entityType)
         }
@@ -284,7 +284,7 @@ class Container extends React.Component<Props, ComponentState> {
     async onClickSaveCreate() {
         const newOrEditedEntity = this.convertStateToEntity(this.state)
 
-        let needPrebuildWarning = this.newPrebuilt(newOrEditedEntity)
+        const needPrebuildWarning = this.newPrebuilt(newOrEditedEntity)
         let needValidationWarning = false
 
         // If editing check for validation errors
@@ -374,9 +374,9 @@ class Container extends React.Component<Props, ComponentState> {
     }
 
     onChangedEnum = (index: number, value: string) => {
-        let enumValuesObjs = [...this.state.enumValues]
+        const enumValuesObjs = [...this.state.enumValues]
         const newValue = value.toUpperCase().trim()
-        let enumValueObj = enumValuesObjs[index]
+        const enumValueObj = enumValuesObjs[index]
 
         if (newValue.length > 0) {    
             // Create new EnumValue if needed 
@@ -431,7 +431,7 @@ class Container extends React.Component<Props, ComponentState> {
 
         // Check that name isn't in use
         if (!this.state.isEditing) {
-            let foundEntity = this.props.entities.find(e => e.entityName === this.state.entityNameVal);
+            const foundEntity = this.props.entities.find(e => e.entityName === this.state.entityNameVal);
             if (foundEntity) {
                 if (CLM.isPrebuilt(foundEntity)
                     && typeof foundEntity.doNotMemorize !== 'undefined'
@@ -629,8 +629,8 @@ class Container extends React.Component<Props, ComponentState> {
         // Check resolvers
         if (newOrEditedEntity.resolverType && newOrEditedEntity.resolverType !== "none") {
 
-            let resolverType = newOrEditedEntity.resolverType
-            let existingBuiltIn = this.props.entities.find(e =>
+            const resolverType = newOrEditedEntity.resolverType
+            const existingBuiltIn = this.props.entities.find(e =>
                 e.resolverType === resolverType ||
                 e.entityType === resolverType)
 
@@ -643,7 +643,7 @@ class Container extends React.Component<Props, ComponentState> {
         if (this.state.isPrebuilt) {
 
             // If a prebuilt - entity name is prebuilt name
-            let existingBuiltIn = this.props.entities.find(e =>
+            const existingBuiltIn = this.props.entities.find(e =>
                 e.resolverType === newOrEditedEntity.entityType ||
                 e.entityType === newOrEditedEntity.entityType)
 
@@ -680,11 +680,11 @@ class Container extends React.Component<Props, ComponentState> {
     isSaveDisabled() {
         if (this.state.entityTypeVal === CLM.EntityType.ENUM) {
             // Enum must have at least 2 values
-            let values = this.state.enumValues.filter(v => v)
+            const values = this.state.enumValues.filter(v => v)
             if (values.length < 2) {
                 return true
             }
-            let invalid = this.state.enumValues.filter(v => v && (this.onGetEnumErrorMessage(v) || this.isEnumDuplicate(v.enumValue)))
+            const invalid = this.state.enumValues.filter(v => v && (this.onGetEnumErrorMessage(v) || this.isEnumDuplicate(v.enumValue)))
             if (invalid.length > 0) {
                 return true
             }

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -156,7 +156,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
 
     withoutPreBuilts(preditedEntities: CLM.PredictedEntity[]): CLM.PredictedEntity[] {
         return preditedEntities.filter(pe => {
-            let entity = this.props.entities.find(e => e.entityId === pe.entityId)
+            const entity = this.props.entities.find(e => e.entityId === pe.entityId)
             if (entity) {
                 return !entity.doNotMemorize
             }
@@ -167,8 +167,8 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
     // Returns true if predicted entities match
     isValid(primaryResponse: CLM.ExtractResponse, extractResponse: CLM.ExtractResponse): boolean {
         // Ignore prebuilts that aren't resolvers
-        let primaryEntities = this.withoutPreBuilts(primaryResponse.predictedEntities)
-        let extractEntities = this.withoutPreBuilts(extractResponse.predictedEntities)
+        const primaryEntities = this.withoutPreBuilts(primaryResponse.predictedEntities)
+        const extractEntities = this.withoutPreBuilts(extractResponse.predictedEntities)
 
         let missing = primaryEntities.filter(item =>
             !extractEntities.find(er => item.entityId === er.entityId));
@@ -271,13 +271,13 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
     onRemoveExtractResponse(extractResponse: CLM.ExtractResponse): void {
 
         // First look for match in extract responses
-        let foundResponse = this.props.extractResponses.find(e => e.text === extractResponse.text);
+        const foundResponse = this.props.extractResponses.find(e => e.text === extractResponse.text);
         if (foundResponse) {
             this.props.removeExtractResponse(foundResponse);
             this.setState({ isPendingSubmit: true });
         } else {
             // Otherwise change is in text variation
-            let newVariations = this.state.newTextVariations
+            const newVariations = this.state.newTextVariations
                 .filter(v => v.text !== extractResponse.text);
             this.setState({
                 newTextVariations: newVariations,
@@ -293,19 +293,19 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
     @OF.autobind
     async onUpdateExtractResponse(extractResponse: CLM.ExtractResponse): Promise<void> {
         // First look for match in extract responses
-        let foundResponse = this.props.extractResponses.find(e => e.text === extractResponse.text)
+        const foundResponse = this.props.extractResponses.find(e => e.text === extractResponse.text)
         if (foundResponse) {
             await this.props.updateExtractResponse(extractResponse)
             await setStateAsync(this, { isPendingSubmit: true })
         } else {
             // Replace existing text variation (if any) with new one and maintain ordering
-            let index = this.state.newTextVariations.findIndex((v: CLM.TextVariation) => v.text === extractResponse.text)
+            const index = this.state.newTextVariations.findIndex((v: CLM.TextVariation) => v.text === extractResponse.text)
             if (index < 0) {
                 // Should never happen, but protect just in case
                 return
             }
-            let newVariation = CLM.ModelUtils.ToTextVariation(extractResponse)
-            let newVariations = [...this.state.newTextVariations]
+            const newVariation = CLM.ModelUtils.ToTextVariation(extractResponse)
+            const newVariations = [...this.state.newTextVariations]
             newVariations[index] = newVariation
             await setStateAsync(this, {
                 newTextVariations: newVariations,
@@ -334,7 +334,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     async onSubmitTextVariation() {
-        let text = this.state.textVariationValue.trim();
+        const text = this.state.textVariationValue.trim();
         if (text.length === 0) {
             return
         }

--- a/src/components/modals/ErrorPanel.tsx
+++ b/src/components/modals/ErrorPanel.tsx
@@ -92,7 +92,7 @@ class ErrorPanel extends React.Component<Props, ComponentState> {
         if (error.message) {
             try {
                 // Try to parse as JSON
-                let errorObj = JSON.parse(error.message)
+                const errorObj = JSON.parse(error.message)
                 if (errorObj.data) {
                     return JSON.stringify(errorObj.data)
                 }

--- a/src/components/modals/MemoryTable.tsx
+++ b/src/components/modals/MemoryTable.tsx
@@ -63,13 +63,13 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                         const changeClass = memoryChangeClassMap[value.changeStatus] || ''
                         let renderedValue;
 
-                        let valuesAsObject = component.valuesAsObject(value.displayText)
+                        const valuesAsObject = component.valuesAsObject(value.displayText)
                         if (valuesAsObject && value.displayText) {
                             renderedValue = <span>{value.prefix}<span className={`${changeClass} cl-font--action`} data-testid="entity-memory-value">{value.displayText.slice(0, 20)}...</span></span>
                             renderedValue = entityObject(valuesAsObject, renderedValue)
                         }
                         else {
-                            let resolutionClass = (value.memoryValue.builtinType && Object.keys(value.memoryValue.resolution).length > 0) ? 'cl-font--action' : ''
+                            const resolutionClass = (value.memoryValue.builtinType && Object.keys(value.memoryValue.resolution).length > 0) ? 'cl-font--action' : ''
                             renderedValue = <span>{value.prefix}<span className={`${changeClass} ${resolutionClass}`} data-testid="entity-memory-value">{value.displayText}</span></span>
 
                             // Decorate with resolution if it exists
@@ -112,11 +112,11 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 180,
             isResizable: true,
             getSortValue: entity => {
-                let display = entity.resolverType === undefined || entity.resolverType === null ? "none" : entity.resolverType;
+                const display = entity.resolverType === undefined || entity.resolverType === null ? "none" : entity.resolverType;
                 return display.toLowerCase();
             },
             render: entity => {
-                let display = entity.resolverType === undefined || entity.resolverType === null ? "none" : entity.resolverType
+                const display = entity.resolverType === undefined || entity.resolverType === null ? "none" : entity.resolverType
                 if (display.toLowerCase() === "none") {
                     return (
                         <OF.Icon iconName="Remove" className="cl-icon" />
@@ -169,7 +169,7 @@ class MemoryTable extends React.Component<Props, ComponentState> {
     }
 
     onColumnClick(event: any, column: IRenderableColumn) {
-        let { columns } = this.state;
+        const { columns } = this.state;
         let isSortedDescending = column.isSortedDescending
 
         // If we've sorted this column, flip it.
@@ -193,13 +193,13 @@ class MemoryTable extends React.Component<Props, ComponentState> {
     }
 
     previousMemory(entityName: string) {
-        let prevMemories = this.props.prevMemories
+        const prevMemories = this.props.prevMemories
         return prevMemories.find(m => m.entityName === entityName);
     }
 
     getMemoryChangeStatus(entityName: string): MemoryChangeStatus {
-        let curEntity = this.props.memories.find(m => m.entityName === entityName);
-        let prevEntity = this.props.prevMemories.find(m => m.entityName === entityName);
+        const curEntity = this.props.memories.find(m => m.entityName === entityName);
+        const prevEntity = this.props.prevMemories.find(m => m.entityName === entityName);
 
         // In old but not new
         if (prevEntity && !curEntity) {
@@ -220,7 +220,7 @@ class MemoryTable extends React.Component<Props, ComponentState> {
         }
 
         try {
-            let obj = JSON.parse(entityValues);
+            const obj = JSON.parse(entityValues);
             if (typeof obj !== 'number' && typeof obj !== 'boolean') {
                 return obj
             }
@@ -231,14 +231,14 @@ class MemoryTable extends React.Component<Props, ComponentState> {
     }
     getEntityValues(entity: CLM.EntityBase) {
         // Current entity values
-        let curMemory = this.props.memories.find(m => m.entityName === entity.entityName)
-        let curMemoryValues = curMemory ? curMemory.entityValues : []
-        let curValues = curMemoryValues.map(cmv => cmv.userText)
+        const curMemory = this.props.memories.find(m => m.entityName === entity.entityName)
+        const curMemoryValues = curMemory ? curMemory.entityValues : []
+        const curValues = curMemoryValues.map(cmv => cmv.userText)
 
         // Corresponding old memory values
-        let prevMemory = this.props.prevMemories.find(m => m.entityName === entity.entityName)
-        let prevMemoryValues = prevMemory ? prevMemory.entityValues : []
-        let prevValues = prevMemoryValues.map(pmv => pmv.userText)
+        const prevMemory = this.props.prevMemories.find(m => m.entityName === entity.entityName)
+        const prevMemoryValues = prevMemory ? prevMemory.entityValues : []
+        const prevValues = prevMemoryValues.map(pmv => pmv.userText)
 
         // Find union and remove duplicates
         const unionMemoryValues = [...curMemoryValues, ...prevMemoryValues.filter(pmv => !curMemoryValues.some(cmv => cmv.userText === pmv.userText))];

--- a/src/components/modals/PackageCreator.tsx
+++ b/src/components/modals/PackageCreator.tsx
@@ -72,7 +72,7 @@ class PackageCreator extends React.Component<Props, ComponentState> {
         }
 
         // Check that name isn't in use
-        let foundName = this.props.packageReferences.find(pr => pr.packageVersion === value)
+        const foundName = this.props.packageReferences.find(pr => pr.packageVersion === value)
         if (foundName) {
             return Util.formatMessageId(intl, FM.APPCREATOR_FIELDERROR_DISTINCT)
         }

--- a/src/components/modals/PackageTable.tsx
+++ b/src/components/modals/PackageTable.tsx
@@ -91,7 +91,7 @@ class PackageTable extends React.Component<Props, ComponentState> {
     }
 
     render() {
-        let packageReferences = util.packageReferences(this.props.app);
+        const packageReferences = util.packageReferences(this.props.app);
         return (
             <div>
                 <OF.PrimaryButton

--- a/src/components/modals/TeachSessionAdmin.tsx
+++ b/src/components/modals/TeachSessionAdmin.tsx
@@ -50,7 +50,7 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
         // Generate list of textVariations that have changed
         const renderData = this.getRenderData()
         const originalTextVariations = renderData.textVariations
-        let changedTextVariations: CLM.TextVariation[] = []
+        const changedTextVariations: CLM.TextVariation[] = []
         textVariations.map(tv => {
             const found = originalTextVariations.find(otv => CLM.ModelUtils.areEqualTextVariations(tv, otv))
             if (!found) {
@@ -62,8 +62,8 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
 
         // First check for internal conflicts
         if (this.props.sourceTrainDialog) {
-            for (let changedTextVariation of changedTextVariations) {
-                let extractConflict = DialogUtils.internalConflict(changedTextVariation, this.props.sourceTrainDialog, renderData.roundIndex)
+            for (const changedTextVariation of changedTextVariations) {
+                const extractConflict = DialogUtils.internalConflict(changedTextVariation, this.props.sourceTrainDialog, renderData.roundIndex)
                 if (extractConflict) {
                     this.props.setTextVariationConflict(extractConflict)
                     return true
@@ -72,8 +72,8 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
         }
 
         // Next against other TrainDialogs
-        for (let changedTextVariation of changedTextVariations) {
-            let conflict = await this.props.fetchTextVariationConflictThunkAsync(
+        for (const changedTextVariation of changedTextVariations) {
+            const conflict = await this.props.fetchTextVariationConflictThunkAsync(
                 this.props.app.appId,
                 this.props.teachSession.teach!.trainDialogId,
                 changedTextVariation,
@@ -116,9 +116,9 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
         const uiScoreResponse: CLM.UIScoreResponse = await ((this.props.runScorerThunkAsync(this.props.user.id, appId, teachId, uiScoreInput) as any) as Promise<CLM.UIScoreResponse>)
 
         if (!uiScoreResponse.extractConflict && !uiScoreResponse.botAPIError) {
-            let turnLookup = [...this.state.turnLookup]
+            const turnLookup = [...this.state.turnLookup]
             // If first turn, set offset based on existing activities
-            let turnLookupOffset = this.state.turnLookup.length === 0 ? this.props.nextActivityIndex - 1 : this.state.turnLookupOffset
+            const turnLookupOffset = this.state.turnLookup.length === 0 ? this.props.nextActivityIndex - 1 : this.state.turnLookupOffset
 
             turnLookup.push({ textVariations, memories: [...this.props.teachSession.memories] })
             turnLookup.push({ uiScoreResponse, memories: [...this.props.teachSession.memories] })
@@ -129,8 +129,8 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
             })
 
             // Replace webchat text with markdown version where labelled entities are bold
-            let excludedEntities = this.props.entities.filter(e => e.doNotMemorize).map(e => e.entityId)
-            let userText = CLM.ModelUtils.textVariationToMarkdown(textVariations[0], excludedEntities)
+            const excludedEntities = this.props.entities.filter(e => e.doNotMemorize).map(e => e.entityId)
+            const userText = CLM.ModelUtils.textVariationToMarkdown(textVariations[0], excludedEntities)
             this.props.onReplaceActivityText(userText, this.props.nextActivityIndex - 1)
 
             this.props.clearExtractResponses()
@@ -166,7 +166,7 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
 
         // Store selected action in "turn lookup"
         if (this.state.turnLookup.length > 0) {
-            let turnLookup = [...this.state.turnLookup]
+            const turnLookup = [...this.state.turnLookup]
             turnLookup[this.state.turnLookup.length - 1].selectedActionId = scoredAction.actionId
             this.setState({
                 turnLookup
@@ -195,10 +195,10 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
 
         if (!waitForUser) {
             const uiScoreResponse = await ((this.props.runScorerThunkAsync(this.props.user.id, appId, teachId, uiScoreInput) as any) as Promise<CLM.UIScoreResponse>)
-            let turnLookup = [...this.state.turnLookup]
+            const turnLookup = [...this.state.turnLookup]
 
             // Update memory on previous turn as may have been an API call
-            let lastLookup = turnLookup[turnLookup.length - 1]
+            const lastLookup = turnLookup[turnLookup.length - 1]
             lastLookup.memories = [...this.props.teachSession.memories]
 
             turnLookup.push({ uiScoreResponse, memories: [...this.props.teachSession.memories] })
@@ -230,11 +230,11 @@ class TeachSessionAdmin extends React.Component<Props, ComponentState> {
         if (this.props.selectedActivityIndex != null) {
 
             // Offset lookup index based on pre-existing activities
-            let lookupIndex = this.props.selectedActivityIndex - this.state.turnLookupOffset
+            const lookupIndex = this.props.selectedActivityIndex - this.state.turnLookupOffset
 
             if (lookupIndex >= 0) {
 
-                let turnData = this.state.turnLookup[lookupIndex]
+                const turnData = this.state.turnLookup[lookupIndex]
 
                 const prevTurn = this.state.turnLookup[lookupIndex - 1]
                 const prevMemories = (prevTurn && prevTurn.uiScoreResponse) ? prevTurn.uiScoreResponse.memories! : []

--- a/src/components/modals/TeachSessionInitState.tsx
+++ b/src/components/modals/TeachSessionInitState.tsx
@@ -41,8 +41,8 @@ class TeachSessionInitState extends React.Component<Props, ComponentState> {
     @autobind
     onClickSubmit() {
         // Remove any empty items
-        for (let entityName of Object.keys(this.state.filledEntityMap.map)) {
-            let filledEntity = this.state.filledEntityMap.map[entityName]
+        for (const entityName of Object.keys(this.state.filledEntityMap.map)) {
+            const filledEntity = this.state.filledEntityMap.map[entityName]
             filledEntity.values = filledEntity.values.filter(entityValue => entityValue.userText !== '' || entityValue.enumValueId)
             if (filledEntity.values.length === 0) {
                 delete this.state.filledEntityMap.map[entityName]
@@ -54,13 +54,13 @@ class TeachSessionInitState extends React.Component<Props, ComponentState> {
 
     @autobind
     onClickAdd(entity: CLM.EntityBase) {
-        let memoryValue: CLM.MemoryValue = {
+        const memoryValue: CLM.MemoryValue = {
             userText: '',
             displayText: null,
             builtinType: null,
             resolution: {}
         }
-        let map = this.state.filledEntityMap.map
+        const map = this.state.filledEntityMap.map
 
         if (!map[entity.entityName]) {
             map[entity.entityName] = {
@@ -76,7 +76,7 @@ class TeachSessionInitState extends React.Component<Props, ComponentState> {
 
     @autobind
     onClickRemove(index: number, entity: CLM.EntityBase) {
-        let map = this.state.filledEntityMap.map
+        const map = this.state.filledEntityMap.map
         map[entity.entityName].values.splice(index, 1)
         if (map[entity.entityName].values.length === 0) {
             delete map[entity.entityName]
@@ -129,7 +129,7 @@ class TeachSessionInitState extends React.Component<Props, ComponentState> {
                                         <OF.Label className="cl-label cl-font--emphasis" data-testid="teach-session-entity-name">{entity.entityName}</OF.Label>
                                         {this.state.filledEntityMap.map[entity.entityName] &&
                                             this.state.filledEntityMap.map[entity.entityName].values.map((memoryValue, index) => {
-                                                let key = `${entity.entityId}+${index}`
+                                                const key = `${entity.entityId}+${index}`
                                                 return (
                                                 <div key={key}>
                                                     <OF.IconButton

--- a/src/components/modals/TeachSessionModal.tsx
+++ b/src/components/modals/TeachSessionModal.tsx
@@ -346,19 +346,19 @@ class TeachModal extends React.Component<Props, ComponentState> {
             throw new Error("historyRender missing data")
         }
 
-        let clData: CLM.CLChannelData = this.state.selectedHistoryActivity.channelData.clData
-        let roundIndex = clData.roundIndex!
+        const clData: CLM.CLChannelData = this.state.selectedHistoryActivity.channelData.clData
+        const roundIndex = clData.roundIndex!
 
         if (roundIndex === null) {
             throw new Error(`Cannot get previous memories because roundIndex is null. This is likely a problem with code. Please open an issue.`)
         }
 
         let memories: CLM.Memory[] = [];
-        let prevIndex = roundIndex - 1;
+        const prevIndex = roundIndex - 1;
         if (prevIndex >= 0) {
-            let round = this.props.sourceTrainDialog.rounds[prevIndex];
+            const round = this.props.sourceTrainDialog.rounds[prevIndex];
             if (round.scorerSteps.length > 0) {
-                let scorerStep = round.scorerSteps[round.scorerSteps.length - 1];
+                const scorerStep = round.scorerSteps[round.scorerSteps.length - 1];
                 memories = scorerStep.input.filledEntities.map<CLM.Memory>(fe => {
                     const entity = this.props.entities.find(e => e.entityId === fe.entityId)
                     if (!entity) {
@@ -389,9 +389,9 @@ class TeachModal extends React.Component<Props, ComponentState> {
         }
 
         const clData: CLM.CLChannelData = this.state.selectedHistoryActivity.channelData.clData
-        let roundIndex = clData.roundIndex!
-        let scoreIndex = clData.scoreIndex
-        let senderType = clData.senderType
+        const roundIndex = clData.roundIndex!
+        const scoreIndex = clData.scoreIndex
+        const senderType = clData.senderType
 
         if (roundIndex !== null && roundIndex < this.props.sourceTrainDialog.rounds.length) {
             round = this.props.sourceTrainDialog.rounds[roundIndex];
@@ -401,7 +401,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                     throw new Error(`Cannot get score step at index: ${scoreIndex} from array of length: ${round.scorerSteps.length}`)
                 }
 
-                let actionId = scorerStep!.labelAction
+                const actionId = scorerStep!.labelAction
                 selectedAction = this.props.actions.find(action => action.actionId === actionId);
 
                 if (!selectedAction) {
@@ -425,8 +425,8 @@ class TeachModal extends React.Component<Props, ComponentState> {
                 }
 
                 memories = scorerStep.input.filledEntities.map<CLM.Memory>((fe) => {
-                    let entity = this.props.entities.find(e => e.entityId === fe.entityId);
-                    let entityName = entity ? entity.entityName : 'UNKNOWN ENTITY'
+                    const entity = this.props.entities.find(e => e.entityId === fe.entityId);
+                    const entityName = entity ? entity.entityName : 'UNKNOWN ENTITY'
                     return {
                         entityName: entityName,
                         entityValues: fe.values
@@ -436,7 +436,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                 // Get prevmemories
                 prevMemories = this.getPrevMemories();
 
-                let scoredAction: CLM.ScoredAction = {
+                const scoredAction: CLM.ScoredAction = {
                     actionId: selectedAction.actionId,
                     payload: selectedAction.payload,
                     isTerminal: selectedAction.isTerminal,
@@ -445,7 +445,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                 }
 
                 // Generate list of all actions (apart from selected) for ScoreResponse as I have no scores
-                let unscoredActions = this.props.actions
+                const unscoredActions = this.props.actions
                     .filter(a => !selectedAction || a.actionId !== selectedAction.actionId)
                     .map<CLM.UnscoredAction>(action =>
                         ({
@@ -734,7 +734,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
 
     renderWarning() {
 
-        let replayError = DialogUtils.getReplayError(this.state.selectedHistoryActivity)
+        const replayError = DialogUtils.getReplayError(this.state.selectedHistoryActivity)
         if (replayError) {
             return renderReplayError(replayError)
         }
@@ -759,8 +759,8 @@ class TeachModal extends React.Component<Props, ComponentState> {
         // Put mask of webchat if waiting for score selector or extraction labelling
         const waitingForScore = this.state.selectedActivityIndex === null && this.props.teachSession.dialogMode === CLM.DialogMode.Scorer
         const waitingForExtract = this.props.teachSession.dialogMode === CLM.DialogMode.Extractor
-        let chatDisable = (waitingForScore || waitingForExtract) ? <div className="cl-overlay" /> : null;
-        let saveDisable = this.props.teachSession.dialogMode === CLM.DialogMode.Extractor
+        const chatDisable = (waitingForScore || waitingForExtract) ? <div className="cl-overlay" /> : null;
+        const saveDisable = this.props.teachSession.dialogMode === CLM.DialogMode.Extractor
             || this.props.teachSession.botAPIError !== null
             || this.state.isInitAvailable  // Empty TD
         const isLastActivitySelected = this.state.selectedActivityIndex ? this.state.selectedActivityIndex === (this.state.nextActivityIndex - 1) : false

--- a/src/components/modals/TutorialImporter.tsx
+++ b/src/components/modals/TutorialImporter.tsx
@@ -27,7 +27,7 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 80,
             isResizable: true,
             render: (tutorial, component) => {
-                let disabled = component.props.apps.filter(a => a.appName === tutorial.appName).length > 0;
+                const disabled = component.props.apps.filter(a => a.appName === tutorial.appName).length > 0;
                 return (
                     <OF.PrimaryButton
                         disabled={disabled}
@@ -106,7 +106,7 @@ class TutorialImporter extends React.Component<Props, ComponentState> {
 
     sortTutorials(): AppBase[] {
         if (this.props.tutorials) {
-            let tutorials = [...this.props.tutorials];
+            const tutorials = [...this.props.tutorials];
             tutorials
                 .sort((a, b) => {
                     return a.appName.localeCompare(b.appName)

--- a/src/reducers/displayReducer.ts
+++ b/src/reducers/displayReducer.ts
@@ -16,7 +16,7 @@ const initialState: DisplayState = {
 };
 
 const spinnerName = (spinner: string): string => {
-    let cut = spinner.lastIndexOf("_");
+    const cut = spinner.lastIndexOf("_");
     return spinner.slice(0, cut);
 }
 

--- a/src/reducers/logDialogsReducer.ts
+++ b/src/reducers/logDialogsReducer.ts
@@ -27,7 +27,7 @@ const logDialogsReducer: Reducer<LogDialogState> = produce((state: LogDialogStat
             // TODO: Refactor to different action instead of using null
             if (action.sourceLogDialogId) {
                 // Update log dialog this train dialog was created from
-                let source = state.filter(d => d.logDialogId === action.sourceLogDialogId);
+                const source = state.filter(d => d.logDialogId === action.sourceLogDialogId);
                 if (source[0]) {
                     source[0].targetTrainDialogIds = [action.trainDialogId]
                 }

--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -79,11 +79,11 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 180,
             isResizable: true,
             getSortValue: entity => {
-                let display = entity.resolverType === undefined || entity.resolverType === null ? "none" : entity.resolverType;
+                const display = entity.resolverType === undefined || entity.resolverType === null ? "none" : entity.resolverType;
                 return display.toLowerCase();
             },
             render: entity => {
-                let display = entity.resolverType === undefined || entity.resolverType === null ? "none" : entity.resolverType
+                const display = entity.resolverType === undefined || entity.resolverType === null ? "none" : entity.resolverType
                 if (display.toLowerCase() === "none") {
                     return (
                         <OF.Icon iconName="Remove" className="cl-icon" />
@@ -150,7 +150,7 @@ class Entities extends React.Component<Props, ComponentState> {
 
     constructor(props: Props) {
         super(props)
-        let columns = getColumns(this.props.intl);
+        const columns = getColumns(this.props.intl);
         this.state = {
             searchValue: '',
             createEditModalOpen: false,
@@ -204,8 +204,8 @@ class Entities extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
-        let { columns } = this.state;
-        let isSortedDescending = !clickedColumn.isSortedDescending;
+        const { columns } = this.state;
+        const isSortedDescending = !clickedColumn.isSortedDescending;
 
         // Reset the items and columns to match the state.
         this.setState({
@@ -221,11 +221,11 @@ class Entities extends React.Component<Props, ComponentState> {
     @OF.autobind
     getFilteredAndSortedEntities(): EntityBase[] {
         //runs when user changes the text or sort
-        let lcString = this.state.searchValue.toLowerCase();
-        let filteredEntities = this.props.entities.filter(e => {
-            let nameMatch = e.entityName.toLowerCase().includes(lcString);
-            let typeMatch = e.entityType.toLowerCase().includes(lcString);
-            let match = nameMatch || typeMatch
+        const lcString = this.state.searchValue.toLowerCase();
+        const filteredEntities = this.props.entities.filter(e => {
+            const nameMatch = e.entityName.toLowerCase().includes(lcString);
+            const typeMatch = e.entityType.toLowerCase().includes(lcString);
+            const match = nameMatch || typeMatch
             return match && !e.positiveId && !e.doNotMemorize;
         })
 
@@ -250,7 +250,7 @@ class Entities extends React.Component<Props, ComponentState> {
     @OF.autobind
     onChange(newValue: string) {
         // runs when user changes the text 
-        let lcString = newValue.toLowerCase();
+        const lcString = newValue.toLowerCase();
         this.setState({
             searchValue: lcString
         })

--- a/src/routes/Apps/App/Index.tsx
+++ b/src/routes/Apps/App/Index.tsx
@@ -49,11 +49,11 @@ class Index extends React.Component<Props, ComponentState> {
     async loadApp(app: CLM.AppBase, packageId: string): Promise<void> {
         this.setState({ packageId })
 
-        let thunk1 = await this.props.fetchBotInfoThunkAsync(this.props.browserId, app.appId)
-        let thunk2 = this.props.setCurrentAppThunkAsync(this.props.user.id, app)
+        const thunk1 = await this.props.fetchBotInfoThunkAsync(this.props.browserId, app.appId)
+        const thunk2 = this.props.setCurrentAppThunkAsync(this.props.user.id, app)
         // Note: We load log dialogs in a separate call as eventually we want to page
-        let thunk3 = this.props.fetchAllLogDialogsThunkAsync(app, packageId)
-        let thunk4 = this.props.fetchAppSourceThunkAsync(app.appId, packageId)
+        const thunk3 = this.props.fetchAllLogDialogsThunkAsync(app, packageId)
+        const thunk4 = this.props.fetchAppSourceThunkAsync(app.appId, packageId)
 
         await Promise.all([thunk1, thunk2, thunk3, thunk4])
         this.setState({ modelLoaded: true })
@@ -94,7 +94,7 @@ class Index extends React.Component<Props, ComponentState> {
         }
 
         if ((newProps.actions !== this.props.actions || newProps.botInfo !== this.props.botInfo) && newProps.botInfo) {
-            let botValidationErrors = this.botValidationErrors(newProps.botInfo, newProps.actions);
+            const botValidationErrors = this.botValidationErrors(newProps.botInfo, newProps.actions);
             this.setState({ botValidationErrors });
         }
     }
@@ -153,7 +153,7 @@ class Index extends React.Component<Props, ComponentState> {
 
     getTrainDialogValidity(): CLM.Validity {
         let validity = CLM.Validity.VALID
-        for (let trainDialog of this.props.trainDialogs) {
+        for (const trainDialog of this.props.trainDialogs) {
             if (trainDialog.validity === CLM.Validity.INVALID) {
                 return CLM.Validity.INVALID
             }

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -50,7 +50,7 @@ function getTagName(logDialog: CLM.LogDialog, component: LogDialogs): string {
         tagName = 'Master'
     }
     else {
-        let packageVersion = component.props.app.packageVersions.find((pv: any) => pv.packageId === logDialog.packageId);
+        const packageVersion = component.props.app.packageVersions.find((pv: any) => pv.packageId === logDialog.packageId);
         if (packageVersion) {
             tagName = packageVersion.packageVersion;
         }
@@ -74,10 +74,10 @@ function getLastResponse(logDialog: CLM.LogDialog, component: LogDialogs): strin
     // Find last action of last scorer step of last round
     // If found, return payload, otherwise return not found icon
     if (logDialog.rounds && logDialog.rounds.length > 0) {
-        let scorerSteps = logDialog.rounds[logDialog.rounds.length - 1].scorerSteps;
+        const scorerSteps = logDialog.rounds[logDialog.rounds.length - 1].scorerSteps;
         if (scorerSteps.length > 0) {
-            let actionId = scorerSteps[scorerSteps.length - 1].predictedAction;
-            let action = component.props.actions.find(a => a.actionId === actionId);
+            const actionId = scorerSteps[scorerSteps.length - 1].predictedAction;
+            const action = component.props.actions.find(a => a.actionId === actionId);
             if (action) {
                 return CLM.ActionBase.GetPayload(action, Util.getDefaultEntityMap(component.props.entities))
             }
@@ -95,11 +95,11 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 120,
             isResizable: true,
             render: (logDialog, component) => {
-                let tagName = getTagName(logDialog, component);
+                const tagName = getTagName(logDialog, component);
                 return <span className={OF.FontClassNames.mediumPlus}>{tagName}</span>;
             },
             getSortValue: (logDialog, component) => {
-                let tagName = getTagName(logDialog, component)
+                const tagName = getTagName(logDialog, component)
                 return tagName ? tagName.toLowerCase() : ''
             }
         },
@@ -111,14 +111,14 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 300,
             isResizable: true,
             render: logDialog => {
-                let firstInput = getFirstInput(logDialog);
+                const firstInput = getFirstInput(logDialog);
                 if (firstInput) {
                     return <span className={OF.FontClassNames.mediumPlus} data-testid="log-dialogs-first-input">{firstInput}</span>;
                 }
                 return <OF.Icon iconName="Remove" className="notFoundIcon" />
             },
             getSortValue: logDialog => {
-                let firstInput = getFirstInput(logDialog)
+                const firstInput = getFirstInput(logDialog)
                 return firstInput ? firstInput.toLowerCase() : ''
             }
         },
@@ -130,14 +130,14 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 300,
             isResizable: true,
             render: logDialog => {
-                let lastInput = getLastInput(logDialog)
+                const lastInput = getLastInput(logDialog)
                 if (lastInput) {
                     return <span className={OF.FontClassNames.mediumPlus}>{lastInput}</span>;
                 }
                 return <OF.Icon iconName="Remove" className="notFoundIcon" />
             },
             getSortValue: logDialog => {
-                let lastInput = getLastInput(logDialog)
+                const lastInput = getLastInput(logDialog)
                 return lastInput ? lastInput.toLowerCase() : ''
             }
         },
@@ -149,14 +149,14 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 300,
             isResizable: true,
             render: (logDialog, component) => {
-                let lastResponse = getLastResponse(logDialog, component);
+                const lastResponse = getLastResponse(logDialog, component);
                 if (lastResponse) {
                     return <span className={OF.FontClassNames.mediumPlus}>{lastResponse}</span>;
                 }
                 return <OF.Icon iconName="Remove" className="notFoundIcon" />;
             },
             getSortValue: (logDialog, component) => {
-                let lastResponse = getLastResponse(logDialog, component)
+                const lastResponse = getLastResponse(logDialog, component)
                 return lastResponse ? lastResponse.toLowerCase() : ''
             }
         },
@@ -215,7 +215,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
 
     constructor(props: Props) {
         super(props)
-        let columns = getColumns(this.props.intl);
+        const columns = getColumns(this.props.intl);
         this.state = {
             columns: columns,
             sortColumn: columns[5],
@@ -247,7 +247,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
 
                     // If primary sort is the same do secondary sort on another column, to prevent sort jumping around
                     if (compareValue === 0) {
-                        let sortColumn2 = ((this.state.sortColumn !== this.state.columns[1]) ? this.state.columns[1] : this.state.columns[2]) as IRenderableColumn
+                        const sortColumn2 = ((this.state.sortColumn !== this.state.columns[1]) ? this.state.columns[1] : this.state.columns[2]) as IRenderableColumn
                         firstValue = sortColumn2.getSortValue(a, this)
                         secondValue = sortColumn2.getSortValue(b, this)
                         compareValue = firstValue.localeCompare(secondValue)
@@ -264,8 +264,8 @@ class LogDialogs extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
-        let { columns } = this.state;
-        let isSortedDescending = !clickedColumn.isSortedDescending;
+        const { columns } = this.state;
+        const isSortedDescending = !clickedColumn.isSortedDescending;
 
         // Reset the items and columns to match the state.
         this.setState({
@@ -293,7 +293,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         // If log dialogs have been updated, update selected logDialog too
         if (this.props.logDialogs !== newProps.logDialogs) {
             if (this.state.currentLogDialogId) {
-                let newLogDialog = newProps.logDialogs.find(t => t.logDialogId === this.state.currentLogDialogId)
+                const newLogDialog = newProps.logDialogs.find(t => t.logDialogId === this.state.currentLogDialogId)
                 this.setState({
                     currentLogDialogId: newLogDialog ? newLogDialog.logDialogId : null,
                     currentTrainDialog: newLogDialog ? CLM.ModelUtils.ToTrainDialog(newLogDialog) : null
@@ -329,7 +329,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     onChange(newValue: string) {
-        let lcString = newValue.toLowerCase();
+        const lcString = newValue.toLowerCase();
         this.setState({
             searchValue: lcString
         })
@@ -340,10 +340,10 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         this.props.clearWebchatScrollPosition()
 
         // Convert to trainDialog until schema update change, and pass in app definition too
-        let trainDialog = CLM.ModelUtils.ToTrainDialog(logDialog, this.props.actions, this.props.entities);
+        const trainDialog = CLM.ModelUtils.ToTrainDialog(logDialog, this.props.actions, this.props.entities);
 
         try {
-            let teachWithHistory = await ((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialog, this.props.user.name, this.props.user.id) as any) as Promise<CLM.TeachWithHistory>)
+            const teachWithHistory = await ((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialog, this.props.user.name, this.props.user.id) as any) as Promise<CLM.TeachWithHistory>)
 
             this.setState({
                 history: teachWithHistory.history,
@@ -382,7 +382,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         try {
             if (this.props.teachSession.teach) {
                 // Get train dialog associated with the teach session
-                let trainDialog = await ((this.props.fetchTrainDialogThunkAsync(this.props.app.appId, this.props.teachSession.teach.trainDialogId, false) as any) as Promise<CLM.TrainDialog>)
+                const trainDialog = await ((this.props.fetchTrainDialogThunkAsync(this.props.app.appId, this.props.teachSession.teach.trainDialogId, false) as any) as Promise<CLM.TrainDialog>)
                 trainDialog.definitions = {
                     entities: this.props.entities,
                     actions: this.props.actions,
@@ -393,10 +393,10 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                 await this.props.deleteTeachSessionThunkAsync(this.props.user.id, this.props.teachSession.teach, this.props.app, this.props.editingPackageId, false, null, null)
 
                 // Generate history
-                let teachWithHistory = await ((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialog, this.props.user.name, this.props.user.id) as any) as Promise<CLM.TeachWithHistory>)
+                const teachWithHistory = await ((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialog, this.props.user.name, this.props.user.id) as any) as Promise<CLM.TeachWithHistory>)
                 if (teachWithHistory) {
 
-                    let selectedActivity = teachWithHistory.history[historyIndex]
+                    const selectedActivity = teachWithHistory.history[historyIndex]
                     if (args) {
                         await editHandler(trainDialog, selectedActivity, args)
                     }
@@ -417,7 +417,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         try {
             const clData: CLM.CLChannelData = selectedActivity.channelData.clData
             const roundIndex = clData.roundIndex || 0
-            let scoreIndex = clData.scoreIndex
+            const scoreIndex = clData.scoreIndex
             const definitions = {
                 entities: this.props.entities,
                 actions: this.props.actions,
@@ -426,7 +426,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
 
             // Created shorted verion of TrainDialog at insert point
             // Copy, Remove rounds / scorer steps below insert
-            let history = JSON.parse(JSON.stringify(trainDialog))
+            const history = JSON.parse(JSON.stringify(trainDialog))
             history.definitions = definitions
             history.rounds = history.rounds.slice(0, roundIndex + 1)
 
@@ -443,7 +443,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
             }
 
             // Get a score for this step
-            let uiScoreResponse = await ((this.props.scoreFromHistoryThunkAsync(this.props.app.appId, history) as any) as Promise<CLM.UIScoreResponse>)
+            const uiScoreResponse = await ((this.props.scoreFromHistoryThunkAsync(this.props.app.appId, history) as any) as Promise<CLM.UIScoreResponse>)
 
             if (!uiScoreResponse.scoreResponse) {
                 throw new Error("Empty Score REsponse")
@@ -457,7 +457,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
 
             // None were qualified so pick the first (will show in UI as invalid)
             if (!insertedAction && uiScoreResponse.scoreResponse.unscoredActions[0]) {
-                let scoredAction = { ...uiScoreResponse.scoreResponse.unscoredActions[0], score: 1 }
+                const scoredAction = { ...uiScoreResponse.scoreResponse.unscoredActions[0], score: 1 }
                 delete scoredAction.reason
                 insertedAction = scoredAction
             }
@@ -465,16 +465,16 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                 throw new Error("No actions available")
             }
 
-            let scorerStep = {
+            const scorerStep = {
                 input: uiScoreResponse.scoreInput,
                 labelAction: insertedAction.actionId,
                 scoredAction: insertedAction
             }
 
             // Insert new Action into Full TrainDialog
-            let newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            const newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
             newTrainDialog.definitions = definitions
-            let curRound = newTrainDialog.rounds[roundIndex]
+            const curRound = newTrainDialog.rounds[roundIndex]
 
             // Replace actionless dummy step (used for rendering) if it exits
             if (curRound.scorerSteps.length === 0 || curRound.scorerSteps[0].labelAction === undefined) {
@@ -575,12 +575,12 @@ class LogDialogs extends React.Component<Props, ComponentState> {
             trainDialogs: []
         }
 
-        let curRound = newTrainDialog.rounds[roundIndex]
+        const curRound = newTrainDialog.rounds[roundIndex]
 
         if (senderType === CLM.SenderType.User) {
             // If user input deleted, append scores to previous round
             if (roundIndex > 0) {
-                let previousRound = newTrainDialog.rounds[roundIndex - 1]
+                const previousRound = newTrainDialog.rounds[roundIndex - 1]
                 previousRound.scorerSteps = [...previousRound.scorerSteps, ...curRound.scorerSteps]
 
                 // Remove actionless dummy step if it exits
@@ -649,10 +649,10 @@ class LogDialogs extends React.Component<Props, ComponentState> {
             }
 
             // Copy, Remove rounds / scorer steps below insert
-            let partialTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            const partialTrainDialog = JSON.parse(JSON.stringify(trainDialog))
             partialTrainDialog.definitions = definitions
             partialTrainDialog.rounds = partialTrainDialog.rounds.slice(0, roundIndex + 1)
-            let lastRound = partialTrainDialog.rounds[partialTrainDialog.rounds.length - 1]
+            const lastRound = partialTrainDialog.rounds[partialTrainDialog.rounds.length - 1]
             lastRound.scorerSteps = lastRound.scorerSteps.slice(0, scoreIndex)
 
             const userInput: CLM.UserInput = { text: inputText }
@@ -664,8 +664,8 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                 throw new Error("No extract response")
             }
 
-            let textVariations = CLM.ModelUtils.ToTextVariations([extractResponse])
-            let extractorStep: CLM.TrainExtractorStep = { textVariations }
+            const textVariations = CLM.ModelUtils.ToTextVariations([extractResponse])
+            const extractorStep: CLM.TrainExtractorStep = { textVariations }
 
             // Copy original and insert new round for the text
             let newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
@@ -689,7 +689,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
             }
 
             // Create new round
-            let newRound = {
+            const newRound = {
                 extractorStep,
                 scorerSteps
             }
@@ -720,7 +720,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                 await this.props.deleteTeachSessionThunkAsync(this.props.user.id, this.props.teachSession.teach, this.props.app, this.props.editingPackageId, false, null, null)
             }
 
-            let teachWithHistory = await ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, initialUserInput) as any) as Promise<CLM.TeachWithHistory>)
+            const teachWithHistory = await ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, initialUserInput) as any) as Promise<CLM.TeachWithHistory>)
 
             // Note: Don't clear currentTrainDialog so I can delete it if I save my edits
             this.setState({
@@ -744,7 +744,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         try {
             if (this.props.teachSession.teach) {
                 // Get train dialog associated with the teach session
-                let trainDialog = await ((this.props.fetchTrainDialogThunkAsync(this.props.app.appId, this.props.teachSession.teach.trainDialogId, false) as any) as Promise<CLM.TrainDialog>)
+                const trainDialog = await ((this.props.fetchTrainDialogThunkAsync(this.props.app.appId, this.props.teachSession.teach.trainDialogId, false) as any) as Promise<CLM.TrainDialog>)
                 trainDialog.definitions = {
                     entities: this.props.entities,
                     actions: this.props.actions,
@@ -806,7 +806,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     async onClickTrainDialogItem(trainDialog: CLM.TrainDialog) {
-        let trainDialogWithDefinitions: CLM.TrainDialog = {
+        const trainDialogWithDefinitions: CLM.TrainDialog = {
             ...trainDialog,
             createdDateTime: new Date().toJSON(),
             lastModifiedDateTime: new Date().toJSON(),
@@ -894,7 +894,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         if (this.props.teachSession && this.props.teachSession.teach) {
             if (save) {
                 // If source was a trainDialog, delete the original
-                let sourceTrainDialogId = this.state.currentTrainDialog && this.state.editType !== EditDialogType.BRANCH
+                const sourceTrainDialogId = this.state.currentTrainDialog && this.state.editType !== EditDialogType.BRANCH
                     ? this.state.currentTrainDialog.trainDialogId : null
                 this.props.deleteTeachSessionThunkAsync(this.props.user.id, this.props.teachSession.teach, this.props.app, this.props.editingPackageId, true, sourceTrainDialogId, this.state.currentLogDialogId)
             }
@@ -920,17 +920,17 @@ class LogDialogs extends React.Component<Props, ComponentState> {
         if (this.state.searchValue) {
             // TODO: Consider caching as not very efficient
             filteredLogDialogs = filteredLogDialogs.filter((l: CLM.LogDialog) => {
-                let keys = [];
-                for (let round of l.rounds) {
+                const keys = [];
+                for (const round of l.rounds) {
                     keys.push(round.extractorStep.text);
-                    for (let le of round.extractorStep.predictedEntities) {
+                    for (const le of round.extractorStep.predictedEntities) {
                         const entity = this.props.entities.find(e => e.entityId === le.entityId)
                         if (!entity) {
                             throw new Error(`Could not find entity by id: ${le.entityId} in list of entities`)
                         }
                         keys.push(entity.entityName)
                     }
-                    for (let ss of round.scorerSteps) {
+                    for (const ss of round.scorerSteps) {
                         const action = this.props.actions.find(a => a.actionId === ss.predictedAction)
                         if (!action) {
                             throw new Error(`Could not find action by id: ${ss.predictedAction} in list of actions`)
@@ -939,7 +939,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                         keys.push(action.payload)
                     }
                 }
-                let searchString = keys.join(' ').toLowerCase();
+                const searchString = keys.join(' ').toLowerCase();
                 return searchString.indexOf(this.state.searchValue) > -1;
             })
         }

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -88,7 +88,7 @@ class Settings extends React.Component<Props, ComponentState> {
     }
 
     componentDidUpdate() {
-        let app = this.props.app
+        const app = this.props.app
         if (this.state.edited === false && (this.state.localeVal !== app.locale ||
             this.state.appIdVal !== app.appId ||
             this.state.appNameVal !== app.appName ||
@@ -134,7 +134,7 @@ class Settings extends React.Component<Props, ComponentState> {
 
     @autobind
     onClickAddBot() {
-        let newBotApps = this.state.botFrameworkAppsVal.concat(this.state.newBotVal);
+        const newBotApps = this.state.botFrameworkAppsVal.concat(this.state.newBotVal);
         this.setState({
             botFrameworkAppsVal: newBotApps,
             newBotVal: ''
@@ -182,7 +182,7 @@ class Settings extends React.Component<Props, ComponentState> {
 
     @autobind
     onClickDiscard() {
-        let app = this.props.app
+        const app = this.props.app
         this.setState({
             localeVal: app.locale,
             appIdVal: app.appId,
@@ -198,8 +198,8 @@ class Settings extends React.Component<Props, ComponentState> {
 
     @autobind
     onClickSave() {
-        let app = this.props.app
-        let modifiedApp: AppBase = {
+        const app = this.props.app
+        const modifiedApp: AppBase = {
             ...app,
             appName: this.state.appNameVal,
             metadata: {
@@ -238,7 +238,7 @@ class Settings extends React.Component<Props, ComponentState> {
         }
 
         // Check that name isn't in use
-        let foundApp = this.props.apps.find(a => (a.appName === value && a.appId !== this.props.app.appId));
+        const foundApp = this.props.apps.find(a => (a.appName === value && a.appId !== this.props.app.appId));
         if (foundApp) {
             return Util.formatMessageId(this.props.intl, FM.SETTINGS_FIELDERROR_DISTINCT)
         }
@@ -318,7 +318,7 @@ class Settings extends React.Component<Props, ComponentState> {
     }
 
     packageOptions() {
-        let packageReferences = Util.packageReferences(this.props.app);
+        const packageReferences = Util.packageReferences(this.props.app);
 
         return Object.values(packageReferences)
             .map<OF.IDropdownOption>(pr => {
@@ -331,11 +331,11 @@ class Settings extends React.Component<Props, ComponentState> {
 
     render() {
         const { intl } = this.props
-        let options = [{
+        const options = [{
             key: this.state.localeVal,
             text: this.state.localeVal,
         }]
-        let packageOptions = this.packageOptions();
+        const packageOptions = this.packageOptions();
         return (
             <div className="cl-page">
                 <span data-testid="settings-title" className={OF.FontClassNames.xxLarge}>

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -50,14 +50,14 @@ const returnStringWhenError = (s: string) => {
 
 export function cleanTrainDialog(trainDialog: CLM.TrainDialog) {
     // Remove actionless dummy step (used for rendering) if they exist
-    for (let round of trainDialog.rounds) {
+    for (const round of trainDialog.rounds) {
         if (round.scorerSteps.length > 0 && round.scorerSteps[0].labelAction === undefined) {
             round.scorerSteps = []
         }
     }
     // Remove empty filled entities (used for rendering) if they exist
-    for (let round of trainDialog.rounds) {
-        for (let scorerStep of round.scorerSteps) {
+    for (const round of trainDialog.rounds) {
+        for (const scorerStep of round.scorerSteps) {
             scorerStep.input.filledEntities = scorerStep.input.filledEntities.filter(fe => fe.values.length > 0)
         }
     }
@@ -88,10 +88,10 @@ function getLastResponse(trainDialog: CLM.TrainDialog, component: TrainDialogs):
     // Find last action of last scorer step of last round
     // If found, return payload, otherwise return not found icon
     if (trainDialog.rounds && trainDialog.rounds.length > 0) {
-        let scorerSteps = trainDialog.rounds[trainDialog.rounds.length - 1].scorerSteps;
+        const scorerSteps = trainDialog.rounds[trainDialog.rounds.length - 1].scorerSteps;
         if (scorerSteps.length > 0) {
-            let actionId = scorerSteps[scorerSteps.length - 1].labelAction;
-            let action = component.props.actions.find(a => a.actionId === actionId);
+            const actionId = scorerSteps[scorerSteps.length - 1].labelAction;
+            const action = component.props.actions.find(a => a.actionId === actionId);
             if (action) {
                 return CLM.ActionBase.GetPayload(action, Util.getDefaultEntityMap(component.props.entities))
             }
@@ -100,7 +100,7 @@ function getLastResponse(trainDialog: CLM.TrainDialog, component: TrainDialogs):
 }
 
 function getColumns(intl: InjectedIntl): IRenderableColumn[] {
-    let equalizeColumnWidth = window.innerWidth / 3
+    const equalizeColumnWidth = window.innerWidth / 3
     return [
         {
             key: `description`,
@@ -163,7 +163,7 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 50,
             isResizable: false,
             render: trainDialog => {
-                let count = trainDialog.rounds ? trainDialog.rounds.length : 0
+                const count = trainDialog.rounds ? trainDialog.rounds.length : 0
                 return <span className={textClassName(trainDialog)} data-testid="train-dialogs-turns">{count}</span>
             },
             getSortValue: trainDialog => (trainDialog.rounds ? trainDialog.rounds.length : 0).toString().padStart(4, '0')
@@ -302,7 +302,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
                     // If primary sort is the same do secondary sort on another column, to prevent sort jumping around
                     if (compareValue === 0) {
-                        let sortColumn2 = ((this.state.sortColumn !== this.state.columns[0]) ? this.state.columns[0] : this.state.columns[1]) as IRenderableColumn
+                        const sortColumn2 = ((this.state.sortColumn !== this.state.columns[0]) ? this.state.columns[0] : this.state.columns[1]) as IRenderableColumn
                         firstValue = sortColumn2.getSortValue(a, this)
                         secondValue = sortColumn2.getSortValue(b, this)
                         compareValue = firstValue.localeCompare(secondValue)
@@ -319,8 +319,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
-        let { columns } = this.state;
-        let isSortedDescending = !clickedColumn.isSortedDescending;
+        const { columns } = this.state;
+        const isSortedDescending = !clickedColumn.isSortedDescending;
 
         // Reset the items and columns to match the state.
         this.setState({
@@ -415,7 +415,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             if (this.props.teachSession.dialogMode !== CLM.DialogMode.EndSession) {
                 if (save) {
                     // If source was a trainDialog, delete the original
-                    let sourceTrainDialogId = this.state.currentTrainDialog && this.state.editType !== EditDialogType.BRANCH
+                    const sourceTrainDialogId = this.state.currentTrainDialog && this.state.editType !== EditDialogType.BRANCH
                         ? this.state.currentTrainDialog.trainDialogId : null;
                     this.props.deleteTeachSessionThunkAsync(this.props.user.id, this.props.teachSession.teach, this.props.app, this.props.editingPackageId, true, sourceTrainDialogId, null, tags, description)
                 }
@@ -440,7 +440,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         try {
             if (this.props.teachSession.teach) {
                 // Get train dialog associated with the teach session
-                let trainDialog = await ((this.props.fetchTrainDialogThunkAsync(this.props.app.appId, this.props.teachSession.teach.trainDialogId, false) as any) as Promise<CLM.TrainDialog>)
+                const trainDialog = await ((this.props.fetchTrainDialogThunkAsync(this.props.app.appId, this.props.teachSession.teach.trainDialogId, false) as any) as Promise<CLM.TrainDialog>)
                 trainDialog.definitions = {
                     entities: this.props.entities,
                     actions: this.props.actions,
@@ -451,10 +451,10 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 await this.props.deleteTeachSessionThunkAsync(this.props.user.id, this.props.teachSession.teach, this.props.app, this.props.editingPackageId, false, null, null)
 
                 // Generate history
-                let teachWithHistory = await ((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialog, this.props.user.name, this.props.user.id) as any) as Promise<CLM.TeachWithHistory>)
+                const teachWithHistory = await ((this.props.fetchHistoryThunkAsync(this.props.app.appId, trainDialog, this.props.user.name, this.props.user.id) as any) as Promise<CLM.TeachWithHistory>)
                 if (teachWithHistory) {
 
-                    let selectedActivity = teachWithHistory.history[historyIndex]
+                    const selectedActivity = teachWithHistory.history[historyIndex]
                     const clData: CLM.CLChannelData = { ...selectedActivity.channelData.clData, activityIndex: historyIndex }
                     selectedActivity.channelData.clData = clData
                     if (args) {
@@ -477,7 +477,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         try {
             const clData: CLM.CLChannelData = selectedActivity.channelData.clData
             const roundIndex = clData.roundIndex || 0
-            let scoreIndex = clData.scoreIndex
+            const scoreIndex = clData.scoreIndex
             const definitions = {
                 entities: this.props.entities,
                 actions: this.props.actions,
@@ -486,7 +486,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
             // Created shorted verion of TrainDialog at insert point
             // Copy, Remove rounds / scorer steps below insert
-            let shortTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            const shortTrainDialog = JSON.parse(JSON.stringify(trainDialog))
             shortTrainDialog.definitions = definitions
             shortTrainDialog.rounds = shortTrainDialog.rounds.slice(0, roundIndex + 1)
 
@@ -503,7 +503,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             }
 
             // Get a score for this step
-            let uiScoreResponse = await ((this.props.scoreFromHistoryThunkAsync(this.props.app.appId, shortTrainDialog) as any) as Promise<CLM.UIScoreResponse>)
+            const uiScoreResponse = await ((this.props.scoreFromHistoryThunkAsync(this.props.app.appId, shortTrainDialog) as any) as Promise<CLM.UIScoreResponse>)
 
             if (!uiScoreResponse.scoreResponse) {
                 throw new Error("Empty Score REsponse")
@@ -517,7 +517,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
             // None were qualified so pick the first (will show in UI as invalid)
             if (!insertedAction && uiScoreResponse.scoreResponse.unscoredActions[0]) {
-                let scoredAction = { ...uiScoreResponse.scoreResponse.unscoredActions[0], score: 1 }
+                const scoredAction = { ...uiScoreResponse.scoreResponse.unscoredActions[0], score: 1 }
                 delete scoredAction.reason
                 insertedAction = scoredAction
             }
@@ -525,16 +525,16 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 throw new Error("Unable to find an action")
             }
 
-            let scorerStep = {
+            const scorerStep = {
                 input: uiScoreResponse.scoreInput,
                 labelAction: insertedAction.actionId,
                 scoredAction: insertedAction
             }
 
             // Insert new Action into Full TrainDialog
-            let newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            const newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
             newTrainDialog.definitions = definitions
-            let curRound = newTrainDialog.rounds[roundIndex]
+            const curRound = newTrainDialog.rounds[roundIndex]
 
             // Replace actionless dummy step (used for rendering) if it exits
             if (curRound.scorerSteps.length === 0 || curRound.scorerSteps[0].labelAction === undefined) {
@@ -635,12 +635,12 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             trainDialogs: []
         }
 
-        let curRound = newTrainDialog.rounds[roundIndex]
+        const curRound = newTrainDialog.rounds[roundIndex]
 
         if (senderType === CLM.SenderType.User) {
             // If user input deleted, append scores to previous round
             if (roundIndex > 0) {
-                let previousRound = newTrainDialog.rounds[roundIndex - 1]
+                const previousRound = newTrainDialog.rounds[roundIndex - 1]
                 previousRound.scorerSteps = [...previousRound.scorerSteps, ...curRound.scorerSteps]
 
                 // Remove actionless dummy step if it exits
@@ -714,11 +714,11 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 throw new Error("No extract response")
             }
 
-            let textVariations = CLM.ModelUtils.ToTextVariations([extractResponse])
-            let extractorStep: CLM.TrainExtractorStep = { textVariations }
+            const textVariations = CLM.ModelUtils.ToTextVariations([extractResponse])
+            const extractorStep: CLM.TrainExtractorStep = { textVariations }
 
             // Create new round
-            let newRound = {
+            const newRound = {
                 extractorStep,
                 scorerSteps: []
             }
@@ -759,10 +759,10 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             }
 
             // Copy, Remove rounds / scorer steps below insert
-            let partialTrainDialog: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            const partialTrainDialog: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
             partialTrainDialog.definitions = definitions
             partialTrainDialog.rounds = partialTrainDialog.rounds.slice(0, roundIndex + 1)
-            let lastRound = partialTrainDialog.rounds[partialTrainDialog.rounds.length - 1]
+            const lastRound = partialTrainDialog.rounds[partialTrainDialog.rounds.length - 1]
             lastRound.scorerSteps = lastRound.scorerSteps.slice(0, scoreIndex)
 
             const userInput: CLM.UserInput = { text: inputText }
@@ -774,8 +774,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 throw new Error("No extract response")
             }
 
-            let textVariations = CLM.ModelUtils.ToTextVariations([extractResponse])
-            let extractorStep: CLM.TrainExtractorStep = { textVariations }
+            const textVariations = CLM.ModelUtils.ToTextVariations([extractResponse])
+            const extractorStep: CLM.TrainExtractorStep = { textVariations }
 
             // Copy original and insert new round for the text
             let newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
@@ -799,7 +799,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             }
 
             // Create new round
-            let newRound = {
+            const newRound = {
                 extractorStep,
                 scorerSteps
             }
@@ -845,7 +845,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         try {
             if (this.props.teachSession.teach) {
                 // Get train dialog associated with the teach session
-                let trainDialog = await ((this.props.fetchTrainDialogThunkAsync(this.props.app.appId, this.props.teachSession.teach.trainDialogId, false) as any) as Promise<CLM.TrainDialog>)
+                const trainDialog = await ((this.props.fetchTrainDialogThunkAsync(this.props.app.appId, this.props.teachSession.teach.trainDialogId, false) as any) as Promise<CLM.TrainDialog>)
                 trainDialog.definitions = {
                     entities: this.props.entities,
                     actions: this.props.actions,
@@ -918,7 +918,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             await this.props.deleteTeachSessionThunkAsync(this.props.user.id, this.props.teachSession.teach, this.props.app, this.props.editingPackageId, false, null, null)
         }
 
-        let teachWithHistory = await ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, initialUserInput) as any) as Promise<CLM.TeachWithHistory>)
+        const teachWithHistory = await ((this.props.createTeachSessionFromHistoryThunkAsync(this.props.app, newTrainDialog, this.props.user.name, this.props.user.id, initialUserInput) as any) as Promise<CLM.TeachWithHistory>)
 
         const editType = (this.state.editType !== EditDialogType.NEW && this.state.editType !== EditDialogType.BRANCH) ?
             EditDialogType.TRAIN_EDITED : this.state.editType
@@ -985,7 +985,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
     async onClickTrainDialogItem(trainDialog: CLM.TrainDialog) {
         this.props.clearWebchatScrollPosition()
-        let trainDialogWithDefinitions: CLM.TrainDialog = {
+        const trainDialogWithDefinitions: CLM.TrainDialog = {
             ...trainDialog,
             createdDateTime: new Date().toJSON(),
             lastModifiedDateTime: new Date().toJSON(),
@@ -1047,7 +1047,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     onChangeSearchString(newValue: string) {
-        let lcString = newValue.toLowerCase();
+        const lcString = newValue.toLowerCase();
         this.setState({
             searchValue: lcString
         })
@@ -1065,10 +1065,10 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 const actionsInTD: CLM.ActionBase[] = []
                 const textVariations: string[] = []
 
-                for (let round of t.rounds) {
-                    for (let variation of round.extractorStep.textVariations) {
+                for (const round of t.rounds) {
+                    for (const variation of round.extractorStep.textVariations) {
                         textVariations.push(variation.text);
-                        for (let le of variation.labelEntities) {
+                        for (const le of variation.labelEntities) {
                             // Include pos and neg examples of entity if reversable
                             const entity = this.props.entities.find(e => e.entityId === le.entityId)
                             if (!entity) {
@@ -1083,8 +1083,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                             entitiesInTD.push(negativeEntity)
                         }
                     }
-                    for (let ss of round.scorerSteps) {
-                        let foundAction = this.props.actions.find(a => a.actionId === ss.labelAction)
+                    for (const ss of round.scorerSteps) {
+                        const foundAction = this.props.actions.find(a => a.actionId === ss.labelAction)
                         // Invalid train dialogs can contain deleted actions
                         if (!foundAction) {
                             continue

--- a/src/routes/Apps/AppsIndex.tsx
+++ b/src/routes/Apps/AppsIndex.tsx
@@ -60,8 +60,8 @@ class AppsIndex extends React.Component<Props, {}> {
     }
 
     onImportTutorial = (tutorial: AppBase) => {
-        let srcUserId = CL_IMPORT_ID;
-        let destUserId = this.props.user.id;
+        const srcUserId = CL_IMPORT_ID;
+        const destUserId = this.props.user.id;
 
         // TODO: Find cleaner solution for the types.  Thunks return functions but when using them on props they should be returning result of the promise.
         this.props.copyApplicationThunkAsync(srcUserId, destUserId, tutorial.appId)

--- a/src/routes/Apps/AppsListComponent.tsx
+++ b/src/routes/Apps/AppsListComponent.tsx
@@ -179,7 +179,7 @@ export class Component extends React.Component<Props, ComponentState> {
     }
 
     onClickColumnHeader = (event: any, column: ISortableRenderableColumn) => {
-        let { columns } = this.state;
+        const { columns } = this.state;
         this.setState({
             columns: columns.map(col => {
                 col.isSorted = false;

--- a/src/services/clientFactory.ts
+++ b/src/services/clientFactory.ts
@@ -17,7 +17,7 @@ let getClientHeaders = (): ClientHeaders => {
 }
 
 export const getInstance = (actionType: AT): ClClient => {
-    let forceError = (actionType && ErrorInjector.ShouldError(actionType));
+    const forceError = (actionType && ErrorInjector.ShouldError(actionType));
 
     /**
      * Notice we provide wrapping get functions which invoke the local functions


### PR DESCRIPTION
Similar to #1035 but covers the /src folder instead of /cypress.  Doesn't change functionality but cleans up code to use `const` when possible to prevent accidental reassignment and make it easier to read.

Would be more work to go through the remaining `let`s to see if they can be removed but the benefit isn't worth the time.