### PR TITLE
Fix Chrome 73 Issue

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,6 +46,11 @@ Cypress.Commands.add('UploadFile', (fileName, selector) => {
 
       dataTransfer.items.add(testFile)
       element.files = dataTransfer.files
+      
+      // https://github.com/cypress-io/cypress/issues/3730
+      // Deal with Chrome v73 issue that was not uploading the files until we add the following line of code.
+      // Also needed to force the trigger since Cypress won't normally do that on an element that is not visible.
+      return cy.wrap(elements).trigger('change', {force: true})
     })
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -50,7 +50,8 @@ Cypress.Commands.add('UploadFile', (fileName, selector) => {
       // https://github.com/cypress-io/cypress/issues/3730
       // Deal with Chrome v73 issue that was not uploading the files until we add the following line of code.
       // Also needed to force the trigger since Cypress won't normally do that on an element that is not visible.
-      return cy.wrap(elements).trigger('change', {force: true})
+      // Also the {force: true} part fails on the Electron Browser, so do this for Chrome only.
+      if (Cypress.browser.name === 'chrome') { cy.wrap(elements).trigger('change', {force: true}) }
     })
   })
 })


### PR DESCRIPTION
Details on the fix can be found here:
https://github.com/cypress-io/cypress/issues/3730

Chrome v73 broke the code we used to import files. This fixes it.