### PR TITLE
chore: add icons to buttons

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -730,8 +730,12 @@ i[data-icon-name="Delete"]:hover, i[data-icon-name="Edit"]:hover{
   margin-right: 5px;
 }
 */
-.ms-Button--primary.is-disabled, .ms-Button--primary:disabled {
+.ms-Button--primary.is-disabled,
+.ms-Button--primary:disabled {
   background-color: var(--color-neutralTertiary) !important;
+  color: var(--color-neutralSecondary) !important;
+}
+.ms-Button--primary.is-disabled .ms-Button-icon {
   color: var(--color-neutralSecondary) !important;
 }
 

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -1425,6 +1425,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                             text={this.state.isEditing ?
                                 formatMessageId(intl, FM.ACTIONCREATOREDITOR_SAVEBUTTON_TEXT) :
                                 formatMessageId(intl, FM.ACTIONCREATOREDITOR_CREATEBUTTON_TEXT)}
+                            iconProps={{ iconName: 'Accept' }}
                         />
 
                         <OF.DefaultButton
@@ -1432,6 +1433,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                             onClick={this.onClickCancel}
                             ariaDescription={formatMessageId(intl, FM.ACTIONCREATOREDITOR_CANCELBUTTON_ARIADESCRIPTION)}
                             text={formatMessageId(intl, FM.ACTIONCREATOREDITOR_CANCELBUTTON_TEXT)}
+                            iconProps={{ iconName: 'Cancel' }}
                         />
 
                         {this.state.isEditing &&
@@ -1441,6 +1443,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                 onClick={this.onClickDelete}
                                 ariaDescription={formatMessageId(intl, FM.ACTIONCREATOREDITOR_DELETEBUTTON_ARIADESCRIPTION)}
                                 text={formatMessageId(intl, FM.ACTIONCREATOREDITOR_DELETEBUTTON_TEXT)}
+                                iconProps={{ iconName: 'Delete' }}
                             />}
                     </div>
                 </div>

--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -279,6 +279,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                                     onClick={this.onClickImport}
                                     ariaDescription={Utils.formatMessageId(this.props.intl, FM.APPCREATOR_IMPORT_BUTTON_ARIADESCRIPTION)}
                                     text={Utils.formatMessageId(this.props.intl, FM.APPCREATOR_IMPORT_BUTTON_TEXT)}
+                                    iconProps={{ iconName: 'Accept' }}
                                 />
                             }
                             {this.props.creatorType === AppCreatorType.NEW &&
@@ -288,6 +289,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                                     onClick={this.onClickCreate}
                                     ariaDescription={Utils.formatMessageId(intl, FM.APPCREATOR_CREATEBUTTON_ARIADESCRIPTION)}
                                     text={Utils.formatMessageId(intl, FM.APPCREATOR_CREATEBUTTON_TEXT)}
+                                    iconProps={{ iconName: 'Accept' }}
                                 />
                             }
                             {this.props.creatorType === AppCreatorType.COPY &&
@@ -297,6 +299,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                                     onClick={this.onClickCreate}
                                     ariaDescription={Utils.formatMessageId(intl, FM.APPCREATOR_COPYBUTTON_ARIADESCRIPTION)}
                                     text={Utils.formatMessageId(intl, FM.APPCREATOR_COPYBUTTON_ARIADESCRIPTION)}
+                                    iconProps={{ iconName: 'Accept' }}
                                 />
                             }
                             <OF.DefaultButton
@@ -304,6 +307,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                                 onClick={this.onClickCancel}
                                 ariaDescription={Utils.formatMessageId(intl, FM.APPCREATOR_CANCELBUTTON_ARIADESCRIPTION)}
                                 text={Utils.formatMessageId(intl, FM.APPCREATOR_CANCELBUTTON_TEXT)}
+                                iconProps={{ iconName: 'Cancel' }}
                             />
                         </div>
                     </div>

