### PR TITLE
build: enable 2.1 and pipelines to reduce redundant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -88,7 +88,6 @@ jobs:
           path: results
       
 workflows:
-  version: 2
   build:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,10 @@ jobs:
 
       # Download and cache dependencies
       - restore_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-          key: v1-deps-{{ .Branch }}
-          key: v1-deps
+          keys:
+            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1-deps-{{ .Branch }}
+            - v1-deps
 
       - run: node --version
       - run: npm --version
@@ -40,9 +41,10 @@ jobs:
 
       # Download and cache dependencies
       - restore_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-          key: v1-deps-{{ .Branch }}
-          key: v1-deps
+          keys:
+            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1-deps-{{ .Branch }}
+            - v1-deps
 
       - run: node --version
       - run: npm --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           path: results
       
 workflows:
-  build:
+  build-test:
     jobs:
       - build
       - test:


### PR DESCRIPTION
In order to enable the ability to cancel the redundant builds we needed to be on 2.1