### PR TITLE
fix: explicitly set sourceLogDialogId when saving

### DIFF
--- a/src/actions/teachActions.ts
+++ b/src/actions/teachActions.ts
@@ -161,7 +161,12 @@ export const deleteTeachSessionThunkAsync = (
                 }
                 else {
                     // Edit the associated train dialogs tag and description
-                    await clClient.trainDialogEdit(app.appId, { trainDialogId: teachSession.trainDialogId, tags, description })
+                    await clClient.trainDialogEdit(app.appId, {
+                        trainDialogId: teachSession.trainDialogId,
+                        tags,
+                        description,
+                        sourceLogDialogId: sourceLogDialogId ? sourceLogDialogId : undefined
+                    })
                 }
 
                 // If we're adding a new train dialog as consequence of the session save, re-fetch train dialogs and start poll for train status

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -871,7 +871,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
 
         // Remove any data added for rendering
         cleanTrainDialog(newTrainDialog)
-
+        newTrainDialog.sourceLogDialogId = this.state.currentLogDialogId ? this.state.currentLogDialogId : undefined
         newTrainDialog.validity = validity
         newTrainDialog.definitions = null
         try {


### PR DESCRIPTION
Depends on server and models changes so will have to wait but at least we can show it now.

To recap, there is pending change in models so `sourceLogDialogId` is not implicitly set on all temporary train dialogs. This fixed the issue of implicitly removing the associated log dialogs as you edited them without saving, but it means we now need to explicitly set the `sourceLogDialogId` when clicking "Save As Train Dialog" so but sure the association is only created when the user actually saves changes.