--- a/src/components/modals/ChatSessionModal.tsx
+++ b/src/components/modals/ChatSessionModal.tsx
@@ -114,6 +114,7 @@ class SessionWindow extends React.Component<Props, ComponentState> {
                                 onClick={this.onClickDone}
                                 ariaDescription={Util.formatMessageId(intl, FM.CHATSESSIONMODAL_PRIMARYBUTTON_ARIADESCRIPTION)}
                                 text={Util.formatMessageId(intl, FM.CHATSESSIONMODAL_PRIMARYBUTTON_TEXT)}
+                                iconProps={{ iconName: 'Accept' }}
                             />
                             <OF.DefaultButton
                                 data-testid="chat-session-modal-session-timeout-button"
@@ -127,6 +128,7 @@ class SessionWindow extends React.Component<Props, ComponentState> {
                                 onClick={this.onClickAbandon}
                                 ariaDescription={Util.formatMessageId(intl, FM.BUTTON_ABANDON)}
                                 text={Util.formatMessageId(intl, FM.BUTTON_ABANDON)}
+                                iconProps={{ iconName: 'Delete' }}
                             />
                         </div>
                     </div>

--- a/src/components/modals/EntityCreatorEditor/EntityCreatorComponent.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorComponent.tsx
@@ -252,12 +252,14 @@ const Component: React.SFC<Props> = (props) => {
                     text={props.isEditing
                         ? Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_SAVEBUTTON_TEXT)
                         : Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_CREATEBUTTON_TEXT)}
+                    iconProps={{ iconName: 'Accept' }}
                 />
 
                 <OF.DefaultButton
                     onClick={props.onClickCancel}
                     ariaDescription={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_CANCELBUTTON_ARIADESCRIPTION)}
                     text={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_CANCELBUTTON_TEXT)}
+                    iconProps={{ iconName: 'Cancel' }}
                 />
 
                 {props.showDelete &&
@@ -266,6 +268,7 @@ const Component: React.SFC<Props> = (props) => {
                         onClick={props.onClickDelete}
                         ariaDescription={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_DELETEBUTTON_ARIADESCRIPTION)}
                         text={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_DELETEBUTTON_TEXT)}
+                        iconProps={{ iconName: 'Delete' }}
                     />}
             </div>
 

--- a/src/components/modals/ExtractConflictModal.tsx
+++ b/src/components/modals/ExtractConflictModal.tsx
@@ -86,10 +86,12 @@ const ExtractConflictModal: React.SFC<Props> = (props) => {
                     <OF.PrimaryButton
                         onClick={() => props.onAccept()}
                         text={formatMessageId(intl, FM.BUTTON_ACCEPT)}
+                        iconProps={{ iconName: 'Accept' }}
                     />
                     <OF.DefaultButton
                         onClick={() => props.onClose()}
                         text={formatMessageId(intl, FM.BUTTON_CLOSE)}
+                        iconProps={{ iconName: 'Cancel' }}
                     />
                 </div>
             </div>

--- a/src/components/modals/PackageCreator.tsx
+++ b/src/components/modals/PackageCreator.tsx
@@ -147,6 +147,7 @@ class PackageCreator extends React.Component<Props, ComponentState> {
                                         id: FM.PACKAGECREATOR_CREATEBUTTON_TEXT,
                                         defaultMessage: 'Create'
                                     })}
+                                    iconProps={{ iconName: 'Add' }}
                                 />
                                 <OF.DefaultButton
                                     onClick={this.onClickCancel}
@@ -158,6 +159,7 @@ class PackageCreator extends React.Component<Props, ComponentState> {
                                         id: FM.PACKAGECREATOR_CANCELBUTTON_TEXT,
                                         defaultMessage: 'Cancel'
                                     })}
+                                    iconProps={{ iconName: 'Cancel' }}
                                 />
                             </div>
                         </div>

--- a/src/components/modals/PackageTable.tsx
+++ b/src/components/modals/PackageTable.tsx
@@ -98,6 +98,7 @@ class PackageTable extends React.Component<Props, ComponentState> {
                     onClick={this.onClickNewTag}
                     ariaDescription='New Tag'
                     text='New Tag'
+                    iconProps={{ iconName: 'Add' }}
                 />
                 <PackageCreator
                     open={this.state.isPackageCreatorOpen}

--- a/src/components/modals/TeachSessionInitState.tsx
+++ b/src/components/modals/TeachSessionInitState.tsx
@@ -188,6 +188,7 @@ class TeachSessionInitState extends React.Component<Props, ComponentState> {
                                     id: FM.BUTTON_OK,
                                     defaultMessage: 'Ok'
                                 })}
+                                iconProps={{ iconName: 'Accept' }}
                             />
                             <OF.DefaultButton
                                 data-testid="teach-session-cancel-button"
@@ -200,6 +201,7 @@ class TeachSessionInitState extends React.Component<Props, ComponentState> {
                                     id: FM.BUTTON_CANCEL,
                                     defaultMessage: 'Cancel'
                                 })}
