### PR TITLE
fix: ensure dialog has at least one action

### DIFF
--- a/cypress/integration/CreateModels/WaitVsNoWaitActions.spec.js
+++ b/cypress/integration/CreateModels/WaitVsNoWaitActions.spec.js
@@ -32,7 +32,8 @@ describe('CreateModels', () => {
     train.TypeYourMessage('Fish')
     editDialogModal.ClickScoreActionsButton()
     train.SelectAction('Fish just swim.')
-
+    train.SelectAction('Which animal would you like?')
+    
     train.Save()
 
     // Manually EXPORT this to fixtures folder and name it 'z-waitNoWait.cl'

--- a/src/components/modals/TeachSessionModal.tsx
+++ b/src/components/modals/TeachSessionModal.tsx
@@ -764,6 +764,7 @@ class TeachModal extends React.Component<Props, ComponentState> {
         const saveDisable = this.props.teachSession.dialogMode === CLM.DialogMode.Extractor
             || this.props.teachSession.botAPIError !== null
             || this.state.isInitAvailable  // Empty TD
+            || !this.state.hasTerminalAction
         const isLastActivitySelected = this.state.selectedActivityIndex ? this.state.selectedActivityIndex === (this.state.nextActivityIndex - 1) : false
         return (
             <div>


### PR DESCRIPTION
Adds `!this.state.hasTerminalAction` check back to `saveDisable` calculation.

Previously it was allowing dialogs be saved without an action.  This caused bugs: 1966, 1964, 1938.

Seems the variable is named `hasTerminalAction` poorly and should be renamed.  I interpreted it to mean the last activity was a bot action, however it only means the dialog contains at least one action not that it ends in an action.

I tested by creating new teach session and noticing it was always true after clicking the first one.

Ironically Brian had made the change to allow this:
https://github.com/Microsoft/ConversationLearner-UI/pull/836/files#diff-1d6c528b0d20670ee41bc043b5358a25L636

Then later opened a bug about it: 
https://dev.azure.com/dialearn/BLIS/_queries/edit/1938/?triage=true

This seems like a temporary fix to prevent the broken dialogs and bugs where user is stuck with a dialog they can't edit but the larger fix seem to be removing / renaming this variable.

What was the original purpose for this variable?