### PR TITLE
fix: reset matched options to default when opened

### DIFF
--- a/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
+++ b/src/components/ExtractorResponseEditor/EntityPickerContainer.tsx
@@ -89,7 +89,8 @@ export default class EntityPickerContainer extends React.Component<Props, State>
             && nextProps.isVisible === true)) {
 
             this.setState({
-                ...initialState
+                ...initialState,
+                matchedOptions: this.defaultMatchedOptions
             })
 
             if (nextProps.options.length !== this.props.options.length) {


### PR DESCRIPTION
Previously did work not to reset the options so they don't get set back to an initial empty array and but forgot about the case where we do need to reset them back to default options list when it's opened.