+                                iconProps={{ iconName: 'Cancel' }}
                             />
                         </div>
                     </div>

--- a/src/components/modals/TeachSessionModal.tsx
+++ b/src/components/modals/TeachSessionModal.tsx
@@ -856,6 +856,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                                         onClick={this.onClickUndoInput}
                                         ariaDescription={Util.formatMessageId(intl, FM.BUTTON_UNDO)}
                                         text={Util.formatMessageId(intl, FM.BUTTON_UNDO)}
+                                        iconProps={{ iconName: 'Undo' }}
                                     />
                                 }
                                 <OF.PrimaryButton

--- a/src/components/modals/TutorialImporter.tsx
+++ b/src/components/modals/TutorialImporter.tsx
@@ -167,12 +167,14 @@ class TutorialImporter extends React.Component<Props, ComponentState> {
                                 onClick={this.props.handleClose}
                                 ariaDescription={formatMessageId(intl, FM.BUTTON_CANCEL)}
                                 text={formatMessageId(intl, FM.BUTTON_CANCEL)}
+                                iconProps={{ iconName: 'Cancel' }}
                             />
                             :
                             <OF.PrimaryButton
                                 onClick={() => this.setState({ moreInfoApp: null })}
                                 ariaDescription={formatMessageId(intl, FM.BUTTON_OK)}
                                 text={formatMessageId(intl, FM.BUTTON_OK)}
+                                iconProps={{ iconName: 'Accept' }}
                             />
                         }
                     </div>

--- a/src/routes/Apps/App/Actions.tsx
+++ b/src/routes/Apps/App/Actions.tsx
@@ -145,6 +145,7 @@ class Actions extends React.Component<Props, ComponentState> {
                             id: FM.ACTIONS_CREATEBUTTONTITLE,
                             defaultMessage: 'New Action'
                         })}
+                        iconProps={{ iconName: 'Add' }}
                         componentRef={component => this.newActionButton = component!}
                     />
                 </div>

--- a/src/routes/Apps/App/Dashboard.tsx
+++ b/src/routes/Apps/App/Dashboard.tsx
@@ -96,6 +96,7 @@ class Dashboard extends React.Component<Props, ComponentState> {
                                 <OF.PrimaryButton
                                     onClick={() => this.onClickAcceptChanges(appDefinitionChange.updatedAppDefinition)}
                                     text="Accept Changes"
+                                    iconProps={{ iconName: 'Accept' }}
                                 />
                             </div>
                             : <div>

--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -284,6 +284,7 @@ class Entities extends React.Component<Props, ComponentState> {
                             id: FM.ENTITIES_CREATEBUTTONTEXT,
                             defaultMessage: 'New Entity'
                         })}
+                        iconProps={{ iconName: 'Add' }}
                         componentRef={component => this.newEntityButton = component!}
                     />
                 </div>

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -985,6 +985,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                         ariaDescription={Util.formatMessageId(this.props.intl, FM.LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION)}
                         text={Util.formatMessageId(this.props.intl, FM.LOGDIALOGS_CREATEBUTTONTITLE)}
                         componentRef={component => this.newChatSessionButton = component!}
