### PR TITLE
fix: enforce app name length on settings page

### DIFF
--- a/src/routes/Apps/App/Index.css
+++ b/src/routes/Apps/App/Index.css
@@ -5,6 +5,7 @@
 }
 .cl-app-title {
     padding-bottom: 0.9rem;
+    word-break: break-all;
 }
 
 .cl-app-tag-status {

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -229,8 +229,14 @@ class Settings extends React.Component<Props, ComponentState> {
     }
 
     onGetNameErrorMessage(value: string): string {
+        const MAX_NAME_LENGTH = 30
+
         if (value.length === 0) {
             return Util.formatMessageId(this.props.intl, FM.SETTINGS_FIELDERROR_REQUIREDVALUE)
+        }
+
+        if (value.length > MAX_NAME_LENGTH) {
+            return Util.formatMessageId(this.props.intl, FM.APPCREATOR_FIELDERROR_TOOLONG)
         }
 
         if (!/^[a-zA-Z0-9- ]+$/.test(value)) {


### PR DESCRIPTION
Combination of error on server not validating and not also checking on client allowed people to put arbitrarily long names for their app in the Settings page after they created it which had really bad efffect on our UI.

UI will now wrap long words, and prevent people from entering long names. There is also associated server PR to fix it there as well.

Before:
![image](https://user-images.githubusercontent.com/2856501/54775937-3e2c1a00-4bcc-11e9-93f0-7e034b0efb86.png)

After:
![image](https://user-images.githubusercontent.com/2856501/54775974-59972500-4bcc-11e9-9554-58e90adb9fa5.png)

Beyond immediate fix, but personally I would like to increase the limit. I think 30 is too short, maybe 50.
Also, our UI could better support long names like LUIS where it is dedicated bar / sub nav, but that's too much work

