### PR TITLE
chore: remove duplicate help panel text

### DIFF
--- a/src/components/ToolTips/ToolTips.tsx
+++ b/src/components/ToolTips/ToolTips.tsx
@@ -479,7 +479,6 @@ export function getTip(tipType: string) {
 
                     <p>Model performance can be improved by providing examples of alternative ways the user might say the same thing.</p>
                     <p>For example, after the Bot asks: "What is your name?" some alternative inputs might be:</p>
-                    <p>For example, after the Bot asks: "What is your name?" some alternive inputs might be:</p>
                     <ul>
                         <li>I go by Joe</li>
                         <li>Call me Joe</li>


### PR DESCRIPTION
Seems alternative was spelled wrong and somehow the text was duplicated, maybe during a merge it accepted both changes instead of keeping one.

Fixes ADO#1995