### PR TITLE
chore: add icons to modal buttons and fix delete hover

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -158,7 +158,6 @@ html {
 .cl-icon[data-icon-name="Delete"] {
   font-size: 16px;
   vertical-align: middle;
-  color: var(--color-red) !important;
 }
 
 .cl-icon[data-icon-name="IncidentTriangle"] {
@@ -234,10 +233,6 @@ html {
   background-color: transparent !important;
 }
 
-.ms-Button-icon[data-icon-name="Delete"]:not(:disabled) {
-  color: var(--color-red);
-}
-
 .ms-Button-icon[data-icon-name="EditSolidMirrored12"] {
   color: var(--color-red);
 }
@@ -283,11 +278,8 @@ html {
     margin-bottom: 15px;
 }
 
-i[data-icon-name="Delete"] {
-  color: var(--color-red) !important;
-}
-
-i[data-icon-name="Delete"]:hover, i[data-icon-name="Edit"]:hover{
+i[data-icon-name="Delete"]:hover, 
+i[data-icon-name="Edit"]:hover {
   cursor: pointer;
 }
 
@@ -828,6 +820,10 @@ i[data-icon-name="Delete"]:hover, i[data-icon-name="Edit"]:hover{
 .cl-button-delete:disabled {
   border: 1px solid var(--color-neutralQuaternary) !important;
   color: 1px solid var(--color-neutralQuaternary) !important;
+}
+
+.cl-button--tree-view i {
+  transform: rotateX(180deg);
 }
 
 /** Log Dialog Admin */

--- a/src/components/ExtractorResponseEditor/CustomEntity.css
+++ b/src/components/ExtractorResponseEditor/CustomEntity.css
@@ -90,11 +90,8 @@
     cursor: default;
 }
 
-.cl-entity-node--custom .cl-entity-node-indicator__controls button {
-    background: var(--color-warning);
-}
-.cl-entity-node--prebuilt .cl-entity-node-indicator__controls button {
-    background: var(--color-warning);
+.cl-entity-node--custom .cl-entity-node-indicator__controls button i {
+    color: var(--color-red);
 }
 
 .cl-entity-node-indicator__name {

--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -256,6 +256,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                                         className="cl-action-creator-file-button"
                                         ariaDescription={Utils.formatMessageId(this.props.intl, FM.APPCREATOR_CHOOSE_FILE_BUTTON_ARIADESCRIPTION)}
                                         text={Utils.formatMessageId(this.props.intl, FM.APPCREATOR_CHOOSE_FILE_BUTTON_TEXT)}
+                                        iconProps={{ iconName: 'DocumentSearch' }}
                                     />
                                     <OF.TextField
                                         disabled={true}

--- a/src/components/modals/EditDialogModal.tsx
+++ b/src/components/modals/EditDialogModal.tsx
@@ -581,6 +581,24 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
         }
     }
 
+    renderAbandonIcon() {
+        const dialogChanged = this.isDialogChanged()
+
+        switch (this.props.editType) {
+            case EditDialogType.NEW:
+            case EditDialogType.BRANCH:
+            case EditDialogType.LOG_EDITED:
+            case EditDialogType.TRAIN_EDITED:
+                return "Cancel"
+            case EditDialogType.LOG_ORIGINAL:
+                return "Delete"
+            case EditDialogType.TRAIN_ORIGINAL:
+                return dialogChanged
+                    ? "Cancel"
+                    : "Delete"
+        }
+    }
+
     trainDialogValidity(): CLM.Validity | undefined {
         // Look for individual replay errors
         const replayErrorLevel = this.replayErrorLevel()
@@ -716,6 +734,24 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
                     : formatMessageId(intl, FM.BUTTON_CLOSE)
             default:
                 return ""
+        }
+    }
+
+    renderCloseOrSaveIcon() {
+        const dialogChanged = this.isDialogChanged()
+
+        switch (this.props.editType) {
+            case EditDialogType.NEW:
+            case EditDialogType.BRANCH:
+            case EditDialogType.LOG_EDITED:
+            case EditDialogType.TRAIN_EDITED:
+                return "Accept"
+            case EditDialogType.LOG_ORIGINAL:
+                return "Cancel"
+            case EditDialogType.TRAIN_ORIGINAL:
+                return dialogChanged
+                    ? "Accept"
+                    : "Cancel"
         }
     }
 
@@ -956,6 +992,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
                                     onClick={this.onClickConvert}
                                     ariaDescription={formatMessageId(intl, FM.BUTTON_SAVE_AS_TRAIN_DIALOG)}
                                     text={formatMessageId(intl, FM.BUTTON_SAVE_AS_TRAIN_DIALOG)}
+                                    iconProps={{ iconName: 'Accept' }}
                                 />
                             }
                             <TooltipHost
@@ -971,6 +1008,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
                                     onClick={() => this.props.onReplayDialog(this.props.trainDialog)}
                                     ariaDescription={formatMessageId(intl, FM.BUTTON_REPLAY)}
                                     text={formatMessageId(intl, FM.BUTTON_REPLAY)}
+                                    iconProps={{ iconName: 'Refresh' }}
                                 />
                             </TooltipHost>
 
@@ -980,6 +1018,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
                                 onClick={this.onClickSave}
                                 ariaDescription={this.renderCloseOrSaveText(intl)}
                                 text={this.renderCloseOrSaveText(intl)}
+                                iconProps={{ iconName: this.renderCloseOrSaveIcon() }}
                             />
                             <OF.DefaultButton
                                 data-testid="edit-dialog-modal-abandon-delete-button"
@@ -988,6 +1027,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
                                 onClick={this.onClickAbandon}
                                 ariaDescription={this.renderAbandonText(intl)}
                                 text={this.renderAbandonText(intl)}
+                                iconProps={{ iconName: this.renderAbandonIcon() }}
                             />
                         </div>
                     </div>

--- a/src/components/modals/EntityExtractor.css
+++ b/src/components/modals/EntityExtractor.css
@@ -16,6 +16,7 @@
     background: none;
     border: none;
     padding: 0;
+    color: var(--color-red);
 }
 
 .editor-button-invalid {

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -407,7 +407,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
         // Need to save this to separate variable for typescript control flow
         const extractConflict = this.props.extractConflict
         const attemptedExtractResponse = extractConflict && allResponses.find(e => e.text.toLowerCase() === extractConflict.text.toLowerCase())
-        
+
         return (
             <div className="entity-extractor">
                 <OF.Label className={`entity-extractor-help-text ${OF.FontClassNames.smallPlus} cl-label`}>
@@ -452,6 +452,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                             ariaDescription={'Add'}
                             text={'Add'}
                             componentRef={(ref: any) => { this.doneExtractingButton = ref }}
+                            iconProps={{ iconName: 'Add' }}
                         />
                         <OF.TextField
                             data-testid="entity-extractor-alternative-input-text"
@@ -467,29 +468,30 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                         />
                         <HelpIcon tipType={ToolTips.TipType.ENTITY_EXTRACTOR_TEXTVARIATION} />
                     </div>}
-                {editingRound &&
-                    <div className="cl-buttons-row">
-                        <OF.PrimaryButton
-                            data-testid="submit-changes-button"
-                            disabled={!this.state.isPendingSubmit
-                                || !allExtractResponsesValid
-                                || this.state.pendingVariationChange}
-                            onClick={this.onClickSubmitExtractions}
-                            ariaDescription={'Submit Changes'}
-                            text={'Submit Changes'}
-                            componentRef={(ref: any) => { this.doneExtractingButton = ref }}
-                        />
-                        <OF.PrimaryButton
-                            disabled={!this.state.isPendingSubmit}
-                            onClick={this.onClickUndoChanges}
-                            ariaDescription="Undo Changes"
-                            text="Undo"
-                        />
-                    </div>
-                }
-                {!editingRound &&
-                    <div className="cl-buttons-row">
-                        <OF.PrimaryButton
+
+                <div className="cl-buttons-row">
+                    {editingRound
+                        ? <>
+                            <OF.PrimaryButton
+                                data-testid="submit-changes-button"
+                                disabled={!this.state.isPendingSubmit
+                                    || !allExtractResponsesValid
+                                    || this.state.pendingVariationChange}
+                                onClick={this.onClickSubmitExtractions}
+                                ariaDescription={'Submit Changes'}
+                                text={'Submit Changes'}
+                                componentRef={(ref: any) => { this.doneExtractingButton = ref }}
+                                iconProps={{ iconName: 'Accept' }}
+                            />
+                            <OF.PrimaryButton
+                                disabled={!this.state.isPendingSubmit}
+                                onClick={this.onClickUndoChanges}
+                                ariaDescription="Undo Changes"
+                                text="Undo"
+                                iconProps={{ iconName: 'Undo' }}
+                            />
+                        </>
+                        : <OF.PrimaryButton
                             data-testid="score-actions-button"
                             disabled={!allExtractResponsesValid || this.state.pendingVariationChange || !canEdit}
                             onClick={this.onClickSubmitExtractions}
@@ -497,8 +499,9 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                             text={'Score Actions'}
                             componentRef={(ref: any) => { this.doneExtractingButton = ref }}
                         />
-                    </div>
-                }
+                    }
+                </div>
+
                 <div className="cl-dialog-admin__dialogs">
                     <EntityCreatorEditor
                         data-testid="entity-extractor-editor"

--- a/src/components/modals/TeachSessionModal.tsx
+++ b/src/components/modals/TeachSessionModal.tsx
@@ -865,6 +865,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                                     onClick={this.onClickSave}
                                     ariaDescription={this.renderSaveText(intl)}
                                     text={this.renderSaveText(intl)}
+                                    iconProps={{ iconName: 'Accept' }}
                                 />
                                 <OF.DefaultButton
                                     data-testid="edit-dialog-modal-abandon-delete-button"
@@ -873,6 +874,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
                                     onClick={this.onClickAbandonTeach}
                                     ariaDescription={this.renderAbandonText(intl)}
                                     text={this.renderAbandonText(intl)}
+                                    iconProps={{ iconName: 'Cancel' }}
                                 />
 
                             </div>

--- a/src/components/modals/UserInputModal.tsx
+++ b/src/components/modals/UserInputModal.tsx
@@ -105,11 +105,13 @@ class UserInputModal extends React.Component<Props, ComponentState> {
                                 onClick={this.onClickSubmit}
                                 ariaDescription={Util.formatMessageId(intl, FM.APPCREATOR_CREATEBUTTON_ARIADESCRIPTION)}
                                 text={Util.formatMessageId(intl, FM.APPCREATOR_CREATEBUTTON_TEXT)}
+                                iconProps={{ iconName: 'Accept' }}
                             />
                             <OF.DefaultButton
                                 onClick={this.onClickCancel}
                                 ariaDescription={Util.formatMessageId(intl, FM.BUTTON_CANCEL)}
                                 text={Util.formatMessageId(intl, FM.BUTTON_CANCEL)}
+                                iconProps={{ iconName: 'Cancel' }}
                             />
                         </div>
                     </div>

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -153,7 +153,12 @@ class App extends React.Component<Props, ComponentState> {
                       <div>
                         <p>Loading Failed.</p>
                         <div>
-                          <OF.PrimaryButton onClick={this.loadBotInfo}>Retry</OF.PrimaryButton>
+                          <OF.PrimaryButton
+                            onClick={this.loadBotInfo}
+                            iconProps={{ iconName: 'Refresh' }}
+                          >
+                            Retry
+                          </OF.PrimaryButton>
                         </div>
                       </div>
                     }

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -1254,6 +1254,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                         iconProps={{ iconName: 'Add' }}
                     />
                     <OF.DefaultButton
+                        className="cl-button--tree-view"
+                        iconProps={{ iconName: 'BranchFork2' }}
                         onClick={this.onOpenTreeView}
                         ariaDescription={Util.formatMessageId(intl, FM.TRAINDIALOGS_CREATEBUTTONARIALDESCRIPTION)}
                         text={"Tree View"}


### PR DESCRIPTION
In previous icon change I had skipped the modal buttons since the buttons change behavior based on state of modal / action taken.  The icons should now match that.

There was also a bug due to use of `!important` with the delete icon always being red.
This is fixed.

If this is merged  almost all the buttons should have icons.

It looks like there is a whole bunch of `!important`s to be removed but they are hard to track down since you don't know what it was compensating for so I will have to do those slowly at a later time.