### PR TITLE
fix: upgrade axios to 0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2613,12 +2613,27 @@
       "dev": true
     },
     "axios": {
-      "version": "0.16.2",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
-      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "^1.2.3",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
       }
     },
     "babel-code-frame": {
@@ -6695,7 +6710,7 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
@@ -17135,7 +17150,7 @@
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "resolved": "http://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "requires": {
         "punycode": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@conversationlearner/webchat": "0.145.0",
     "@cypress/webpack-preprocessor": "4.0.3",
     "adaptivecards": "1.0.0",
-    "axios": "^0.16.2",
+    "axios": "^0.19.0",
     "botframework-directlinejs": "^0.9.17",
     "fast-json-stable-stringify": "2.0.0",
     "file-saver": "^1.3.8",


### PR DESCRIPTION
Been watching this one for a while, they finally merged a fix! 

https://nvd.nist.gov/vuln/detail/CVE-2019-10742
https://github.com/axios/axios/pull/1485

We use another package in the SDK which depends on axios so will likely have to update that one when a fix is published.

This one wasn't caught by `npm audit` but there are other similar suggested changes. Will have to understand more about the `npm audit` suggested fixes and maybe submit those in different PR.
