### PR TITLE
feat: only show functions defined in callbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1796,9 +1796,9 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.199.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.199.0.tgz",
-      "integrity": "sha512-EH9qMwFkQCEgE5R3yARI6bOQcFYPBoeX3pgsDy7rsnQtfIuqznz2GXHV1lwx4/03WfABXbn6vriV969kMnmCgQ=="
+      "version": "0.199.1",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.199.1.tgz",
+      "integrity": "sha512-9jRSCx2QT3wIZ8ONEKU78APYi7RZZo2YAngo36xIzaPK8BBTPGPA7QUyXaUMOFhneRxksvQk/i7nsuAQOmSIjg=="
     },
     "@conversationlearner/webchat": {
       "version": "0.145.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "private": true,
   "dependencies": {
-    "@conversationlearner/models": "0.199.0",
+    "@conversationlearner/models": "0.199.1",
     "@conversationlearner/webchat": "0.145.0",
     "adaptivecards": "1.0.0",
     "axios": "^0.16.2",

--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -199,10 +199,12 @@ function getActionPayloadRenderer(action: CLM.ActionBase, component: ActionDetai
     }
     else if (action.actionType === CLM.ActionTypes.API_LOCAL) {
         const apiAction = new CLM.ApiAction(action)
+        const callback = component.props.botInfo.callbacks.find(t => t.name === apiAction.name)
         return (<ActionPayloadRenderers.ApiPayloadRendererContainer
             apiAction={apiAction}
             entities={component.props.entities}
             memories={null}
+            callback={callback}
         />)
     }
     else if (action.actionType === CLM.ActionTypes.CARD) {

--- a/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
@@ -19,8 +19,10 @@ interface ICombinedActionArguments {
 
 interface Props {
     name: string
+    showLogicFunction: boolean
     originalLogicArguments: RenderedActionArgument[]
     substitutedLogicArguments: RenderedActionArgument[] | null
+    showRenderFunction: boolean
     originalRenderArguments: RenderedActionArgument[]
     substitutedRenderArguments: RenderedActionArgument[] | null
 }
@@ -48,7 +50,8 @@ export default class Component extends React.Component<Props, State> {
         return <div className="cl-api-payload">
             <div>
                 <div className={OF.FontClassNames.mediumPlus}>{this.props.name}</div>
-                <div className="cl-api-payload__fn">
+                {this.props.showLogicFunction
+                    && <div className="cl-api-payload__fn">
                     <div className="cl-api-payload__signature">logic(memoryManager{pairedLogicArguments.argumentPairs.length !== 0 && `, ${pairedLogicArguments.argumentPairs.map(a => a.original.parameter).join(', ')}`})</div>
                     <div className="cl-api-payload__arguments ms-ListItem-primaryText">
                         {pairedLogicArguments.argumentPairs.length !== 0
@@ -61,9 +64,10 @@ export default class Component extends React.Component<Props, State> {
                                     }"</div>
                                 </React.Fragment>)}
                     </div>
-                </div>
+                </div>}
 
-                <div className="cl-api-payload__fn">
+                {this.props.showRenderFunction
+                    && <div className="cl-api-payload__fn">
                     <div className="cl-api-payload__signature">render(result, memoryManager{pairedRenderArguments.argumentPairs.length !== 0 && `, ${pairedRenderArguments.argumentPairs.map(a => a.original.parameter).join(', ')}`})</div>
                     <div className="cl-api-payload__arguments ms-ListItem-primaryText">
                         {pairedRenderArguments.argumentPairs.length !== 0
@@ -76,7 +80,7 @@ export default class Component extends React.Component<Props, State> {
                                     }"</div>
                                 </React.Fragment>)}
                     </div>
-                </div>
+                </div>}
             </div>
             {showToggle
                 && <div>

--- a/src/components/actionPayloadRenderers/ApiPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRendererContainer.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import * as React from 'react'
-import { ApiAction, EntityBase, Memory } from '@conversationlearner/models'
+import { ApiAction, EntityBase, Memory, Callback } from '@conversationlearner/models'
 import * as Util from '../../Utils/util'
 import ApiPayloadRenderer from './ApiPayloadRenderer'
 
@@ -11,11 +11,12 @@ interface Props {
     apiAction: ApiAction
     entities: EntityBase[]
     memories: Memory[] | null
+    callback: Callback | undefined
 }
 
 export default class Component extends React.Component<Props, {}> {
     render() {
-        const { apiAction, entities, memories } = this.props
+        const { apiAction, entities, memories, callback } = this.props
         const defaultEntityMap = Util.getDefaultEntityMap(entities)
         const logicArgumentsUsingEntityNames = apiAction.renderLogicArguments(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
         const logicArgumentsUsingCurrentMemory = memories === null
@@ -27,10 +28,22 @@ export default class Component extends React.Component<Props, {}> {
             ? null
             : apiAction.renderRenderArguments(Util.createEntityMapFromMemories(entities, memories), { fallbackToOriginal: true })
 
+        const showLogicFunction = !callback
+            ? true
+            : callback.isLogicFunctionProvided
+                // && callback.logicArguments.length > 0
+
+        const showRenderFunction = !callback
+            ? true
+            : callback.isRenderFunctionProvided
+                // && callback.renderArguments.length > 0
+
         return <ApiPayloadRenderer
             name={apiAction.name}
+            showLogicFunction={showLogicFunction}
             originalLogicArguments={logicArgumentsUsingEntityNames}
             substitutedLogicArguments={logicArgumentsUsingCurrentMemory}
+            showRenderFunction={showRenderFunction}
             originalRenderArguments={renderArgumentsUsingEntityNames}
             substitutedRenderArguments={renderArgumentsUsingCurrentMemory}
         />

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -128,12 +128,14 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                 }
                 else if (action.actionType === CLM.ActionTypes.API_LOCAL) {
                     const apiAction = new CLM.ApiAction(action)
+                    const callback = component.props.botInfo.callbacks.find(t => t.name === apiAction.name)
                     return (
                         <ActionPayloadRenderers.ApiPayloadRendererContainer
                             data-testid="action-scorer-action-api"
                             apiAction={apiAction}
                             entities={component.props.entities}
                             memories={component.props.memories}
+                            callback={callback}
                         />)
                 }
                 else if (action.actionType === CLM.ActionTypes.CARD) {
@@ -758,7 +760,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
         if (this.state.cardViewerAction) {
             const cardAction = new CLM.CardAction(this.state.cardViewerAction)
             const entityMap = Util.getDefaultEntityMap(this.props.entities)
-            template = this.props.templates.find((t) => t.name === cardAction.templateName)
+            template = this.props.botInfo.templates.find((t) => t.name === cardAction.templateName)
             renderedActionArguments = this.state.cardViewerShowOriginal
                 ? cardAction.renderArguments(entityMap, { preserveOptionalNodeWrappingCharacters: true })
                 : cardAction.renderArguments(Util.createEntityMapFromMemories(this.props.entities, this.props.memories), { fallbackToOriginal: true })
@@ -862,7 +864,7 @@ const mapStateToProps = (state: State, ownProps: any) => {
         user: state.user.user,
         entities: state.entities,
         actions: state.actions,
-        templates: state.bot.botInfo.templates
+        botInfo: state.bot.botInfo
     }
 }
 


### PR DESCRIPTION
Depends on these PRs:

Only shows functions that were defined/given.  It will help users associate the each action in the list with the callback code for it better. 
Previously it showed both functions always which might confuse a user if they didn't actually define that function.

**Update: had wrong pictures before**

If we go further it could hide functions that don't define any custom arguments.
Issue here is that it violates easy rule to follow that if I wrote a function it will show up in this list.  Now it might be hidden if it didn't use arguments and confuse them thinking it was not defined.
![image](https://user-images.githubusercontent.com/2856501/55114854-4be81080-50a0-11e9-9800-12b77b8e6c3c.png)


This second view, only hides the logic function if it doesn't define custom arguments. This would make it still usable for the "set entity" case, and less confusing for people who do write render functions that just take things out of memory and don't use arguments:
![image](https://user-images.githubusercontent.com/2856501/55114203-8badf880-509e-11e9-8d8b-7617eb277b3a.png)

Still think it's important to know what value is going in which argument so you know what you can/should do with that argument in code though.