### PR TITLE
docs: use consistent language around model versions

### DIFF
--- a/src/components/ToolTips/ToolTips.tsx
+++ b/src/components/ToolTips/ToolTips.tsx
@@ -70,8 +70,8 @@ export enum TipType {
     REPLAYERROR_DESC_ENTITY_UNEXPECTED_MULTIVALUE = "REPLAYERROR_DESC_ENTITY_UNEXPECTED_MULTIVALUE",
     REPLAYERROR_DESC_ACTION_UNDEFINED = "REPLAYERROR_DESC_ACTION_UNDEFINED",
 
-    TAG_EDITING = 'tagEditing',
-    TAG_LIVE = 'tagLIve'
+    MODEL_VERSION_EDITING = 'modelVersionEditing',
+    MODEL_VERSION_LIVE = 'modelVersionLIve'
 }
 
 export function onRenderDetailsHeader(detailsHeaderProps: OF.IDetailsHeaderProps, defaultRender: OF.IRenderFunction<OF.IDetailsHeaderProps>) {
@@ -742,10 +742,10 @@ export function getTip(tipType: string) {
                 </div>
             )
 
-        case TipType.TAG_EDITING:
+        case TipType.MODEL_VERSION_EDITING:
             return (<FormattedMessageId id={FM.TOOLTIP_TAG_EDITING} />);
 
-        case TipType.TAG_LIVE:
+        case TipType.MODEL_VERSION_LIVE:
             return (<FormattedMessageId id={FM.TOOLTIP_TAG_LIVE} />);
 
         default:

--- a/src/components/modals/PackageTable.tsx
+++ b/src/components/modals/PackageTable.tsx
@@ -13,6 +13,7 @@ import { injectIntl, InjectedIntlProps } from 'react-intl'
 import { createAppTagThunkAsync } from '../../actions/appActions'
 import PackageCreator from './PackageCreator'
 import * as util from '../../Utils/util'
+import { FM } from '../../react-intl-messages'
 
 interface IRenderableColumn extends OF.IColumn {
     render: (packageReference: PackageReference, component: PackageTable) => React.ReactNode
@@ -96,10 +97,13 @@ class PackageTable extends React.Component<Props, ComponentState> {
             <div>
                 <OF.PrimaryButton
                     onClick={this.onClickNewTag}
-                    ariaDescription='New Tag'
-                    text='New Tag'
+                    ariaDescription={util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSIONS_CREATE)}
+                    text={util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSIONS_CREATE)}
                     iconProps={{ iconName: 'Add' }}
                 />
+                <p>
+                    {util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSIONS_DESCRIPTION)}
+                </p>
                 <PackageCreator
                     open={this.state.isPackageCreatorOpen}
                     onSubmit={this.onSubmitPackageCreator}

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -394,7 +394,13 @@ export enum FM {
     SETTINGS_SAVECHANGES = 'Settings.saveChanges',
     SETTINGS_DISCARD = 'Settings.discard',
     SETTINGS_LOGGINGON_LABEL = 'Settings.loggingon',
-    SETINGS_DELETEISPERMANENT = 'Settings.deleteIsPermanent',
+    SETTINGS_DELETEISPERMANENT = 'Settings.deleteIsPermanent',
+    SETTINGS_LUIS_LINK = 'Settings.luisLink',
+    SETTINGS_MODEL_VERSION_EDITING = 'Settings.modelVersionEditing',
+    SETTINGS_MODEL_VERSION_LIVE = 'Settings.modelVersionLive',
+    SETTINGS_MODEL_VERSIONS_CREATE = 'Settings.modelVersionsCreate',
+    SETTINGS_MODEL_VERSIONS_TITLE = 'Settings.modelVersionsTitle',
+    SETTINGS_MODEL_VERSIONS_DESCRIPTION = 'Settings.modelVersionsDescription',
 
     // Tags and Description
     DIALOGMETADATA_TAGS_LABEL = 'DialogMetadata.Tags.label',
@@ -776,7 +782,13 @@ export default {
         [FM.SETTINGS_SAVECHANGES]: 'Save Changes',
         [FM.SETTINGS_DISCARD]: 'Discard',
         [FM.SETTINGS_LOGGINGON_LABEL]: 'Log Conversations',
-        [FM.SETINGS_DELETEISPERMANENT]: 'Deletion is irreversible.',
+        [FM.SETTINGS_DELETEISPERMANENT]: 'Deletion is irreversible.',
+        [FM.SETTINGS_LUIS_LINK]: 'Go to LUIS',
+        [FM.SETTINGS_MODEL_VERSION_EDITING]: 'Editing Version',
+        [FM.SETTINGS_MODEL_VERSION_LIVE]: 'Live Version',
+        [FM.SETTINGS_MODEL_VERSIONS_CREATE]: 'New Version',
+        [FM.SETTINGS_MODEL_VERSIONS_TITLE]: 'Model Versions',
+        [FM.SETTINGS_MODEL_VERSIONS_DESCRIPTION]: 'Creating a new version will save a snapshot of the currently active model. You can promote this version to "live" for use in deployed bots while you continue to edit the latest version.  You can also recall these snapshots at any point in time to test previous bot behavior.',
 
         // ToolTip
         [FM.TOOLTIP_ACTION_API]: 'APIs exposed in the running Bot of the form:',

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -29,8 +29,8 @@ interface ComponentState {
     localeVal: string
     appIdVal: string
     appNameVal: string
-    selectedEditingTagOptionKey: string | number | undefined,
-    selectedLiveTagOptionKey: string | number | undefined,
+    selectedEditingVersionOptionKey: string | number | undefined,
+    selectedLiveVersionOptionKey: string | number | undefined,
     markdownVal: string
     videoVal: string
     edited: boolean
@@ -52,8 +52,8 @@ class Settings extends React.Component<Props, ComponentState> {
             localeVal: '',
             appIdVal: '',
             appNameVal: '',
-            selectedEditingTagOptionKey: undefined,
-            selectedLiveTagOptionKey: undefined,
+            selectedEditingVersionOptionKey: undefined,
+            selectedLiveVersionOptionKey: undefined,
             markdownVal: '',
             videoVal: '',
             edited: false,
@@ -73,8 +73,8 @@ class Settings extends React.Component<Props, ComponentState> {
             localeVal: app.locale,
             appIdVal: app.appId,
             appNameVal: app.appName,
-            selectedEditingTagOptionKey: this.props.editingPackageId,
-            selectedLiveTagOptionKey: app.livePackageId,
+            selectedEditingVersionOptionKey: this.props.editingPackageId,
+            selectedLiveVersionOptionKey: app.livePackageId,
             markdownVal: (app.metadata && app.metadata.markdown) ? app.metadata.markdown : '',
             videoVal: (app.metadata && app.metadata.video) ? app.metadata.video : '',
             botFrameworkAppsVal: app.metadata.botFrameworkApps,
@@ -264,17 +264,17 @@ class Settings extends React.Component<Props, ComponentState> {
         })
     }
 
-    onChangedEditingTag = (editingOption: OF.IDropdownOption) => {
+    onChangedEditingVersion = (editingOption: OF.IDropdownOption) => {
         this.props.editAppEditingTagThunkAsync(this.props.app.appId, editingOption.key as string)
         this.setState({
-            selectedEditingTagOptionKey: editingOption.key,
+            selectedEditingVersionOptionKey: editingOption.key,
         })
     }
 
-    onChangedLiveTag = (liveOption: OF.IDropdownOption) => {
+    onChangedLiveVersion = (liveOption: OF.IDropdownOption) => {
         this.props.editAppLiveTagThunkAsync(this.props.app, liveOption.key as string)
         this.setState({
-            selectedLiveTagOptionKey: liveOption.key,
+            selectedLiveVersionOptionKey: liveOption.key,
         })
     }
 
@@ -317,7 +317,7 @@ class Settings extends React.Component<Props, ComponentState> {
     getDeleteDialogBoxText = (modelName: string) => {
         return (
             <div>
-                <h1 className={`${OF.FontClassNames.xxLarge} cl-text--error`} style={{ fontWeight: OF.FontWeights.semibold }}>{Util.formatMessageId(this.props.intl, FM.SETINGS_DELETEISPERMANENT)}</h1>
+                <h1 className={`${OF.FontClassNames.xxLarge} cl-text--error`} style={{ fontWeight: OF.FontWeights.semibold }}>{Util.formatMessageId(this.props.intl, FM.SETTINGS_DELETEISPERMANENT)}</h1>
                 <p>Confirm permanent deletion of the <strong>{modelName}</strong> Model by entering its name.</p>
             </div>
         )
@@ -400,33 +400,33 @@ class Settings extends React.Component<Props, ComponentState> {
                                 target="_blank">
                                 <OF.DefaultButton
                                     iconProps={{ iconName: "OpenInNewWindow" }}
-                                    ariaDescription="Go to LUIS"
-                                    text="Go to LUIS"
+                                    ariaDescription={Util.formatMessageId(this.props.intl, FM.SETTINGS_LUIS_LINK)}
+                                    text={Util.formatMessageId(this.props.intl, FM.SETTINGS_LUIS_LINK)}
                                 />
                             </a>
                         </div>
                     </div>
                     <div className="cl-command-bar">
                         <TC.Dropdown
-                            label="Editing Tag"
+                            label={Util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSION_EDITING)}
                             options={packageOptions}
-                            onChanged={acionTypeOption => this.onChangedEditingTag(acionTypeOption)}
-                            selectedKey={this.state.selectedEditingTagOptionKey}
-                            tipType={ToolTip.TipType.TAG_EDITING}
+                            onChanged={this.onChangedEditingVersion}
+                            selectedKey={this.state.selectedEditingVersionOptionKey}
+                            tipType={ToolTip.TipType.MODEL_VERSION_EDITING}
                         />
                         <TC.Dropdown
-                            label="Live Tag"
+                            label={Util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSION_LIVE)}
                             options={packageOptions}
-                            onChanged={acionTypeOption => this.onChangedLiveTag(acionTypeOption)}
-                            selectedKey={this.state.selectedLiveTagOptionKey}
-                            tipType={ToolTip.TipType.TAG_LIVE}
+                            onChanged={this.onChangedLiveVersion}
+                            selectedKey={this.state.selectedLiveVersionOptionKey}
+                            tipType={ToolTip.TipType.MODEL_VERSION_LIVE}
                         />
                     </div>
 
                     <Expando
                         className={'cl-settings-container-header'}
                         isOpen={this.state.isPackageExpandoOpen}
-                        text="Version Tags"
+                        text="Model Versions"
                         onToggle={() => this.setState({ isPackageExpandoOpen: !this.state.isPackageExpandoOpen })}
                     />
                     {this.state.isPackageExpandoOpen &&


### PR DESCRIPTION
We introduced tags on dialogs which caused rename of model tags to model versions, but didn't rename everything related.

Here is new picture:
![image](https://user-images.githubusercontent.com/2856501/55579025-2b393f80-56cc-11e9-81f1-f0648fcbc096.png)

Think it needed a description to show people use cases and why they might want to use versioning.  Looking for feedback.
Does creating a snapshot always use the live version?
Also, should we change the words "Editing Version" since you can't edit version?