### PR TITLE
chore: move entity picker below selected text to preserve top search placement

### DIFF
--- a/src/components/ExtractorResponseEditor/EntityPicker.css
+++ b/src/components/ExtractorResponseEditor/EntityPicker.css
@@ -12,7 +12,6 @@
     padding: 0.25em;
     position: absolute;
     left: -10000px;
-    bottom: 10000px;
     transition: opacity .75s;
     z-index: 2;
     visibility: hidden;
@@ -63,8 +62,8 @@
     margin: 0;
     list-style: none;
     padding: 0;
-    padding-bottom: 0.25em;
-    border-bottom: 2px solid lightgrey;
+    padding-top: 0.25em;
+    border-top: 2px solid lightgrey;
     overflow-y: auto;
     max-height: 8.9em;
 }

--- a/src/components/ExtractorResponseEditor/EntityPicker.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPicker.tsx
@@ -55,9 +55,9 @@ export default class EntityPicker extends React.Component<MenuProps, ComponentSt
     }
 
     render() {
-        const style: any = {
-            left: this.props.isVisible ? `${this.props.position.left}px` : null,
-            bottom: this.props.isVisible ? `${this.props.position.bottom}px` : null,
+        const style = {
+            left: this.props.isVisible ? `${this.props.position.left}px` : undefined,
+            top: this.props.isVisible ? `${this.props.position.top}px` : undefined,
             height: !this.props.isOverlappingOtherEntities ? "auto" : "4em",
             marginBottom: !this.props.isOverlappingOtherEntities ? "0" : "1em"
         }
@@ -73,6 +73,23 @@ export default class EntityPicker extends React.Component<MenuProps, ComponentSt
                 style={style}
                 role="button"
             >
+                <div className="custom-toolbar__search">
+                    <input
+                        data-testid="entity-picker-entity-search"
+                        id="toolbar-input"
+                        type="text"
+                        placeholder="Search for entities"
+                        value={this.props.searchText}
+                        className="custom-toolbar__input"
+                        onChange={event => this.props.onChangeSearchText(event.target.value)}
+                    />
+                </div>
+                <OF.PrimaryButton
+                    tabIndex={-1}
+                    onClick={() => this.props.onClickNewEntity(this.props.entityTypeFilter)}
+                    text="New Entity"
+                    iconProps={{ iconName: 'Add' }}
+                />
                 <div className="custom-toolbar__results" ref={this.state.resultsRef}>
                     {this.props.matchedOptions.length === 0
                         ? <div className="custom-toolbar__result">No matching entites</div>
@@ -86,23 +103,6 @@ export default class EntityPicker extends React.Component<MenuProps, ComponentSt
                                 <FuseMatch matches={matchedOption.matchedStrings} />
                             </div>
                         )}
-                </div>
-                <OF.PrimaryButton
-                    tabIndex={-1}
-                    onClick={() => this.props.onClickNewEntity(this.props.entityTypeFilter)}
-                    text="New Entity"
-                    iconProps={{ iconName: 'Add' }}
-                />
-                <div className="custom-toolbar__search">
-                    <input
-                        data-testid="entity-picker-entity-search"
-                        id="toolbar-input"
-                        type="text"
-                        placeholder="Search for entities"
-                        value={this.props.searchText}
-                        className="custom-toolbar__input"
-                        onChange={event => this.props.onChangeSearchText(event.target.value)}
-                    />
                 </div>
             </div>
         )

