### PR TITLE
fix: entity picker reset bug

### DIFF
--- a/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
@@ -49,10 +49,9 @@ interface State {
     matchedOptions: MatchedOption<IOption>[]
 }
 
-const initialState: Readonly<State> = {
+const initialState: Readonly<Pick<State, "highlightIndex" | "searchText">> = {
     highlightIndex: 0,
-    searchText: '',
-    matchedOptions: []
+    searchText: ''
 }
 
 type IndexFunction = (x: number, limit?: number) => number
@@ -65,7 +64,6 @@ export default class EntityPickerContainer extends React.Component<Props, State>
     defaultMatchedOptions: MatchedOption<IOption>[]
     fuse: Fuse
     element: HTMLElement
-    resultsElement: HTMLDivElement | null
 
     constructor(props: Props) {
         super(props)
@@ -91,8 +89,7 @@ export default class EntityPickerContainer extends React.Component<Props, State>
             && nextProps.isVisible === true)) {
 
             this.setState({
-                searchText: '',
-                highlightIndex: 0
+                ...initialState
             })
 
             if (nextProps.options.length !== this.props.options.length) {


### PR DESCRIPTION
Removes the `matchedOptions` from the initial state so it doesn't get reset.

Will probably refactor this mess after release, but this should be temporary fix.
Alternate is to revert both the previous commits and put it back to original. Basically had a bug in the component since the beginning where it kept mutating `initialState` which is supposed to be static as the initial state for the component so even though we were resetting it by setting `initialState` it wasn't resetting `matchedOptions` and when you could look at the definition of `initialState` and see it's an empty array but it's actually not at runtime. Very confusing.