### PR TITLE
chore: show bot responses on default description

### DIFF
--- a/src/Utils/dialogUtils.tsx
+++ b/src/Utils/dialogUtils.tsx
@@ -153,10 +153,12 @@ export function dialogSampleInput(dialog: CLM.TrainDialog | CLM.LogDialog, actio
             (round.extractorStep as CLM.TrainExtractorStep).textVariations[0].text;
 
         phrases.push(userInput)
+        length = length + userInput.length
 
         // Add bot response
-        const scorerStep = round.scorerSteps[0]
-        if (scorerStep) {
+        let scorerStepIndex = 0
+        while (scorerStepIndex < round.scorerSteps.length && length < MAX_SAMPLE_INPUT_LENGTH) {
+            const scorerStep = round.scorerSteps[scorerStepIndex]
             const actionId =
                 (scorerStep as CLM.LogScorerStep).predictedAction ||
                 (scorerStep as CLM.TrainScorerStep).labelAction;
@@ -166,10 +168,11 @@ export function dialogSampleInput(dialog: CLM.TrainDialog | CLM.LogDialog, actio
                 const textAction = new CLM.TextAction(action)
                 const botResponse = textAction.renderValue(getDefaultEntityMap(entities))
                 phrases.push(botResponse)
+                length = length + botResponse.length 
             }
+            scorerStepIndex = scorerStepIndex + 1
         }
 
-        length = length + userInput.length
         roundIndex = roundIndex + 1
     }
     return phrases.join(" ◾️ ").slice(0, MAX_SAMPLE_INPUT_LENGTH)

--- a/src/components/modals/MergeModal.tsx
+++ b/src/components/modals/MergeModal.tsx
@@ -17,9 +17,11 @@ interface ReceivedProps {
     onCancel: Function
     onMerge: (description: string, tags: string[]) => void
     open: boolean
-    savedTrainDialog: CLM.TrainDialog | null,
-    existingTrainDialog: CLM.TrainDialog | null,
+    savedTrainDialog: CLM.TrainDialog | null
+    existingTrainDialog: CLM.TrainDialog | null
     allUniqueTags: string[]
+    actions: CLM.ActionBase[]
+    entities: CLM.EntityBase[]
 }
 
 interface ComponentState {
@@ -45,8 +47,8 @@ class MergeModal extends React.Component<Props, ComponentState> {
             if (this.props.savedTrainDialog && this.props.existingTrainDialog) {
 
                 const userInput = DialogUtils.isTrainDialogLonger(this.props.savedTrainDialog, this.props.existingTrainDialog)
-                    ? DialogUtils.dialogSampleInput(this.props.savedTrainDialog)
-                    : DialogUtils.dialogSampleInput(this.props.existingTrainDialog)
+                    ? DialogUtils.dialogSampleInput(this.props.savedTrainDialog, this.props.actions, this.props.entities)
+                    : DialogUtils.dialogSampleInput(this.props.existingTrainDialog, this.props.actions, this.props.entities)
 
                 this.setState({
                     description: DialogUtils.mergeTrainDialogDescription(this.props.savedTrainDialog, this.props.existingTrainDialog),
@@ -129,7 +131,7 @@ class MergeModal extends React.Component<Props, ComponentState> {
                     <div className="cl-merge-box cl-merge-box--readonly">
                         <DialogMetadata
                                 description={this.props.savedTrainDialog.description}
-                                userInput={DialogUtils.dialogSampleInput(this.props.savedTrainDialog)}
+                                userInput={DialogUtils.dialogSampleInput(this.props.savedTrainDialog, this.props.actions, this.props.entities)}
                                 tags={this.props.savedTrainDialog.tags}
                                 allUniqueTags={[]}
                                 readOnly={true}
@@ -141,7 +143,7 @@ class MergeModal extends React.Component<Props, ComponentState> {
                     <div className="cl-merge-box cl-merge-box--readonly">
                         <DialogMetadata
                                 description={this.props.existingTrainDialog.description}
-                                userInput={DialogUtils.dialogSampleInput(this.props.existingTrainDialog)}
+                                userInput={DialogUtils.dialogSampleInput(this.props.existingTrainDialog, this.props.actions, this.props.entities)}
                                 tags={this.props.existingTrainDialog.tags}
                                 allUniqueTags={[]}
                                 readOnly={true}

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -83,11 +83,10 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
             maxWidth: 1500,
             isResizable: true,
             render: (trainDialog, component) => {
-
                 return <>
                     <span className={OF.FontClassNames.mediumPlus} data-testid="log-dialogs-first-input">
                         <span data-testid="train-dialogs-description">
-                            {DialogUtils.dialogSampleInput(trainDialog)}
+                            {DialogUtils.dialogSampleInput(trainDialog, component.props.actions, component.props.entities)}
                         </span>
                     </span>
                 </>
@@ -998,6 +997,8 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                     savedTrainDialog={this.state.mergeNewTrainDialog}
                     existingTrainDialog={this.state.mergeExistingTrainDialog}
                     allUniqueTags={this.props.allUniqueTags}
+                    actions={this.props.actions}
+                    entities={this.props.entities}
                 />
                 <EditDialogModal
                     data-testid="train-dialog-modal"

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -64,7 +64,7 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                             />
                         }
                         <span data-testid="train-dialogs-description">
-                            {DialogUtils.trainDialogRenderDescription(trainDialog)}
+                            {DialogUtils.trainDialogRenderDescription(trainDialog, component.props.actions, component.props.entities)}
                         </span>
                     </span>
                     {/* TODO: Keep firstInput and lastInput available in DOM until tests are upgraded */}
@@ -1133,6 +1133,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                     savedTrainDialog={this.state.mergeNewTrainDialog}
                     existingTrainDialog={this.state.mergeExistingTrainDialog}
                     allUniqueTags={this.props.allUniqueTags}
+                    actions={this.props.actions}
+                    entities={this.props.entities}
                 />
                 <EditDialogModal
                     data-testid="train-dialog-modal"


### PR DESCRIPTION
Shows bot responses in between user input so the sequence is more logical and linear.

Need to decide if this is better or not. Could argue that the bot responses are known to the trainers and don't as much value but I think it helps them make sense of the dialog when it's more complicated and they can't assume all the transitions in their head.

See: https://dev.azure.com/dialearn/BLIS/_queries/edit/2005/?triage=true

Currently image only shows text actions, but we could show the name of the code or card callbacks as well.

Before:
![image](https://user-images.githubusercontent.com/2856501/55842570-05a3a000-5ae9-11e9-8355-f8c72b973482.png)

After:
![image](https://user-images.githubusercontent.com/2856501/55892175-abe3ba00-5b6a-11e9-905a-2db02ca576d3.png)

