### PR TITLE
fix: settings.botPort was undefined

### DIFF
--- a/src/components/Webchat.tsx
+++ b/src/components/Webchat.tsx
@@ -251,6 +251,10 @@ const mapStateToProps = (state: State, ownProps: any) => {
         throw new Error(`You attempted to render WebChat but the user was not defined. This is likely a problem with higher level component. Please open an issue.`)
     }
 
+    if (!state.settings.botPort) {
+        throw new Error(`Bot port is not set. This should not be possible. Please open an issue.`)
+    }
+
     return {
         settings: state.settings,
         user: state.user.user,

--- a/src/reducers/settingsReducer.ts
+++ b/src/reducers/settingsReducer.ts
@@ -8,7 +8,7 @@ import { Reducer } from 'redux'
 import produce from 'immer'
 
 // TODO: Consolidate calculation, needs to match reduxStore
-const botPort = ports.defaultUiPort = ports.urlBotPort
+const botPort = ports.defaultUiPort === ports.urlBotPort
     ? ports.defaultBotPort
     : ports.urlBotPort
 

--- a/src/reduxStore.ts
+++ b/src/reduxStore.ts
@@ -25,7 +25,9 @@ export const createReduxStore = (): Store<State> => {
     else {
         if (ports.defaultUiPort === ports.urlBotPort) {
             ClientFactory.setPort(ports.defaultBotPort)
-            state.settings.botPort = ports.defaultBotPort
+            if (settings) {
+                state.settings.botPort = settings.customPort
+            }
         }
     }
 

--- a/src/reduxStore.ts
+++ b/src/reduxStore.ts
@@ -12,22 +12,25 @@ import * as ClientFactory from './services/clientFactory'
 
 export const createReduxStore = (): Store<State> => {
     const persistedState = localStorage.load<Partial<State>>()
+    const state = persistedState as State
 
     const settings = persistedState && persistedState.settings
     // If user chose to use custom port update the client to use this port
     // Need this since the subscribe below only happens on store change not initialization
     if (settings && settings.useCustomPort) {
         ClientFactory.setPort(settings.customPort)
+        state.settings.botPort = settings.customPort
     }
     // TODO: Could move initialization to client, but try to keep on one place
     else {
-        if (ports.defaultUiPort = ports.urlBotPort) {
+        if (ports.defaultUiPort === ports.urlBotPort) {
             ClientFactory.setPort(ports.defaultBotPort)
+            state.settings.botPort = ports.defaultBotPort
         }
     }
 
     const store = createStore(rootReducer,
-        persistedState as State,
+        state,
         applyMiddleware(
             thunk
         )
@@ -43,7 +46,7 @@ export const createReduxStore = (): Store<State> => {
 
         const stateToPersist = {
             settings: {
-                userCustomPort: state.settings.useCustomPort,
+                useCustomPort: state.settings.useCustomPort,
                 customPort: state.settings.customPort,
             }
         }

--- a/src/types/const.ts
+++ b/src/types/const.ts
@@ -22,7 +22,7 @@ export enum SelectionType {
 
 export const CL_IMPORT_ID = '9c110735ea8b440d8f31c5c68ffb767d'
 
-export const ports = {
+export const ports: Readonly<any> = {
     urlBotPort: parseInt(location.port, 10),
     defaultUiPort: 3000,
     defaultBotPort: 3978,


### PR DESCRIPTION
There were many different fixes here.  Some blatant typo errors and others initialization and store / storage errors.

In summary, previous changes stopped storing the `botPort` but left the initialization of the `reduxStore` to use this object which no longer had `botPort`.  This meant `botPort` was undefined when being used by `Webcat` which explains why it never set the conversation reference because it never connected to the SDK and failed silently.

This now adds protection in Webchat so it throws an error if `botPort` is not set instead of failing silently.

Originally we were storing the `botPort` in localStorage and always sending requests to that port.  When we changed the UI to run on the bot and wanted it to communicate with this port from the URL we introduced some complexity as we now had to decide when to use the port in the url or the port in storage. We also wanted to make it work by default for development and testing as it did before.

The trouble is reproducing this reliably as the initial PR passed tests which made me think it worked.
https://circleci.com/gh/Microsoft/ConversationLearner-UI/2628
