### PR TITLE
fix: ensure logDialogs reducer returns arrays

### DIFF
--- a/src/reducers/logDialogsReducer.ts
+++ b/src/reducers/logDialogsReducer.ts
@@ -12,11 +12,11 @@ const initialState: LogDialogState = [];
 const logDialogsReducer: Reducer<LogDialogState> = produce((state: LogDialogState, action: ActionObject) => {
     switch (action.type) {
         case AT.USER_LOGOUT:
-            return { ...initialState }
+            return [...initialState]
         case AT.FETCH_LOG_DIALOGS_FULFILLED:
             return action.allLogDialogs
         case AT.CREATE_APPLICATION_FULFILLED:
-            return { ...initialState }
+            return [...initialState]
         case AT.CREATE_LOG_DIALOG:
             state.push(action.logDialog)
             return


### PR DESCRIPTION
Seem to be bug introduced 11 months ago back in this PR: https://github.com/Microsoft/ConversationLearner-UI/pull/500/files#diff-518bcbb8f90efc09b8f2544ec56b56d8R10

Error was only noticed when I moved up the `filter` function which meant it could be called at a time when it's an object instead of an array. We have it typed as an array, so typescript didn't catch it, but after importing a model it would be an object instead of array. I'm still not sure why the reducer allowed you to return values that were not the same type as the expected return value