### PR TITLE
chore: use font matching Office Fabric typography for delete modal

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -938,11 +938,6 @@ i[data-icon-name="Edit"]:hover {
   margin-bottom:1em;
 }
 
-.cl-ux-msg-cautionary {
-  color: var(--color-alert) !important;
-  font-weight: 900;
-}
-
 .cl-float-left {
   float: left;
 }

--- a/src/components/modals/TextboxRestrictable.tsx
+++ b/src/components/modals/TextboxRestrictable.tsx
@@ -27,7 +27,7 @@ class TextboxRestrictableModal extends React.Component<Props, ComponentState> {
     }
 
     isContinueDisabled() {
-        return (this.props.matched_text != null) && this.props.matched_text !== this.state.value
+        return (this.props.matchedText != null) && this.props.matchedText !== this.state.value
     }
 
     @OF.autobind
@@ -84,13 +84,13 @@ class TextboxRestrictableModal extends React.Component<Props, ComponentState> {
                                 disabled={this.isContinueDisabled()}
                                 data-testid="app-modal-continue-button"
                                 onClick={this.onClickOK}
-                                ariaDescription={this.props.button_ok}
-                                text={this.props.button_ok}
+                                ariaDescription={this.props.buttonOk}
+                                text={this.props.buttonOk}
                             />
                             <OF.DefaultButton
                                 onClick={this.onClickCancel}
-                                ariaDescription={this.props.button_cancel}
-                                text={this.props.button_cancel}
+                                ariaDescription={this.props.buttonCancel}
+                                text={this.props.buttonCancel}
                             />
                         </div>
                     </div>
@@ -114,9 +114,9 @@ export interface ReceivedProps {
     open: boolean
     message: JSX.Element
     placeholder: string
-    matched_text: any
-    button_ok: string
-    button_cancel: string
+    matchedText: any
+    buttonOk: string
+    buttonCancel: string
     onOK: (userInput: string) => void
     onCancel: () => void
 }

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -308,11 +308,11 @@ class Settings extends React.Component<Props, ComponentState> {
         })
     }
 
-    getDeleteDialogBoxText = (model_name: string) => {
+    getDeleteDialogBoxText = (modelName: string) => {
         return (
             <div>
-                <h1 className="cl-ux-msg-cautionary">{Util.formatMessageId(this.props.intl, FM.SETINGS_DELETEISPERMANENT)}</h1>
-                <p>Confirm permanent deletion of the <strong>{model_name}</strong> Model by entering its name.</p>
+                <h1 className={`${OF.FontClassNames.xxLarge} cl-text--error`} style={{ fontWeight: OF.FontWeights.semibold }}>{Util.formatMessageId(this.props.intl, FM.SETINGS_DELETEISPERMANENT)}</h1>
+                <p>Confirm permanent deletion of the <strong>{modelName}</strong> Model by entering its name.</p>
             </div>
         )
     }
@@ -511,9 +511,9 @@ class Settings extends React.Component<Props, ComponentState> {
                     open={this.state.isConfirmDeleteAppModalOpen}
                     message={this.getDeleteDialogBoxText(this.props.app.appName)}
                     placeholder={""}
-                    matched_text={this.props.app.appName}
-                    button_ok={Util.getDefaultText(FM.ACTIONCREATOREDITOR_DELETEBUTTON_TEXT)}
-                    button_cancel={Util.getDefaultText(FM.ACTIONCREATOREDITOR_CANCELBUTTON_TEXT)}
+                    matchedText={this.props.app.appName}
+                    buttonOk={Util.getDefaultText(FM.ACTIONCREATOREDITOR_DELETEBUTTON_TEXT)}
+                    buttonCancel={Util.getDefaultText(FM.ACTIONCREATOREDITOR_CANCELBUTTON_TEXT)}
                     onOK={this.onConfirmDeleteApp}
                     onCancel={this.onCancelDeleteModal}
                 />


### PR DESCRIPTION
Minor, just changes the font of the "Deletion is irreversible." to be one of the fonts from Office Fabric.
The old one used different color than the delete button and was custom weight.

Think in future we should stick to these:
https://developer.microsoft.com/en-us/fabric#/styles/typography

It does make the font smaller though so let me know if you want or not.

Before:
![image](https://user-images.githubusercontent.com/2856501/54773304-8ba58880-4bc6-11e9-97aa-851d81dfb722.png)

After:
![image](https://user-images.githubusercontent.com/2856501/54773311-8fd1a600-4bc6-11e9-9563-7b85714526d1.png)
