### PR TITLE
fix: bot port undefined

### DIFF
--- a/src/reducers/settingsReducer.ts
+++ b/src/reducers/settingsReducer.ts
@@ -8,12 +8,14 @@ import { Reducer } from 'redux'
 import produce from 'immer'
 
 // TODO: Consolidate calculation, needs to match reduxStore
-const botPort = ports.defaultUiPort === ports.urlBotPort
+const useCustomPort = ports.defaultUiPort === ports.urlBotPort
+const botPort = useCustomPort
     ? ports.defaultBotPort
     : ports.urlBotPort
 
-const initialState: SettingsState = {
-    useCustomPort: false,
+
+export const initialState: SettingsState = {
+    useCustomPort,
     botPort,
     customPort: ports.defaultBotPort,
 }


### PR DESCRIPTION
Make the bot port settings more robust to corrupt objects. Still not quite sure how it was getting set incorrect after a browser refresh or open/close, but this hopefully ensures it's always correct by setting it to something acceptable if it's not.