### PR TITLE
chore: add end session sort value

### DIFF
--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -310,6 +310,10 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                             const cardAction = new CLM.CardAction(action)
                             return cardAction.templateName
                         }
+                        case CLM.ActionTypes.END_SESSION: {
+                            const sessionAction = new CLM.SessionAction(action)
+                            return sessionAction.renderValue(entityMap, { preserveOptionalNodeWrappingCharacters: true })
+                        }
                         default: {
                             console.warn(`Could not get sort value for unknown action type: ${action.actionType}`)
                             return ''


### PR DESCRIPTION
Was missing an implementation for `END_SESSION` actions.  It should be similar to the `TextAction` since they both use a single payload. Glad we put these warnings in.

Fixes ADO#1999