+                        iconProps={{ iconName: 'Add' }}
                     />
                     <OF.DefaultButton
                         data-testid="logdialogs-button-refresh"

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -357,11 +357,13 @@ class Settings extends React.Component<Props, ComponentState> {
                             onClick={this.onClickExport}
                             ariaDescription={Util.formatMessageId(intl, FM.SETTINGS_EXPORTBUTTONARIALDESCRIPTION)}
                             text={Util.formatMessageId(intl, FM.SETTINGS_EXPORTBUTTONTEXT)}
+                            iconProps={{ iconName: 'DownloadDocument' }}
                         />
                         <OF.PrimaryButton
                             onClick={this.onClickCopy}
                             ariaDescription={Util.formatMessageId(intl, FM.SETTINGS_COPYBUTTONARIALDESCRIPTION)}
                             text={Util.formatMessageId(intl, FM.SETTINGS_COPYBUTTONTEXT)}
+                            iconProps={{ iconName: 'Copy' }}
                         />
                         <OF.DefaultButton
                             data-testid="settings-delete-model-button"
@@ -369,6 +371,7 @@ class Settings extends React.Component<Props, ComponentState> {
                             onClick={this.onClickDelete}
                             ariaDescription={Util.formatMessageId(intl, FM.ACTIONCREATOREDITOR_DELETEBUTTON_ARIADESCRIPTION)}
                             text={Util.formatMessageId(intl, FM.ACTIONCREATOREDITOR_DELETEBUTTON_TEXT)}
+                            iconProps={{ iconName: 'Delete' }}
                         />
                     </div>
                     <OF.TextField
@@ -482,12 +485,14 @@ class Settings extends React.Component<Props, ComponentState> {
                             onClick={this.onClickSave}
                             ariaDescription={Util.formatMessageId(intl, FM.SETTINGS_SAVECHANGES)}
                             text={Util.formatMessageId(intl, FM.SETTINGS_SAVECHANGES)}
+                            iconProps={{ iconName: 'Accept' }}
                         />
                         <OF.DefaultButton
                             disabled={this.state.edited === false}
                             onClick={this.onClickDiscard}
                             ariaDescription={Util.formatMessageId(intl, FM.SETTINGS_DISCARD)}
                             text={Util.formatMessageId(intl, FM.SETTINGS_DISCARD)}
+                            iconProps={{ iconName: 'Undo' }}
                         />
                     </div>
 

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -1185,6 +1185,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                         ariaDescription={Util.formatMessageId(intl, FM.TRAINDIALOGS_CREATEBUTTONARIALDESCRIPTION)}
                         text={Util.formatMessageId(intl, FM.TRAINDIALOGS_CREATEBUTTONTITLE)}
                         componentRef={component => this.newTeachSessionButton = component!}
+                        iconProps={{ iconName: 'Add' }}
                     />
                 </div>
 

--- a/src/routes/Apps/AppsListComponent.tsx
+++ b/src/routes/Apps/AppsListComponent.tsx
@@ -207,12 +207,14 @@ export class Component extends React.Component<Props, ComponentState> {
                     onClick={props.onClickCreateNewApp}
                     ariaDescription={Util.formatMessageId(props.intl, FM.APPSLIST_CREATEBUTTONARIADESCRIPTION)}
                     text={Util.formatMessageId(props.intl, FM.APPSLIST_CREATEBUTTONTEXT)}
+                    iconProps={{ iconName: 'Add' }}
                 />
                 <OF.DefaultButton
                     data-testid="model-list-import-model-button"
                     onClick={props.onClickImportApp}
                     ariaDescription={Util.formatMessageId(props.intl, FM.APPSLIST_IMPORTAPP_BUTTONARIADESCRIPTION)}
                     text={Util.formatMessageId(props.intl, FM.APPSLIST_IMPORTAPP_BUTTONTEXT)}
+                    iconProps={{ iconName: 'DownloadDocument' }}
                 />
                 {!Util.isDemoAccount(props.user.id) &&
                     <OF.DefaultButton
@@ -220,6 +222,7 @@ export class Component extends React.Component<Props, ComponentState> {
                         onClick={props.onClickImportDemoApps}
                         ariaDescription={Util.formatMessageId(props.intl, FM.APPSLIST_IMPORTTUTORIALS_BUTTONARIADESCRIPTION)}
                         text={Util.formatMessageId(props.intl, FM.APPSLIST_IMPORTTUTORIALS_BUTTONTEXT)}
+                        iconProps={{ iconName: 'CloudDownload' }}
                     />
                 }
             </div>

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -51,6 +51,7 @@ class Settings extends React.Component<Props> {
                         <OF.PrimaryButton
                             text="Reset"
                             ariaDescription="Reset"
+                            iconProps={{ iconName: 'Undo' }}
                             onClick={this.reset}
                         />
                     </div>


### PR DESCRIPTION
I noticed some places our buttons have icons and other places they don't so I wanted to see what it looked like it we added them in more places.

Having a visual indicator can be more well-known than language so this might help non-English speakers.

Some of them of simple like, adding + indicator when we create something, but there are many others.
I tried to create image of before / after to see. 

There is still an issue we have to figure out with icon contrast when the button is disabled, so this will have to wait until that is fixed, but wanted to see what people felt about change visually.

![image](https://user-images.githubusercontent.com/2856501/54448688-8e593700-4709-11e9-8e3a-ca66230c38e2.png)

There are some other buttons that change the action depending on context such as TeachSessionModal depending if you delete or abandon or continue etc.  I tried to leave those alone for now, but let me know if I have missed some or icon isn't semantic to the button.


