### PR TITLE
chore: ensure proper typing clones

### DIFF
--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -427,7 +427,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
 
             // Created shorted verion of TrainDialog at insert point
             // Copy, Remove rounds / scorer steps below insert
-            const history = JSON.parse(JSON.stringify(trainDialog))
+            const history: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
             history.definitions = definitions
             history.rounds = history.rounds.slice(0, roundIndex + 1)
 
@@ -466,14 +466,15 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                 throw new Error("No actions available")
             }
 
-            const scorerStep = {
-                input: uiScoreResponse.scoreInput,
+            const scorerStep: CLM.TrainScorerStep = {
+                logicResult: undefined,
+                input: uiScoreResponse.scoreInput!,
                 labelAction: insertedAction.actionId,
                 scoredAction: insertedAction
             }
 
             // Insert new Action into Full TrainDialog
-            const newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            const newTrainDialog: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
             newTrainDialog.definitions = definitions
             const curRound = newTrainDialog.rounds[roundIndex]
 
@@ -669,7 +670,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
             const extractorStep: CLM.TrainExtractorStep = { textVariations }
 
             // Copy original and insert new round for the text
-            let newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            let newTrainDialog: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
             newTrainDialog.definitions = definitions
 
             let scorerSteps: CLM.TrainScorerStep[]

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -490,7 +490,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
             // Created shorted verion of TrainDialog at insert point
             // Copy, Remove rounds / scorer steps below insert
-            const shortTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            const shortTrainDialog: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
             shortTrainDialog.definitions = definitions
             shortTrainDialog.rounds = shortTrainDialog.rounds.slice(0, roundIndex + 1)
 
@@ -529,14 +529,15 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 throw new Error("Unable to find an action")
             }
 
-            const scorerStep = {
-                input: uiScoreResponse.scoreInput,
+            const scorerStep: CLM.TrainScorerStep = {
+                input: uiScoreResponse.scoreInput!,
                 labelAction: insertedAction.actionId,
+                logicResult: undefined,
                 scoredAction: insertedAction
             }
 
             // Insert new Action into Full TrainDialog
-            const newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            const newTrainDialog: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
             newTrainDialog.definitions = definitions
             const curRound = newTrainDialog.rounds[roundIndex]
 
@@ -705,7 +706,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             }
 
             // Copy, Remove rounds / scorer steps below branch
-            let newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            let newTrainDialog: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
             newTrainDialog.definitions = definitions
             newTrainDialog.rounds = newTrainDialog.rounds.slice(0, roundIndex)
 
@@ -782,7 +783,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             const extractorStep: CLM.TrainExtractorStep = { textVariations }
 
             // Copy original and insert new round for the text
-            let newTrainDialog = JSON.parse(JSON.stringify(trainDialog))
+            let newTrainDialog: CLM.TrainDialog = JSON.parse(JSON.stringify(trainDialog))
             newTrainDialog.definitions = definitions
 
             let scorerSteps: CLM.TrainScorerStep[]


### PR DESCRIPTION
There was many copies/clones of dialogs using `JSON.parse(JSON.stringify(...)` that dropped the types.
This puts them back.