### PR TITLE
chore: restructure app versions on settings

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -606,6 +606,7 @@ i[data-icon-name="Edit"]:hover {
   display: grid;
   grid-gap: 1em;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  align-items: end;
 }
 
 .cl-spinner

--- a/src/components/modals/PackageTable.tsx
+++ b/src/components/modals/PackageTable.tsx
@@ -10,10 +10,7 @@ import { State } from '../../types'
 import * as OF from 'office-ui-fabric-react'
 import { AppBase, PackageReference } from '@conversationlearner/models'
 import { injectIntl, InjectedIntlProps } from 'react-intl'
-import { createAppTagThunkAsync } from '../../actions/appActions'
-import PackageCreator from './PackageCreator'
 import * as util from '../../Utils/util'
-import { FM } from '../../react-intl-messages'
 
 interface IRenderableColumn extends OF.IColumn {
     render: (packageReference: PackageReference, component: PackageTable) => React.ReactNode
@@ -53,7 +50,6 @@ const columns: IRenderableColumn[] = [
 
 interface ComponentState {
     columns: IRenderableColumn[]
-    isPackageCreatorOpen: boolean
 }
 
 class PackageTable extends React.Component<Props, ComponentState> {
@@ -61,7 +57,6 @@ class PackageTable extends React.Component<Props, ComponentState> {
         super(p);
         this.state = {
             columns: columns,
-            isPackageCreatorOpen: false
         }
     }
 
@@ -69,67 +64,26 @@ class PackageTable extends React.Component<Props, ComponentState> {
         return column.render(packageReference, this)
     }
 
-    @OF.autobind
-    onClickNewTag() {
-        this.setState({
-            isPackageCreatorOpen: true
-        })
-    }
-
-    @OF.autobind
-    onSubmitPackageCreator(tagName: string, setLive: boolean) {
-        this.props.createAppTagThunkAsync(this.props.app.appId, tagName, setLive)
-        this.setState({
-            isPackageCreatorOpen: false
-        })
-    }
-
-    @OF.autobind
-    onCancelPackageCreator() {
-        this.setState({
-            isPackageCreatorOpen: false
-        })
-    }
-
     render() {
         const packageReferences = util.packageReferences(this.props.app);
         return (
-            <div>
-                <OF.PrimaryButton
-                    onClick={this.onClickNewTag}
-                    ariaDescription={util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSIONS_CREATE)}
-                    text={util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSIONS_CREATE)}
-                    iconProps={{ iconName: 'Add' }}
-                />
-                <p>
-                    {util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSIONS_DESCRIPTION)}
-                </p>
-                <PackageCreator
-                    open={this.state.isPackageCreatorOpen}
-                    onSubmit={this.onSubmitPackageCreator}
-                    onCancel={this.onCancelPackageCreator}
-                    packageReferences={this.props.app.packageVersions}
-                />
-                <OF.DetailsList
-                    className={OF.FontClassNames.mediumPlus}
-                    items={packageReferences}
-                    columns={this.state.columns}
-                    onRenderItemColumn={(packageReference, i, column: IRenderableColumn) => column.render(packageReference, this)}
-                    checkboxVisibility={OF.CheckboxVisibility.hidden}
-                    constrainMode={OF.ConstrainMode.horizontalConstrained}
-                />
-            </div>
+            <OF.DetailsList
+                className={OF.FontClassNames.mediumPlus}
+                items={packageReferences}
+                columns={this.state.columns}
+                onRenderItemColumn={(packageReference, i, column: IRenderableColumn) => column.render(packageReference, this)}
+                checkboxVisibility={OF.CheckboxVisibility.hidden}
+                constrainMode={OF.ConstrainMode.horizontalConstrained}
+            />
         )
     }
 }
 const mapDispatchToProps = (dispatch: any) => {
     return bindActionCreators({
-        createAppTagThunkAsync
     }, dispatch);
 }
 const mapStateToProps = (state: State, ownProps: any) => {
     return {
-        user: state.user
     }
 }
 

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -10,12 +10,16 @@ import EntityCreatorEditor from './EntityCreatorEditor'
 import EditDialogModal from './EditDialogModal'
 import EditDialogAdmin from './EditDialogAdmin'
 import ErrorPanel from './ErrorPanel'
+import ErrorInjectionEditor from './ErrorInjectionEditor'
 import Expando from './Expando'
 import LogConversionConflictModal from './LogConversionConflictModal'
 import MergeModal from './MergeModal'
 import SpinnerWindow from './SpinnerWindow'
 import TeachSessionModal from './TeachSessionModal'
 import TutorialImporterModal from './TutorialImporter'
+import TextboxRestrictable from './TextboxRestrictable'
+import PackageCreator from './PackageCreator'
+import PackageTable from './PackageTable'
 
 // What is being edited
 export enum EditDialogType {
@@ -45,10 +49,14 @@ export {
     EditDialogAdmin,
     EditDialogModal,
     ErrorPanel,
+    ErrorInjectionEditor,
     Expando,
     LogConversionConflictModal,
     MergeModal,
+    PackageCreator,
+    PackageTable,
     SpinnerWindow,
     TeachSessionModal,
     TutorialImporterModal,
+    TextboxRestrictable,
 }

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -813,7 +813,7 @@ export default {
         [FM.SETTINGS_MODEL_VERSION_LIVE]: 'Live Version',
         [FM.SETTINGS_MODEL_VERSIONS_CREATE]: 'New Version',
         [FM.SETTINGS_MODEL_VERSIONS_TITLE]: 'Model Versions',
-        [FM.SETTINGS_MODEL_VERSIONS_DESCRIPTION]: 'Creating a new version will save a snapshot of the currently active model. You can promote this version to "live" for use in deployed bots while you continue to edit the latest version.  You can also recall these snapshots at any point in time to test previous bot behavior.',
+        [FM.SETTINGS_MODEL_VERSIONS_DESCRIPTION]: 'Creating a new version will save a snapshot of the currently active model. You can promote this version to "live" for use in deployed bots while you continue to edit the latest version.  You can also recall these snapshots at any point in time.',
 
         // ToolTip
         [FM.TOOLTIP_ACTION_API]: 'APIs exposed in the running Bot of the form:',

--- a/src/routes/Apps/App/Settings.css
+++ b/src/routes/Apps/App/Settings.css
@@ -10,7 +10,12 @@
     grid-gap: 1em 0;
 }
 
+.cl-settings-header {
+    color: black;
+    padding: 1em 0;
+    border-bottom: 1px solid rgba(0,0,0,0.25);
+}
+
 .cl-settings-container-header {
     font-weight: bold;
-    border-bottom: 1px solid rgba(0,0,0,0.25);
 }


### PR DESCRIPTION
Given the importance of versioning I wanted to see how it would look with different design that increases information and discovery. The current design has creation button and version description hidden which could lead users to avoid using it or knowing how to create one.

Making version creation button visible by default is probably the most important change.

Adds new header for "versions" section.
Removes the border from bottom header since that wasn't the "start" of the section but I could add it back.

![http://g.recordit.co/Qi5zSVKWAv.gif](http://g.recordit.co/Qi5zSVKWAv.gif)