### PR TITLE
fix: prevent issue with sort trying modify immutable prop

### DIFF
--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -237,9 +237,10 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     sortLogDialogs(logDialogs: CLM.LogDialog[]): CLM.LogDialog[] {
+        const logDialogsCopy = [...logDialogs]
         // If column header selected sort the items
         if (this.state.sortColumn) {
-            logDialogs
+            logDialogsCopy
                 .sort((a, b) => {
                     let firstValue = this.state.sortColumn.getSortValue(a, this)
                     let secondValue = this.state.sortColumn.getSortValue(b, this)
@@ -259,7 +260,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                 })
         }
 
-        return logDialogs;
+        return logDialogsCopy
     }
 
     @OF.autobind

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -282,9 +282,10 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     sortTrainDialogs(trainDialogs: CLM.TrainDialog[]): CLM.TrainDialog[] {
+        const trainDialogsCopy = [...trainDialogs]
         // If column header selected sort the items, always putting invalid at the top
         if (this.state.sortColumn) {
-            trainDialogs
+            trainDialogsCopy
                 .sort((a, b) => {
 
                     // Always put invalid at top (values can also be undefined)
@@ -314,7 +315,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 })
         }
 
-        return trainDialogs;
+        return trainDialogsCopy
     }
 
     @OF.autobind


### PR DESCRIPTION
Issue with `sort` modifying the array it operates on instead of returning a new array.
In cases where we didn't have any filters applied we were passing the trainDialogs directly to this function.
Fix is to have this function make a copy of array so no matter what it's called with it won't mutate it.
I checked all the other sort cases and they all seem to be using temporary arrays as well and in some cases we were doing this such as `unionMemoryNames.concat([])`.  I think this wasn't exposed as an issue until we switched to `immer` which freezes objects to ensure you aren't mutating stuff in the redux store and this started happening.

I had seen this before and couldn't reproduce reliably.

Fixes ADO#1949
