### PR TITLE
chore: add id to poller for visualizing logs and test output

### DIFF
--- a/src/services/poller.test.ts
+++ b/src/services/poller.test.ts
@@ -107,8 +107,8 @@ describe('Poller', () => {
         await p1
         const after = new Date().getTime()
 
-        // 200 + 400
-        expect(after - now).toBeGreaterThanOrEqual(600)
+        // 200 + 400 (should be 600 but make 590 since javascript timers can be skewed by couple milliseconds)
+        expect(after - now).toBeGreaterThanOrEqual(590)
     })
 
     test('calling poll with different id should NOT extend existing polls', async () => {

--- a/src/services/poller.ts
+++ b/src/services/poller.ts
@@ -31,6 +31,8 @@ export interface IPollerOptions {
 
 const global = window
 export class Poller {
+    // Need some random character for visual difference in logs. Could use uuid() library but don't want dependency
+    private id = Symbol(Math.floor(Math.random() * 100))
     private polls: ActivePoll[] = []
     constructor(options: IPollerOptions) {
         global.setInterval(async () => await this.poll(), options.interval)
@@ -43,14 +45,14 @@ export class Poller {
         const activeApp = this.polls.find(p => p.id === id)
 
         if (activeApp) {
-            console.log(`Existing polling found for id: ${id} increasing end from ${activeApp.end} to: ${end}`)
+            console.log(`Poller: ${this.id.toString()} - Existing polling found for id: ${id} increasing end from ${activeApp.end} to: ${end}`)
             activeApp.end = end
             return new Promise((resolve, reject) => {
                 activeApp.deferred.push({ resolve, reject, pollConfig })
             })
         }
 
-        console.log(`No polling found for id: ${id}. Starting new polling until: ${end}`)
+        console.log(`Poller: ${this.id.toString()} - No polling found for id: ${id}. Starting new polling until: ${end}`)
         return new Promise((resolve, reject) => {
             this.polls.push({
                 id,


### PR DESCRIPTION
One of the poller tests was off by 1 millisecond again... relaxing to 590 instead of exactly 600.
I thought if the times were off they could only be later than specified but I guess they can be earlier also.
E.g. if you say `setTimeout` for 50 it can timeout for 50 or more, but apparently it can also timeout for 49...

Also added unique id and random character to visualize logs