### PR TITLE
test: prep for smoke tests, separate UI changes

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl": "http://localhost:3000",
   "projectId": "so64kq",
   "reporter": "mocha-multi-reporters",
   "requestTimeout": 20000,

--- a/cypress/integration/actionDeletion.spec.ts
+++ b/cypress/integration/actionDeletion.spec.ts
@@ -28,7 +28,7 @@ describe('Action Deletion', () => {
     }
 
     before(() => {
-        cy.visit(constants.baseUrl)
+        cy.visit('/')
         util.importModel(testData.modelName, testData.modelFile)
     })
 

--- a/cypress/integration/actionModal.spec.ts
+++ b/cypress/integration/actionModal.spec.ts
@@ -16,7 +16,7 @@ describe('action modal', () => {
     }
 
     before(() => {
-        cy.visit(constants.baseUrl)
+        cy.visit('/')
         util.importModel(testData.modelName, testData.modelFile)
         cy.get(s.model.buttonNavActions)
             .click()

--- a/cypress/integration/descriptionAndTags.spec.ts
+++ b/cypress/integration/descriptionAndTags.spec.ts
@@ -452,7 +452,7 @@ describe('Description and Tags', () => {
 
             cy.wait(['@getLogDialogs'])
 
-            cy.get(s.logDialogs.firstInput)
+            cy.get(s.logDialogs.description)
                 .contains(testData.input)
                 .click()
 

--- a/cypress/integration/entityConflicts.spec.ts
+++ b/cypress/integration/entityConflicts.spec.ts
@@ -119,7 +119,7 @@ describe('Entity Conflicts', () => {
             })
 
             it('clicking Save As Train dialog should show conflict modal', () => {
-                cy.get(s.logDialogs.firstInput)
+                cy.get(s.logDialogs.description)
                     .contains(testData.userInput1)
                     .click()
 
@@ -186,7 +186,7 @@ describe('Entity Conflicts', () => {
                     cy.get(s.mergeModal.buttonSaveAsIs)
                         .click()
 
-                    cy.get(s.logDialogs.firstInput)
+                    cy.get(s.logDialogs.description)
                         .should('have.length', 3)
                 })
             })
@@ -195,7 +195,7 @@ describe('Entity Conflicts', () => {
         describe('insert operations', () => {
             describe('insert user input', () => {
                 it('should show log conversion conflict modal', () => {
-                    cy.get(s.logDialogs.firstInput)
+                    cy.get(s.logDialogs.description)
                         .contains(testData.userInput1)
                         .click()
 
@@ -208,7 +208,7 @@ describe('Entity Conflicts', () => {
 
             describe('insert bot action', () => {
                 it('should show log conversion conflict modal', () => {
-                    cy.get(s.logDialogs.firstInput)
+                    cy.get(s.logDialogs.description)
                         .contains(testData.userInput1)
                         .click()
 
@@ -251,7 +251,7 @@ describe('Entity Conflicts', () => {
 
         describe('continuing the dialog', () => {
             it('should show log conversion conflict modal', () => {
-                cy.get(s.logDialogs.firstInput)
+                cy.get(s.logDialogs.description)
                     .contains(testData.userInput1)
                     .click()
 

--- a/cypress/integration/entityPicker.spec.ts
+++ b/cypress/integration/entityPicker.spec.ts
@@ -23,7 +23,7 @@ describe('EntityPicker', () => {
         testData.phrase = `Phrase start ${testData.word1} ${testData.word2} ${testData.word3} ${testData.word4} end.`
 
         before(() => {
-            cy.visit(constants.baseUrl)
+            cy.visit('/')
 
             cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
                 .should('not.exist')
@@ -173,7 +173,7 @@ describe('EntityPicker', () => {
         testData.phrase = `Phrase start ${testData.word1} ${testData.word2} ${testData.word3} ${testData.word4} end.`
 
         before(() => {
-            cy.visit(constants.baseUrl)
+            cy.visit('/')
 
             cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
                 .should('not.exist')
@@ -368,6 +368,7 @@ describe('EntityPicker', () => {
                     .trigger(constants.events.selectWord, { detail: testData.word3 })
 
                 cy.get(s.entityPicker.inputSearch)
+                    .wait(50)
                     .type(testData.entitySearchPrefix)
             })
 

--- a/cypress/integration/setEntityActions.spec.ts
+++ b/cypress/integration/setEntityActions.spec.ts
@@ -25,7 +25,7 @@ describe('Set Entity Actions', () => {
 
     describe('model behavior', () => {
         before(() => {
-            cy.visit(constants.baseUrl)
+            cy.visit('/')
 
             cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
                 .should('not.exist')
@@ -291,16 +291,16 @@ describe('Set Entity Actions', () => {
 
             // dependent on above
             it('when clicking the placeholder action it should create a default set entity action then take it', () => {
-                const setEntityPlaceholderText = `${testData.action.entityName}: ${testData.action.nonExistingEnumValue}`
+                const setEntityPlaceholderText = `${testData.action.entityName}: ${testData.action.nonExistingEnumValue.toUpperCase()}`
 
                 // Select set entity action
-                selectAction(s.trainDialog.actionScorerSetEntityActions, setEntityPlaceholderText)
+                util.selectAction(s.trainDialog.actionScorerSetEntityActions, setEntityPlaceholderText)
 
                 cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
                     .should('not.exist')
 
                 // Select other wait action
-                selectAction(s.trainDialog.actionScorerTextActions, testData.action.text)
+                util.selectAction(s.trainDialog.actionScorerTextActions, testData.action.text)
 
                 cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
                     .should('not.exist')
@@ -338,7 +338,7 @@ describe('Set Entity Actions', () => {
 
     describe('scenario using set entity actions', () => {
         before(() => {
-            cy.visit(constants.baseUrl)
+            cy.visit('/')
 
             cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
                 .should('not.exist')
@@ -368,26 +368,26 @@ describe('Set Entity Actions', () => {
             cy.get(s.trainDialogs.buttonNew)
                 .click()
 
-            inputText(`Hi, I'd like a large coke and fries.`)
-            clickScoreActionButton()
-            selectAction(s.trainDialog.actionScorerSetEntityActions, 'drinkSize: LARGE')
-            selectAction(s.trainDialog.actionScorerTextActions, 'What size fries would you like?')
+            util.inputText(`Hi, I'd like a large coke and fries.`)
+            util.clickScoreActionButton()
+            util.selectAction(s.trainDialog.actionScorerSetEntityActions, 'drinkSize: LARGE')
+            util.selectAction(s.trainDialog.actionScorerTextActions, 'What size fries would you like?')
 
-            inputText(`Um, make that a medium.`)
-            clickScoreActionButton()
-            selectAction(s.trainDialog.actionScorerSetEntityActions, 'friesSize: MEDIUM')
-            selectAction(s.trainDialog.actionScorerTextActions, 'Ok, I have an order for a LARGE drink and MEDIUM fries. Is that correct?')
+            util.inputText(`Um, make that a medium.`)
+            util.clickScoreActionButton()
+            util.selectAction(s.trainDialog.actionScorerSetEntityActions, 'friesSize: MEDIUM')
+            util.selectAction(s.trainDialog.actionScorerTextActions, 'Ok, I have an order for a LARGE drink and MEDIUM fries. Is that correct?')
 
-            inputText(`Actually, make the fries a small`)
-            clickScoreActionButton()
-            selectAction(s.trainDialog.actionScorerSetEntityActions, 'orderConfirmation: NO')
-            selectAction(s.trainDialog.actionScorerSetEntityActions, 'friesSize: SMALL')
-            selectAction(s.trainDialog.actionScorerTextActions, 'Ok, I have an order for a LARGE drink and SMALL fries. Is that correct?')
+            util.inputText(`Actually, make the fries a small`)
+            util.clickScoreActionButton()
+            util.selectAction(s.trainDialog.actionScorerSetEntityActions, 'orderConfirmation: NO')
+            util.selectAction(s.trainDialog.actionScorerSetEntityActions, 'friesSize: SMALL')
+            util.selectAction(s.trainDialog.actionScorerTextActions, 'Ok, I have an order for a LARGE drink and SMALL fries. Is that correct?')
 
-            inputText(`Yep, that's correct.`)
-            clickScoreActionButton()
-            selectAction(s.trainDialog.actionScorerSetEntityActions, 'orderConfirmation: YES')
-            selectAction(s.trainDialog.actionScorerTextActions, `Ok, your order number is 58. Please wait over there.`)
+            util.inputText(`Yep, that's correct.`)
+            util.clickScoreActionButton()
+            util.selectAction(s.trainDialog.actionScorerSetEntityActions, 'orderConfirmation: YES')
+            util.selectAction(s.trainDialog.actionScorerTextActions, `Ok, your order number is 58. Please wait over there.`)
 
             cy.get(s.trainDialog.buttonSave)
                 .click()
@@ -402,28 +402,3 @@ describe('Set Entity Actions', () => {
     })
 })
 
-function selectAction(actionScorerSelector: string, actionResponseText: string) {
-    cy.get(actionScorerSelector)
-        .contains(actionResponseText)
-        .parents(s.trainDialog.actionScorer.rowField)
-        .find(s.trainDialog.buttonSelectAction)
-        .click()
-
-    cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
-        .should('not.exist')
-}
-
-function inputText(text: string) {
-    cy.get(s.trainDialog.inputWebChat)
-        .type(`${text}{enter}`)
-
-    cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
-        .should('not.exist')
-}
-
-function clickScoreActionButton() {
-    cy.get(s.trainDialog.buttonScoreActions)
-        .click();
-    cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
-        .should('not.exist');
-}

--- a/cypress/support/constants.ts
+++ b/cypress/support/constants.ts
@@ -1,7 +1,5 @@
 
 export const constants = {
-    // TODO: See why setting this as baseUrl in cypress.json doesn't work for cy.visit()
-    baseUrl: 'http://localhost:3000',
     spinner: {
         timeout: 120000
     },

--- a/cypress/support/selectors.ts
+++ b/cypress/support/selectors.ts
@@ -120,7 +120,7 @@ const selectors = {
     },
     logDialogs: {
         buttonCreate: '[data-testid="log-dialogs-new-button"]',
-        firstInput: '[data-testid="log-dialogs-first-input"]',
+        description: '[data-testid="log-dialogs-description"]',
     },
     logConversionConflictsModal: {
         modal: '[data-testid="log-conversion-conflicts-modal"]',
@@ -141,6 +141,8 @@ const selectors = {
         customNode: '.cl-entity-node--custom',
         nodeIndicator: '.cl-entity-node-indicator',
         buttonRemoveLabel: '[data-testid="entity-extractor-button-remove-label"]',
+        slateEditor: '[data-slate-editor="true"]',
+        tokenNode: '[data-testid="token-node-entity-value"]',
     },
     entityPicker: {
         inputSearch: '[data-testid="entity-picker-entity-search"]',

--- a/cypress/support/utilities.ts
+++ b/cypress/support/utilities.ts
@@ -1,7 +1,6 @@
 import * as helpers from './Helpers'
 import s from '../support/selectors'
 import constants from '../support/constants'
-import * as util from '../support/utilities'
 
 export function generateUniqueModelName(name: string): string {
     return `z-${name}-${Cypress.moment().format('MMDD-HHmmss')}${helpers.GetBuildKey()}`
@@ -25,7 +24,7 @@ export function importModel(modelName: string, modelFile: string): void {
         .click()
 
     cy.get(s.models.name)
-        .type(util.generateUniqueModelName(modelName))
+        .type(generateUniqueModelName(modelName))
 
     cy.get(s.models.buttonLocalFile)
         .click()
@@ -37,4 +36,41 @@ export function importModel(modelName: string, modelFile: string): void {
 
     cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
         .should('not.exist')
+}
+
+export function selectAction(actionScorerSelector: string, actionResponseText: string) {
+    cy.get(actionScorerSelector)
+        .contains(actionResponseText)
+        .parents(s.trainDialog.actionScorer.rowField)
+        .find(s.trainDialog.buttonSelectAction)
+        .click()
+
+    cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
+        .should('not.exist')
+}
+
+export function inputText(text: string) {
+    cy.get(s.trainDialog.inputWebChat)
+        .type(`${text}{enter}`)
+
+    cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
+        .should('not.exist')
+}
+
+export function clickScoreActionButton() {
+    cy.get(s.trainDialog.buttonScoreActions)
+        .click()
+
+    cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
+        .should('not.exist')
+}
+
+export function removeLabel(tokenText: string) {
+    cy.get(s.extractionEditor.slateEditor)
+        .get(s.extractionEditor.tokenNode)
+        .contains(tokenText)
+        .click()
+        .parents('.cl-entity-node--custom')
+        .find(s.extractionEditor.buttonRemoveLabel)
+        .click()
 }


### PR DESCRIPTION
I had noticed and fix various things as I was going through smoke test development, wanted to separate some of the UI changes from the larger test PR.

There were various mis-used CSS selectors for example using `.cl-action-creator-fieldset` on things other than the `ActionCreator`.

Also change to properly use cypress baseUrl, log dialog description testid, and package creactor modal to use consistent modal styles

Updates: Something was going on with interpreation of the `support/index.js` file which I didn't change and now appears to be working correctly. I had split out the UI changes thinking they shouldn't affect tests, already merged that and now doing the test stuff.

It primarily is using the `baseUrl` and updating utilities
