### PR TITLE
chore: correct API callback examples in help panel

### DIFF
--- a/src/components/ToolTips/ToolTipAPI.tsx
+++ b/src/components/ToolTips/ToolTipAPI.tsx
@@ -78,12 +78,12 @@ const apiWrong =
 const resultAsEntity =
     `cl.AddCallback({
         name: "ResultAsEntity",
-        logic: async (memoryManager : ClientMemoryManager) => {
+        logic: async (memoryManager) => {
             var options = { method: 'GET', uri: 'https://jsonplaceholder.typicode.com/posts/1', json: true }
             const response = await requestpromise(options)
-            memoryManager.Set("RandomMessage", response.body);
+            memoryManager.Set("RandomMessage", response.body.title);
         },
-        render: async (logicResult: any, memoryManager: ReadOnlyClientMemoryManager, ...args: string[]) => {
+        render: async (logicResult, memoryManager) => {
             const value = memoryManager.Get("RandomMessage", ClientMemoryManager.AS_STRING)
             return value || ""
         }
@@ -92,13 +92,13 @@ const resultAsEntity =
 const resultPassed =
     `cl.AddCallback({
         name: "ResultAsLogicResult",
-        logic: async (memoryManager : ClientMemoryManager) => {
+        logic: async (memoryManager) => {
             var options = { method: 'GET', uri: 'https://jsonplaceholder.typicode.com/posts/1', json: true }
             const response = await requestpromise(options)
-            memoryManager.Set("RandomMessage", response.body);
+            return response.body
         },
-        render: async (logicResult: any, memoryManager: ReadOnlyClientMemoryManager, ...args: string[]) => {
-            return logicResult.body
+        render: async (logicResult) => {
+            return \`Title: \${logicResult.title}\`
         }
     })`;
 


### PR DESCRIPTION
Actually uses logicResult in the example that's suppose to demonstrate it.

Fixes the use of the response body to title since the entity was expecting a string.

Also remove types since those are supposed to automatically inferred by typescript and make the example seem more complicated.

![image](https://user-images.githubusercontent.com/2856501/55362504-0441fa00-548f-11e9-8cfe-70da5bdf3641.png)

Fixes ADO#1871