--- a/src/components/ExtractorResponseEditor/EntityPicker.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPicker.tsx
@@ -92,7 +92,7 @@ export default class EntityPicker extends React.Component<MenuProps, ComponentSt
                 />
                 <div className="custom-toolbar__results" ref={this.state.resultsRef}>
                     {this.props.matchedOptions.length === 0
-                        ? <div className="custom-toolbar__result">No matching entites</div>
+                        ? <div className="custom-toolbar__result">No matching entities</div>
                         : this.props.matchedOptions.map((matchedOption, i) =>
                             <div
                                 key={matchedOption.original.id}

--- a/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
@@ -85,33 +85,37 @@ export default class EntityPickerContainer extends React.Component<Props, State>
     }
 
     componentWillReceiveProps(nextProps: Props) {
-        if (nextProps.options.length !== this.props.options.length
-            || (this.props.isVisible === false
+        if ((this.props.isVisible === false
             && nextProps.isVisible === true)) {
 
-            this.fuse = new Fuse(nextProps.options, fuseOptions)
-
-            // Recompute default options in case options list and max displayed props have changed
-            this.defaultMatchedOptions = nextProps.options.filter((_, i) => i < nextProps.maxDisplayedOptions)
-                .map<MatchedOption<IOption>>(option => ({
-                    highlighted: false,
-                    matchedStrings: [{ text: option.name, matched: false }],
-                    original: option
-                }))
-
-            // We want to still show all options of the user has entered nothing or whitespace so trim and check for empty condition
-            const normalizedSearchText = this.state.searchText.trim()
-            const matchedOptions = (normalizedSearchText.length === 0)
-                ? this.defaultMatchedOptions
-                : this.fuse.search<FuseResult<IOption>>(normalizedSearchText)
-                    .filter((_, i) => i < nextProps.maxDisplayedOptions)
-                    .map(result => convertMatchedTextIntoMatchedOption(result.item.name, result.matches[0].indices, result.item))
-
-            this.setState(prevState => ({
+            this.setState({
                 ...initialState,
-                matchedOptions,
-                highlightIndex: 0 //prevState.highlightIndex > (matchedOptions.length - 1) ? 0 : prevState.highlightIndex
-            }))
+                highlightIndex: 0
+            })
+
+            if (nextProps.options.length !== this.props.options.length) {
+                this.fuse = new Fuse(nextProps.options, fuseOptions)
+
+                // Recompute default options in case options list and max displayed props have changed
+                this.defaultMatchedOptions = nextProps.options.filter((_, i) => i < nextProps.maxDisplayedOptions)
+                    .map<MatchedOption<IOption>>(option => ({
+                        highlighted: false,
+                        matchedStrings: [{ text: option.name, matched: false }],
+                        original: option
+                    }))
+
+                // We want to still show all options of the user has entered nothing or whitespace so trim and check for empty condition
+                const normalizedSearchText = this.state.searchText.trim()
+                const matchedOptions = (normalizedSearchText.length === 0)
+                    ? this.defaultMatchedOptions
+                    : this.fuse.search<FuseResult<IOption>>(normalizedSearchText)
+                        .filter((_, i) => i < nextProps.maxDisplayedOptions)
+                        .map(result => convertMatchedTextIntoMatchedOption(result.item.name, result.matches[0].indices, result.item))
+
+                this.setState({
+                    matchedOptions
+                })
+            }
         }
     }
 

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -178,7 +178,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
 
         const left = (selectionBoundingRect.left - relativeRect.left) + window.scrollX - menu.offsetWidth / 2 + selectionBoundingRect.width / 2
         const menuPosition: IPosition = {
-            top: ((selectionBoundingRect.top - relativeRect.top) - menu.offsetHeight) + window.scrollY - 20,
+            top: ((selectionBoundingRect.top - relativeRect.top) + selectionBoundingRect.height) + window.scrollY + 10,
             left: Math.max(0, left),
             bottom: relativeRect.height - (selectionBoundingRect.top - relativeRect.top) + 10
         }


### PR DESCRIPTION
The search results prioritize from most relavant at top and least at bottom. As the user searches they would likely be looking at this top to ensure it's the correct element.  When the picker was above without a fixed height it would cause the "top" item to move as the list got smaller making it difficult to read.

Picker and results are now moved below so this item can stay in place as you filter more items out.

Before:
![http://g.recordit.co/qD6llTJkbD.gif](http://g.recordit.co/qD6llTJkbD.gif)

After:
![http://g.recordit.co/q0M8lGER2O.gif](http://g.recordit.co/q0M8lGER2O.gif)

I'm hesitant about this change as I think most selections go on top, but it seems to make more sense when we have this search list changing it's height and things:

Word:
![wordSelection](https://user-images.githubusercontent.com/2856501/54785304-185e3f80-4be3-11e9-9235-e3e6c4fe6d82.png)

Medium:
![image](https://user-images.githubusercontent.com/2856501/54785397-5bb8ae00-4be3-11e9-9061-fd8686b1934d.png)
