### PR TITLE
feat: allow creating any entities during extraction

### DIFF
--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -203,7 +203,14 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
             }
         }
 
-        let builtInTypeFilter = null
+        /**
+         * If the text you select has a prebuilt entity detected within same region
+         * it opens the entity creator modal with that prebuilt type pre-selected to help prevent mismatches.
+         * This means `entityTypeFilter` and `builtInTypeFilter` do need to remain a string since the pre-built types/names are not EntityTypes
+         * 
+         * TODO: In future look at adding explicit resolver preset parameter and remove casting
+         */
+        let builtInTypeFilter: string | null = null
         const selectedNodes: any[] = value.inlines.toJS()
         if (selectedNodes.length > 0 && selectedNodes.every(n => n.type === NodeType.TokenNodeType)) {
             const startIndex = selectedNodes[0].data.startIndex

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -34,7 +34,7 @@ interface ComponentState {
     isPendingSubmit: boolean
     pendingVariationChange: boolean
     entityModalOpen: boolean
-    entityTypeFilter: string
+    entityTypeFilter: string | null
     warningOpen: boolean
     // Handle saves after round change
     savedExtractResponses: CLM.ExtractResponse[]
@@ -144,7 +144,15 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
     onNewEntity(entityTypeFilter: string) {
         this.setState({
             entityModalOpen: true,
-            entityTypeFilter: entityTypeFilter
+            entityTypeFilter
+        })
+    }
+    
+    @OF.autobind
+    onClickCreateEntity(): void {
+        this.setState({
+            entityModalOpen: true,
+            entityTypeFilter: null,
         })
     }
 
@@ -573,6 +581,13 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                             componentRef={(ref: any) => { this.doneExtractingButton = ref }}
                         />
                     }
+
+                    <OF.DefaultButton
+                        onClick={this.onClickCreateEntity}
+                        ariaDescription="Create Entity"
+                        text="Create Entity"
+                        iconProps={{ iconName: 'Add' }}
+                    />
                 </div>
 
                 <div className="cl-dialog-admin__dialogs">


### PR DESCRIPTION
Adds "Create Entity" button to Extractor to allow creating ENUM entities during creation of dialog.

Also adds comment clarifying used of `entityTypeFilter` and `builtInTypeFilter`

![image](https://user-images.githubusercontent.com/2856501/56989871-56d30c80-6b48-11e9-9a1e-b6c119b376cd.png)
