### PR TITLE
fix: prevent auto adding new end session action if not available

### DIFF
--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -20,6 +20,7 @@ import { FM } from '../../react-intl-messages'
 import AdaptiveCardViewer from './AdaptiveCardViewer/AdaptiveCardViewer'
 import ConfirmCancelModal from './ConfirmCancelModal'
 import './ActionScorer.css'
+import { ActionTypes } from '@conversationlearner/models';
 
 const ACTION_BUTTON = 'action_button'
 const MISSING_ACTION = 'missing_action'
@@ -350,8 +351,13 @@ class ActionScorer extends React.Component<Props, ComponentState> {
         await Util.setStateAsync(this, { actionModalOpen: false })
 
         const newAction = await ((this.props.createActionThunkAsync(this.props.app.appId, action) as any) as Promise<CLM.ActionBase>)
-
-        if (newAction) {
+        if (newAction
+            && (
+                newAction.actionType === ActionTypes.END_SESSION
+                    ? this.props.isEndSessionAvailable
+                    : true
+            )
+        ) {
             // See if new action is available, then take it
             const isAvailable = this.isAvailable(newAction);
             if (isAvailable) {

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -20,7 +20,6 @@ import { FM } from '../../react-intl-messages'
 import AdaptiveCardViewer from './AdaptiveCardViewer/AdaptiveCardViewer'
 import ConfirmCancelModal from './ConfirmCancelModal'
 import './ActionScorer.css'
-import { ActionTypes } from '@conversationlearner/models';
 
 const ACTION_BUTTON = 'action_button'
 const MISSING_ACTION = 'missing_action'
@@ -353,7 +352,7 @@ class ActionScorer extends React.Component<Props, ComponentState> {
         const newAction = await ((this.props.createActionThunkAsync(this.props.app.appId, action) as any) as Promise<CLM.ActionBase>)
         if (newAction
             && (
-                newAction.actionType === ActionTypes.END_SESSION
+                newAction.actionType === CLM.ActionTypes.END_SESSION
                     ? this.props.isEndSessionAvailable
                     : true
             )


### PR DESCRIPTION
Prevents adding duplicate END_SESSION actions.
Also prevents adding END_SESSION when it's not the last action.

Seems like this was used in some places like `isUnscoredActionAvailable` but this relies on an `UnscoredAction` instead of regular `Action` which doesn't have the `reason` attribute.  Could have cased the action and reworked this method but I thought it was more confusing.
