### PR TITLE
 fix: prevent expansion of enum entities when opening

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -260,7 +260,7 @@ interface ComponentState {
     newOrEditedAction: CLM.ActionBase | null
     selectedActionTypeOptionKey: string | number
     availableExpectedEntityTags: OF.ITag[]
-    conditionalTags: OF.ITag[]
+    availableConditionalTags: OF.ITag[]
     expectedEntityTags: OF.ITag[]
     requiredEntityTagsFromPayload: OF.ITag[]
     requiredEntityTags: IConditionalTag[]
@@ -297,7 +297,7 @@ const initialState: Readonly<ComponentState> = {
     newOrEditedAction: null,
     selectedActionTypeOptionKey: actionTypeOptions[0].key,
     availableExpectedEntityTags: [],
-    conditionalTags: [],
+    availableConditionalTags: [],
     expectedEntityTags: [],
     requiredEntityTagsFromPayload: [],
     requiredEntityTags: [],
@@ -331,7 +331,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
             apiOptions,
             cardOptions,
             availableExpectedEntityTags: availableExpectedEntityTags(entities),
-            conditionalTags: conditionalEntityTags(entities),
+            availableConditionalTags: conditionalEntityTags(entities),
             isEditing: !!this.props.action
         }
     }
@@ -351,7 +351,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                     nextState = {
                         ...nextState,
                         availableExpectedEntityTags: availableExpectedEntityTags(nextProps.entities),
-                        conditionalTags: conditionalEntityTags(nextProps.entities),
+                        availableConditionalTags: conditionalEntityTags(nextProps.entities),
                     }
                 }
 
@@ -1046,7 +1046,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
     onResolveRequiredEntityTags = (filterText: string, selectedTags: OF.ITag[]): OF.ITag[] => {
         return getSuggestedTags(
             filterText,
-            this.state.conditionalTags,
+            this.state.availableConditionalTags,
             [...selectedTags, ...this.state.requiredEntityTagsFromPayload, ...this.state.negativeEntityTags, ...this.state.expectedEntityTags],
             this.state.requiredEntityTags
         )
@@ -1073,7 +1073,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
     onResolveNegativeEntityTags = (filterText: string, selectedTags: OF.ITag[]): OF.ITag[] => {
         return getSuggestedTags(
             filterText,
-            this.state.conditionalTags,
+            this.state.availableConditionalTags,
             [...selectedTags, ...this.state.requiredEntityTagsFromPayload, ...this.state.requiredEntityTags]
         )
     }


### PR DESCRIPTION
Previously the enum entities were always expanded into their conditions.

This meant when you opened an item that used the enum entity in the payload to display it's value it would still expand set these as the initial state of the picker.

![image](https://user-images.githubusercontent.com/2856501/58659999-2d3d0a80-82d9-11e9-916f-a893e7f49161.png)

This was further complicated because if you edited and resaved the action it would then persist these conditions to the server which are duplicated and mutually exclusive.

This now prevents expansion but there are still other issues with showing mutually exclusive or showing options that should have no effect.