### PR TITLE
 test: use wait-on for CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           background: true
 
       # Ensure bot and ui are running
-      - run: cd ../cl-samples && npx wait-on -- http://localhost:3978
+      # - run: npx wait-on -- http://localhost:3978
       - run: npx wait-on -- http://localhost:3000
       
       # Run UI e2e tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,8 @@ jobs:
           command: npm start
           background: true
 
+      - run: npx wait-on -- http://localhost:3978
+      
       # Run UI e2e tests
       # Need to add in --parallel once we have a license for it from Cypress
       # - run: npm run cypress -- run --record false --spec  "cypress/integration/smoke/**/*.spec.*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Run sample
       - run: 
-          command: cd ../cl-samples && npm run test-ApiCallbacks > sample.txt
+          command: cd ../cl-samples && npm run test-ApiCallbacks
           background: true
 
       # Run UI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Run sample
       - run: 
-          command: cd ../cl-samples && npm run test-ApiCallbacks
+          command: cd ../cl-samples && npm run test-ApiCallbacks > sample.txt
           background: true
 
       # Run UI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ jobs:
           background: true
 
       # Ensure bot and ui are running
-      - run: npx wait-on -- http://localhost:3978
       - run: npx wait-on -- http://localhost:3000
+      - run: npx wait-on -- http://localhost:3978
       
       # Run UI e2e tests
       # Need to add in --parallel once we have a license for it from Cypress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ jobs:
           background: true
 
       # Ensure bot and ui are running
+      - run: cd ../cl-samples && npx wait-on -- http://localhost:3978
       - run: npx wait-on -- http://localhost:3000
-      - run: npx wait-on -- http://localhost:3978
       
       # Run UI e2e tests
       # Need to add in --parallel once we have a license for it from Cypress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,9 @@ jobs:
           command: npm start
           background: true
 
+      # Ensure bot and ui are running
       - run: npx wait-on -- http://localhost:3978
+      - run: npx wait-on -- http://localhost:3000
       
       # Run UI e2e tests
       # Need to add in --parallel once we have a license for it from Cypress

--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "@types/jest": {
       "version": "20.0.8",
-      "resolved": "http://registry.npmjs.org/@types/jest/-/jest-20.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/@types%2fjest/-/jest-20.0.8.tgz",
       "integrity": "sha512-+vFMPCwOffrTy685X9Kj+Iz83I56Q8j0JK6xvsm6TA5qxbtPUJZcXtJY05WMGlhCKp/9qbpRCwyOp6GkMuyuLg==",
       "dev": true
     },
@@ -2244,12 +2244,12 @@
     },
     "abab": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
     },
     "accepts": {
       "version": "1.3.5",
-      "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
         "mime-types": "~2.1.18",
@@ -2273,12 +2273,12 @@
     },
     "acorn": {
       "version": "4.0.13",
-      "resolved": "http://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "requires": {
         "acorn": "^4.0.3"
@@ -2286,7 +2286,7 @@
     },
     "acorn-globals": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "requires": {
         "acorn": "^4.0.4"
@@ -2304,7 +2304,7 @@
     },
     "address": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/address/-/address-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
     "agent-base": {
@@ -2333,7 +2333,7 @@
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
         "kind-of": "^3.0.2",
@@ -2343,12 +2343,12 @@
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "ansi-align": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
         "string-width": "^2.0.0"
@@ -2356,17 +2356,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -2375,7 +2375,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -2390,7 +2390,7 @@
     },
     "ansi-html": {
       "version": "0.0.7",
-      "resolved": "http://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
@@ -2408,7 +2408,7 @@
     },
     "anymatch": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
         "micromatch": "^2.1.5",
@@ -2417,7 +2417,7 @@
     },
     "append-transform": {
       "version": "0.4.0",
-      "resolved": "http://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "requires": {
         "default-require-extensions": "^1.0.0"
@@ -2451,17 +2451,17 @@
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-filter": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
     "array-find-index": {
@@ -2471,7 +2471,7 @@
     },
     "array-flatten": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
       "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
     },
     "array-ify": {
@@ -2482,7 +2482,7 @@
     },
     "array-includes": {
       "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
         "define-properties": "^1.1.2",
@@ -2491,17 +2491,17 @@
     },
     "array-map": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
     "array-reduce": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
         "array-uniq": "^1.0.1"
@@ -2509,7 +2509,7 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
@@ -2537,7 +2537,7 @@
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "http://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
         "bn.js": "^4.0.0",
@@ -2547,7 +2547,7 @@
     },
     "assert": {
       "version": "1.4.1",
-      "resolved": "http://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "requires": {
         "util": "0.10.3"
@@ -2575,7 +2575,7 @@
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
@@ -2593,7 +2593,7 @@
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
     },
     "async-limiter": {
@@ -2613,7 +2613,7 @@
     },
     "autoprefixer": {
       "version": "7.1.6",
-      "resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
       "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
       "requires": {
         "browserslist": "^2.5.1",
@@ -2661,7 +2661,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
         "chalk": "^1.1.3",
@@ -2697,7 +2697,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -2705,14 +2705,14 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "http://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "requires": {
         "babel-messages": "^6.23.0",
@@ -2727,7 +2727,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
@@ -2860,7 +2860,7 @@
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "resolved": "http://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -2869,7 +2869,7 @@
     },
     "babel-jest": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
       "integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
       "requires": {
         "babel-core": "^6.0.0",
@@ -2889,7 +2889,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -2926,7 +2926,7 @@
     },
     "babel-plugin-jest-hoist": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
       "integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
     },
     "babel-plugin-syntax-async-functions": {
@@ -3292,7 +3292,7 @@
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "resolved": "http://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -3365,7 +3365,7 @@
     },
     "babel-preset-jest": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
       "integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
       "requires": {
         "babel-plugin-jest-hoist": "^20.0.3"
@@ -3406,7 +3406,7 @@
     },
     "babel-register": {
       "version": "6.26.0",
-      "resolved": "http://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
         "babel-core": "^6.26.0",
@@ -3429,7 +3429,7 @@
     },
     "babel-template": {
       "version": "6.26.0",
-      "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -3441,7 +3441,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -3457,7 +3457,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -3467,7 +3467,7 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -3478,7 +3478,7 @@
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "bail": {
@@ -3488,12 +3488,12 @@
     },
     "balanced-match": {
       "version": "0.4.2",
-      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
       "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "http://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
         "cache-base": "^1.0.1",
@@ -3507,7 +3507,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -3553,7 +3553,7 @@
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "bcrypt-pbkdf": {
@@ -3567,7 +3567,7 @@
     },
     "big.js": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "binary-extensions": {
@@ -3582,7 +3582,7 @@
     },
     "bn.js": {
       "version": "4.11.8",
-      "resolved": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
@@ -3604,7 +3604,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -3622,7 +3622,7 @@
     },
     "bonjour": {
       "version": "3.5.0",
-      "resolved": "http://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
         "array-flatten": "^2.1.0",
@@ -3635,7 +3635,7 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "botframework-directlinejs": {
@@ -3648,7 +3648,7 @@
     },
     "boxen": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
         "ansi-align": "^2.0.0",
@@ -3662,12 +3662,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "chalk": {
@@ -3682,12 +3682,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -3696,7 +3696,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -3732,7 +3732,7 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-process-hrtime": {
@@ -3750,7 +3750,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
@@ -3813,7 +3813,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "http://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
         "bn.js": "^4.1.1",
@@ -3827,7 +3827,7 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
         "pako": "~1.0.5"
@@ -3835,7 +3835,7 @@
     },
     "browserslist": {
       "version": "2.11.3",
-      "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
         "caniuse-lite": "^1.0.30000792",
@@ -3844,7 +3844,7 @@
     },
     "bser": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "requires": {
         "node-int64": "^0.4.0"
@@ -3862,7 +3862,7 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
@@ -3880,12 +3880,12 @@
     },
     "buffer-indexof": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-modules": {
@@ -3895,12 +3895,12 @@
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "bytes": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
@@ -3932,7 +3932,7 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
         "collection-visit": "^1.0.0",
@@ -3983,12 +3983,12 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
         "no-case": "^2.2.0",
@@ -4011,14 +4011,14 @@
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         }
       }
     },
     "caniuse-api": {
       "version": "1.6.1",
-      "resolved": "http://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "^1.3.6",
@@ -4029,7 +4029,7 @@
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
-          "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
             "caniuse-db": "^1.0.30000639",
@@ -4055,7 +4055,7 @@
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz",
       "integrity": "sha1-PSnO2MHxJL9vU4Rvs/WJRzH9yQk="
     },
     "caseless": {
@@ -4065,7 +4065,7 @@
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
         "align-text": "^0.1.3",
@@ -4135,7 +4135,7 @@
     },
     "cheerio": {
       "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
         "css-select": "~1.2.0",
@@ -4158,7 +4158,7 @@
     },
     "chokidar": {
       "version": "1.7.0",
-      "resolved": "http://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
         "anymatch": "^1.3.0",
@@ -4184,7 +4184,7 @@
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "^2.0.1",
@@ -4193,7 +4193,7 @@
     },
     "clap": {
       "version": "1.2.3",
-      "resolved": "http://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "requires": {
         "chalk": "^1.1.3"
@@ -4201,7 +4201,7 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "http://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
         "arr-union": "^3.1.0",
@@ -4212,7 +4212,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -4230,7 +4230,7 @@
     },
     "cli-boxes": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
     },
     "cli-cursor": {
@@ -4364,7 +4364,7 @@
     },
     "coa": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "requires": {
         "q": "^1.1.2"
@@ -4382,7 +4382,7 @@
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
         "map-visit": "^1.0.0",
@@ -4421,7 +4421,7 @@
     },
     "color-string": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
         "color-name": "^1.0.0"
@@ -4429,7 +4429,7 @@
     },
     "colormin": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "requires": {
         "color": "^0.11.0",
@@ -4439,7 +4439,7 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combined-stream": {
@@ -4657,7 +4657,7 @@
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compressible": {
@@ -4691,7 +4691,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -4768,12 +4768,12 @@
     },
     "connect-history-api-fallback": {
       "version": "1.5.0",
-      "resolved": "http://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
       "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
         "date-now": "^0.1.4"
@@ -4781,22 +4781,22 @@
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "content-type-parser": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
       "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
     },
     "conventional-changelog-angular": {
@@ -4980,12 +4980,12 @@
     },
     "cookie": {
       "version": "0.3.1",
-      "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
@@ -5008,7 +5008,7 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
@@ -5023,7 +5023,7 @@
     },
     "cosmiconfig": {
       "version": "2.2.2",
-      "resolved": "http://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "requires": {
         "is-directory": "^0.3.1",
@@ -5071,7 +5071,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "http://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
         "capture-stack-trace": "^1.0.0"
@@ -5145,7 +5145,7 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -5163,7 +5163,7 @@
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "css-color-names": {
@@ -5173,7 +5173,7 @@
     },
     "css-loader": {
       "version": "0.28.7",
-      "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
       "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
       "requires": {
         "babel-code-frame": "^6.11.0",
@@ -5194,12 +5194,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -5210,12 +5210,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -5233,7 +5233,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -5271,7 +5271,7 @@
     },
     "cssesc": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
     },
     "cssnano": {
@@ -5315,7 +5315,7 @@
       "dependencies": {
         "autoprefixer": {
           "version": "6.7.7",
-          "resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "^1.7.6",
@@ -5328,7 +5328,7 @@
         },
         "browserslist": {
           "version": "1.7.7",
-          "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
             "caniuse-db": "^1.0.30000639",
@@ -5337,12 +5337,12 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -5353,12 +5353,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -5368,7 +5368,7 @@
     },
     "csso": {
       "version": "2.3.2",
-      "resolved": "http://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "requires": {
         "clap": "^1.0.9",
@@ -5377,7 +5377,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
@@ -5389,7 +5389,7 @@
     },
     "cssstyle": {
       "version": "0.2.37",
-      "resolved": "http://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "requires": {
         "cssom": "0.3.x"
@@ -5721,7 +5721,7 @@
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "debug": {
@@ -5749,7 +5749,7 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "dedent": {
@@ -5760,7 +5760,7 @@
     },
     "deep-equal": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-extend": {
@@ -5770,7 +5770,7 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
@@ -5780,7 +5780,7 @@
     },
     "default-require-extensions": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "requires": {
         "strip-bom": "^2.0.0"
@@ -5796,7 +5796,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -5838,7 +5838,7 @@
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "degenerator": {
@@ -5853,7 +5853,7 @@
     },
     "del": {
       "version": "2.2.2",
-      "resolved": "http://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "requires": {
         "globby": "^5.0.0",
@@ -5872,12 +5872,12 @@
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "des.js": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
         "inherits": "^2.0.1",
@@ -5886,7 +5886,7 @@
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-file": {
@@ -5922,7 +5922,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -5952,12 +5952,12 @@
     },
     "dns-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
       "version": "1.3.1",
-      "resolved": "http://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
         "ip": "^1.1.0",
@@ -5966,7 +5966,7 @@
     },
     "dns-txt": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
         "buffer-indexof": "^1.0.0"
@@ -5974,7 +5974,7 @@
     },
     "doctrine": {
       "version": "0.7.2",
-      "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
@@ -5984,7 +5984,7 @@
       "dependencies": {
         "esutils": {
           "version": "1.1.6",
-          "resolved": "http://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
           "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
           "dev": true
         }
@@ -6024,7 +6024,7 @@
     },
     "dom-urls": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "requires": {
         "urijs": "^1.16.1"
@@ -6032,7 +6032,7 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "domelementtype": {
@@ -6067,7 +6067,7 @@
     },
     "dot-prop": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
         "is-obj": "^1.0.0"
@@ -6090,7 +6090,7 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
@@ -6137,7 +6137,7 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
@@ -6167,12 +6167,12 @@
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
@@ -6193,7 +6193,7 @@
     },
     "enhanced-resolve": {
       "version": "3.4.1",
-      "resolved": "http://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -6209,7 +6209,7 @@
     },
     "errno": {
       "version": "0.1.7",
-      "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "~1.0.1"
@@ -6257,7 +6257,7 @@
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1",
@@ -6267,7 +6267,7 @@
     },
     "es6-map": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1",
@@ -6285,7 +6285,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -6293,7 +6293,7 @@
     },
     "es6-set": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1",
@@ -6305,7 +6305,7 @@
     },
     "es6-symbol": {
       "version": "3.1.1",
-      "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1",
@@ -6314,7 +6314,7 @@
     },
     "es6-weak-map": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1",
@@ -6325,7 +6325,7 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
@@ -6347,7 +6347,7 @@
     },
     "escope": {
       "version": "3.6.0",
-      "resolved": "http://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "requires": {
         "es6-map": "^0.1.3",
@@ -6363,7 +6363,7 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "requires": {
         "estraverse": "^4.1.0"
@@ -6376,22 +6376,22 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "http://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "http://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1",
@@ -6410,7 +6410,7 @@
     },
     "eventsource": {
       "version": "0.1.6",
-      "resolved": "http://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
         "original": ">=0.0.5"
@@ -6418,7 +6418,7 @@
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "^1.3.4",
@@ -6466,7 +6466,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
         "homedir-polyfill": "^1.0.1"
@@ -6588,12 +6588,12 @@
       "dependencies": {
         "array-flatten": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -6601,7 +6601,7 @@
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "safe-buffer": {
@@ -6623,7 +6623,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "http://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -6632,7 +6632,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -6671,7 +6671,7 @@
     },
     "extract-text-webpack-plugin": {
       "version": "3.0.2",
-      "resolved": "http://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
       "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
       "requires": {
         "async": "^2.4.1",
@@ -6738,7 +6738,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastparse": {
@@ -6748,7 +6748,7 @@
     },
     "faye-websocket": {
       "version": "0.11.1",
-      "resolved": "http://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "requires": {
         "websocket-driver": ">=0.5.1"
@@ -6756,7 +6756,7 @@
     },
     "fb-watchman": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
         "bser": "^2.0.0"
@@ -6826,7 +6826,7 @@
     },
     "fileset": {
       "version": "2.0.3",
-      "resolved": "http://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "requires": {
         "glob": "^7.0.3",
@@ -6835,7 +6835,7 @@
     },
     "filesize": {
       "version": "3.5.11",
-      "resolved": "http://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
       "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g=="
     },
     "fill-range": {
@@ -6881,7 +6881,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -7057,7 +7057,7 @@
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "0.2.10",
-      "resolved": "http://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-0.2.10.tgz",
       "integrity": "sha1-0KQIDnfp9dbjtDzc59JmWPnSUMY=",
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -7097,12 +7097,12 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "http://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
@@ -7110,7 +7110,7 @@
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from2": {
@@ -7694,7 +7694,7 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "fuse.js": {
@@ -7714,7 +7714,7 @@
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
@@ -7766,7 +7766,7 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "http://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "get-window": {
@@ -8006,7 +8006,7 @@
     },
     "global-modules": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
         "global-prefix": "^1.0.1",
@@ -8016,7 +8016,7 @@
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
         "expand-tilde": "^2.0.2",
@@ -8028,12 +8028,12 @@
     },
     "globals": {
       "version": "9.18.0",
-      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "requires": {
         "array-union": "^1.0.1",
@@ -8075,12 +8075,12 @@
     },
     "growly": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "gzip-size": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
       "requires": {
         "duplexer": "^0.1.1"
@@ -8088,7 +8088,7 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
     "handlebars": {
@@ -8145,7 +8145,7 @@
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
         "get-value": "^2.0.6",
@@ -8155,7 +8155,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
         "is-number": "^3.0.0",
@@ -8164,7 +8164,7 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -8172,7 +8172,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -8182,7 +8182,7 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -8228,13 +8228,19 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hoek": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "3.1.0",
@@ -8246,7 +8252,7 @@
     },
     "home-or-tmp": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
         "os-homedir": "^1.0.0",
@@ -8268,7 +8274,7 @@
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "http://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
         "inherits": "^2.0.1",
@@ -8279,7 +8285,7 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
@@ -8313,7 +8319,7 @@
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "requires": {
         "whatwg-encoding": "^1.0.1"
@@ -8321,7 +8327,7 @@
     },
     "html-entities": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-minifier": {
@@ -8347,7 +8353,7 @@
     },
     "html-webpack-plugin": {
       "version": "2.29.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.29.0.tgz",
       "integrity": "sha1-6Yf0IYU9O2k4yMTIFxhC5f0XryM=",
       "requires": {
         "bluebird": "^3.4.7",
@@ -8360,7 +8366,7 @@
       "dependencies": {
         "loader-utils": {
           "version": "0.2.17",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "requires": {
             "big.js": "^3.1.3",
@@ -8386,7 +8392,7 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "http://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
@@ -8426,7 +8432,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.17.4",
-      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
         "http-proxy": "^1.16.2",
@@ -8437,12 +8443,12 @@
       "dependencies": {
         "is-extglob": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
@@ -8462,7 +8468,7 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "https-proxy-agent": {
@@ -8682,12 +8688,12 @@
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
     },
     "icss-utils": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "requires": {
         "postcss": "^6.0.1"
@@ -8736,7 +8742,7 @@
     },
     "import-lazy": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "import-local": {
@@ -8750,7 +8756,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
@@ -8763,12 +8769,12 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
@@ -8815,7 +8821,7 @@
     },
     "inquirer": {
       "version": "3.3.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -8841,7 +8847,7 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "chalk": {
@@ -8856,12 +8862,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -8870,7 +8876,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -8880,7 +8886,7 @@
     },
     "internal-ip": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
       "requires": {
         "meow": "^3.3.0"
@@ -8893,12 +8899,12 @@
     },
     "intl-format-cache": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
       "integrity": "sha1-BKNp/sv61tpgBbrh8UMzMy3PkxY="
     },
     "intl-messageformat": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
       "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
       "requires": {
         "intl-messageformat-parser": "1.4.0"
@@ -8906,12 +8912,12 @@
     },
     "intl-messageformat-parser": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
       "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
     },
     "intl-relativeformat": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
       "integrity": "sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=",
       "requires": {
         "intl-messageformat": "^2.0.0"
@@ -8927,12 +8933,12 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "http://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
@@ -8942,7 +8948,7 @@
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
     },
     "is-accessor-descriptor": {
@@ -8974,7 +8980,7 @@
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
         "binary-extensions": "^1.0.0"
@@ -9016,7 +9022,7 @@
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
@@ -9129,7 +9135,7 @@
     },
     "is-npm": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
     },
     "is-number": {
@@ -9147,7 +9153,7 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
     },
     "is-path-in-cwd": {
@@ -9196,12 +9202,12 @@
     },
     "is-redirect": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
         "has": "^1.0.1"
@@ -9209,12 +9215,12 @@
     },
     "is-retry-allowed": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-root": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
       "integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU="
     },
     "is-stream": {
@@ -9224,7 +9230,7 @@
     },
     "is-svg": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "requires": {
         "html-comment-regex": "^1.1.0"
@@ -9254,7 +9260,7 @@
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-whitespace-character": {
@@ -9279,13 +9285,30 @@
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
       "version": "0.0.1",
       "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "dev": true,
+      "requires": {
+        "punycode": "2.x.x"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -9374,12 +9397,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -9401,7 +9424,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
@@ -9416,7 +9439,7 @@
     },
     "jest": {
       "version": "20.0.4",
-      "resolved": "http://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
       "integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
       "requires": {
         "jest-cli": "^20.0.4"
@@ -9424,7 +9447,7 @@
       "dependencies": {
         "jest-cli": {
           "version": "20.0.4",
-          "resolved": "http://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
           "integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
           "requires": {
             "ansi-escapes": "^1.4.0",
@@ -9463,12 +9486,12 @@
     },
     "jest-changed-files": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
       "integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g="
     },
     "jest-config": {
       "version": "20.0.4",
-      "resolved": "http://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
       "integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
       "requires": {
         "chalk": "^1.1.3",
@@ -9485,7 +9508,7 @@
     },
     "jest-diff": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
       "integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
       "requires": {
         "chalk": "^1.1.3",
@@ -9496,12 +9519,12 @@
     },
     "jest-docblock": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
       "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
     },
     "jest-environment-jsdom": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
       "integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
       "requires": {
         "jest-mock": "^20.0.3",
@@ -9511,7 +9534,7 @@
     },
     "jest-environment-node": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
       "integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
       "requires": {
         "jest-mock": "^20.0.3",
@@ -9525,7 +9548,7 @@
     },
     "jest-haste-map": {
       "version": "20.0.5",
-      "resolved": "http://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
       "integrity": "sha512-0IKAQjUvuZjMCNi/0VNQQF74/H9KB67hsHJqGiwTWQC6XO5Azs7kLWm+6Q/dwuhvDUvABDOBMFK2/FwZ3sZ07Q==",
       "requires": {
         "fb-watchman": "^2.0.0",
@@ -9538,7 +9561,7 @@
     },
     "jest-jasmine2": {
       "version": "20.0.4",
-      "resolved": "http://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
       "integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
       "requires": {
         "chalk": "^1.1.3",
@@ -9554,7 +9577,7 @@
     },
     "jest-matcher-utils": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
       "integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
       "requires": {
         "chalk": "^1.1.3",
@@ -9563,7 +9586,7 @@
     },
     "jest-matchers": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
       "integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
       "requires": {
         "jest-diff": "^20.0.3",
@@ -9574,7 +9597,7 @@
     },
     "jest-message-util": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
       "integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
       "requires": {
         "chalk": "^1.1.3",
@@ -9584,17 +9607,17 @@
     },
     "jest-mock": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
       "integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk="
     },
     "jest-regex-util": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
       "integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I="
     },
     "jest-resolve": {
       "version": "20.0.4",
-      "resolved": "http://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
       "integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
       "requires": {
         "browser-resolve": "^1.11.2",
@@ -9604,7 +9627,7 @@
     },
     "jest-resolve-dependencies": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
       "integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
       "requires": {
         "jest-regex-util": "^20.0.3"
@@ -9612,7 +9635,7 @@
     },
     "jest-runtime": {
       "version": "20.0.4",
-      "resolved": "http://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
       "integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
       "requires": {
         "babel-core": "^6.0.0",
@@ -9634,14 +9657,14 @@
       "dependencies": {
         "strip-bom": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
     "jest-snapshot": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
       "integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
       "requires": {
         "chalk": "^1.1.3",
@@ -9654,7 +9677,7 @@
     },
     "jest-util": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
       "integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
       "requires": {
         "chalk": "^1.1.3",
@@ -9668,13 +9691,24 @@
     },
     "jest-validate": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
       "integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
       "requires": {
         "chalk": "^1.1.3",
         "jest-matcher-utils": "^20.0.3",
         "leven": "^2.1.0",
         "pretty-format": "^20.0.3"
+      }
+    },
+    "joi": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+      "dev": true,
+      "requires": {
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
       }
     },
     "js-base64": {
@@ -9694,7 +9728,7 @@
     },
     "js-yaml": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
         "argparse": "^1.0.7",
@@ -9716,7 +9750,7 @@
     },
     "jsdom": {
       "version": "9.12.0",
-      "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "requires": {
         "abab": "^1.0.3",
@@ -9747,7 +9781,7 @@
     },
     "json-loader": {
       "version": "0.5.7",
-      "resolved": "http://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
     },
     "json-parse-better-errors": {
@@ -9768,7 +9802,7 @@
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
         "jsonify": "~0.0.0"
@@ -9781,7 +9815,7 @@
     },
     "json3": {
       "version": "3.3.2",
-      "resolved": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
     },
     "json5": {
@@ -9799,7 +9833,7 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
@@ -9847,7 +9881,7 @@
     },
     "latest-version": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
         "package-json": "^4.0.0"
@@ -9861,12 +9895,12 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
         "invert-kv": "^1.0.0"
@@ -9879,12 +9913,12 @@
     },
     "leven": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
       "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -10067,7 +10101,7 @@
     },
     "load-script": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
       "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-runner": {
@@ -10077,7 +10111,7 @@
     },
     "loader-utils": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "requires": {
         "big.js": "^3.1.3",
@@ -10111,12 +10145,12 @@
     },
     "lodash.assignin": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
       "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
     "lodash.bind": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
     },
     "lodash.camelcase": {
@@ -10136,37 +10170,37 @@
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.endswith": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
       "integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk="
     },
     "lodash.filter": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.foreach": {
       "version": "4.5.0",
-      "resolved": "http://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
     "lodash.isfunction": {
       "version": "3.0.9",
-      "resolved": "http://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
       "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.kebabcase": {
@@ -10182,7 +10216,7 @@
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "http://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "lodash.merge": {
@@ -10215,12 +10249,12 @@
     },
     "lodash.reduce": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
       "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
     },
     "lodash.reject": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
       "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
     },
     "lodash.snakecase": {
@@ -10231,7 +10265,7 @@
     },
     "lodash.some": {
       "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.sortby": {
@@ -10247,7 +10281,7 @@
     },
     "lodash.startswith": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
       "integrity": "sha1-xZjErc4YiiflMUVzHNxsDnF3YAw="
     },
     "lodash.template": {
@@ -10275,7 +10309,7 @@
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "http://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "lodash.upperfirst": {
@@ -10345,7 +10379,7 @@
     },
     "loglevel": {
       "version": "1.6.1",
-      "resolved": "http://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
     },
     "longest": {
@@ -10372,7 +10406,7 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "http://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lowercase-keys": {
@@ -10399,14 +10433,14 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
     "makeerror": {
       "version": "1.0.11",
-      "resolved": "http://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "requires": {
         "tmpl": "1.0.x"
@@ -10414,7 +10448,7 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-obj": {
@@ -10424,7 +10458,7 @@
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
@@ -10449,7 +10483,7 @@
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
-      "resolved": "http://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
     },
     "math-random": {
@@ -10495,7 +10529,7 @@
     },
     "mdurl": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
@@ -10520,7 +10554,7 @@
     },
     "mem": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
         "mimic-fn": "^1.0.0"
@@ -10528,7 +10562,7 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
         "errno": "^0.1.3",
@@ -10537,7 +10571,7 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
@@ -10587,12 +10621,12 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
@@ -10617,7 +10651,7 @@
     },
     "microsoft-adaptivecards": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/microsoft-adaptivecards/-/microsoft-adaptivecards-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/microsoft-adaptivecards/-/microsoft-adaptivecards-0.6.1.tgz",
       "integrity": "sha512-TYNgO+DkXskpr+sspyiwcchaB/zh//is3BRCA5YtmjS0OeZCAlRZ3k1vzJfC639w/Ci+zft+MbIA/p6BuVbGEg==",
       "requires": {
         "markdown-it": "^8.2.2"
@@ -10625,12 +10659,12 @@
     },
     "microsoft-speech-browser-sdk": {
       "version": "0.0.12",
-      "resolved": "http://registry.npmjs.org/microsoft-speech-browser-sdk/-/microsoft-speech-browser-sdk-0.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/microsoft-speech-browser-sdk/-/microsoft-speech-browser-sdk-0.0.12.tgz",
       "integrity": "sha512-JYIR/WpaCyV1wk+4ff3kSJMqJFehbeApzG9CJxR+mN3z+4hFKGB/D5GaFsdN5WtRvnrekzUYSOv2nljMQb3Nwg=="
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
         "bn.js": "^4.0.0",
@@ -10667,7 +10701,7 @@
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
@@ -10712,7 +10746,7 @@
     },
     "mixin-deep": {
       "version": "1.3.1",
-      "resolved": "http://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
         "for-in": "^1.0.2",
@@ -10721,7 +10755,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -10847,7 +10881,7 @@
     },
     "multicast-dns": {
       "version": "6.2.3",
-      "resolved": "http://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "requires": {
         "dns-packet": "^1.3.1",
@@ -10856,7 +10890,7 @@
     },
     "multicast-dns-service-types": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
     "mute-stream": {
@@ -10890,29 +10924,29 @@
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "negotiator": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "neo-async": {
@@ -10938,7 +10972,7 @@
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "http://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
         "lower-case": "^1.1.1"
@@ -10960,12 +10994,12 @@
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "http://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
     },
     "node-libs-browser": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "requires": {
         "assert": "^1.1.1",
@@ -10995,7 +11029,7 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
@@ -11054,12 +11088,12 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "http://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
       "version": "1.9.1",
-      "resolved": "http://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "requires": {
         "object-assign": "^4.0.1",
@@ -11086,7 +11120,7 @@
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "number-is-nan": {
@@ -11117,7 +11151,7 @@
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -11127,7 +11161,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -11142,7 +11176,7 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
@@ -11169,7 +11203,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -11177,7 +11211,7 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "office-ui-fabric-react": {
@@ -11198,7 +11232,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
@@ -11206,7 +11240,7 @@
     },
     "on-headers": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
@@ -11348,7 +11382,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
         "minimist": "~0.0.1",
@@ -11364,7 +11398,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
         "deep-is": "~0.1.3",
@@ -11424,7 +11458,7 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
     "os-homedir": {
@@ -11522,7 +11556,7 @@
     },
     "package-json": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
         "got": "^6.7.1",
@@ -11542,7 +11576,7 @@
     },
     "pako": {
       "version": "1.0.6",
-      "resolved": "http://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
       "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
     },
     "parallel-transform": {
@@ -11578,7 +11612,7 @@
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
         "no-case": "^2.2.0"
@@ -11622,7 +11656,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
         "error-ex": "^1.2.0"
@@ -11635,27 +11669,27 @@
     },
     "parse5": {
       "version": "1.5.1",
-      "resolved": "http://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
       "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
     },
     "parseurl": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
@@ -11693,7 +11727,7 @@
     },
     "path-type": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -11744,7 +11778,7 @@
     },
     "pkg-dir": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
         "find-up": "^2.1.0"
@@ -11781,7 +11815,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -11791,7 +11825,7 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
@@ -11836,12 +11870,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -11852,12 +11886,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -11867,7 +11901,7 @@
     },
     "postcss-colormin": {
       "version": "2.2.2",
-      "resolved": "http://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "requires": {
         "colormin": "^1.0.5",
@@ -11877,12 +11911,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -11893,12 +11927,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -11908,7 +11942,7 @@
     },
     "postcss-convert-values": {
       "version": "2.6.1",
-      "resolved": "http://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "requires": {
         "postcss": "^5.0.11",
@@ -11917,12 +11951,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -11933,12 +11967,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -11956,12 +11990,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -11972,12 +12006,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -11987,7 +12021,7 @@
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "requires": {
         "postcss": "^5.0.4"
@@ -11995,12 +12029,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12011,12 +12045,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12034,12 +12068,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12050,12 +12084,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12073,12 +12107,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12089,12 +12123,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12113,12 +12147,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12129,12 +12163,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12152,12 +12186,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12168,12 +12202,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12183,7 +12217,7 @@
     },
     "postcss-flexbugs-fixes": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.2.0.tgz",
       "integrity": "sha512-0AuD9HG1Ey3/3nqPWu9yqf7rL0KCPu5VgjDsjf5mzEcuo9H/z8nco/fljKgjsOUrZypa95MI0kS4xBZeBzz2lw==",
       "requires": {
         "postcss": "^6.0.1"
@@ -12191,7 +12225,7 @@
     },
     "postcss-load-config": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "requires": {
         "cosmiconfig": "^2.1.0",
@@ -12202,7 +12236,7 @@
     },
     "postcss-load-options": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "requires": {
         "cosmiconfig": "^2.1.0",
@@ -12211,7 +12245,7 @@
     },
     "postcss-load-plugins": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "requires": {
         "cosmiconfig": "^2.1.1",
@@ -12220,7 +12254,7 @@
     },
     "postcss-loader": {
       "version": "2.0.8",
-      "resolved": "http://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.8.tgz",
       "integrity": "sha512-KtXBiQ/r/WYW8LxTSJK7h8wLqvCMSub/BqmRnud/Mu8RzwflW9cmXxwsMwbn15TNv287Hcufdb3ZSs7xHKnG8Q==",
       "requires": {
         "loader-utils": "^1.1.0",
@@ -12241,12 +12275,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12257,12 +12291,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12272,7 +12306,7 @@
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "requires": {
         "postcss": "^5.0.4"
@@ -12280,12 +12314,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12296,12 +12330,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12311,7 +12345,7 @@
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
-      "resolved": "http://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "requires": {
         "browserslist": "^1.5.2",
@@ -12323,7 +12357,7 @@
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
-          "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
             "caniuse-db": "^1.0.30000639",
@@ -12332,12 +12366,12 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12348,12 +12382,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12363,7 +12397,7 @@
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
       "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
     },
     "postcss-minify-font-values": {
@@ -12378,12 +12412,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12394,12 +12428,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12418,12 +12452,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12434,12 +12468,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12460,12 +12494,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12476,12 +12510,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12502,12 +12536,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12518,12 +12552,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12541,7 +12575,7 @@
     },
     "postcss-modules-local-by-default": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
@@ -12550,7 +12584,7 @@
     },
     "postcss-modules-scope": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
@@ -12559,7 +12593,7 @@
     },
     "postcss-modules-values": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
         "icss-replace-symbols": "^1.1.0",
@@ -12576,12 +12610,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12592,12 +12626,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12618,12 +12652,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12634,12 +12668,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12649,7 +12683,7 @@
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
-      "resolved": "http://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "requires": {
         "postcss": "^5.0.4",
@@ -12658,12 +12692,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12674,12 +12708,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12698,12 +12732,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12714,12 +12748,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12737,12 +12771,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12753,12 +12787,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12778,12 +12812,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12794,12 +12828,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12809,7 +12843,7 @@
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
-      "resolved": "http://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "requires": {
         "flatten": "^1.0.2",
@@ -12830,12 +12864,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12846,12 +12880,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12871,12 +12905,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12887,12 +12921,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12917,12 +12951,12 @@
       "dependencies": {
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "5.2.18",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "^1.1.3",
@@ -12933,12 +12967,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
             "has-flag": "^1.0.0"
@@ -12948,12 +12982,12 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "preserve": {
@@ -12963,12 +12997,12 @@
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
     },
     "pretty-error": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
         "renderkid": "^2.0.1",
@@ -12977,7 +13011,7 @@
     },
     "pretty-format": {
       "version": "20.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
       "integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
       "requires": {
         "ansi-regex": "^2.1.1",
@@ -12986,12 +13020,12 @@
     },
     "private": {
       "version": "0.1.8",
-      "resolved": "http://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "http://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
@@ -13064,7 +13098,7 @@
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pseudomap": {
@@ -13133,7 +13167,7 @@
     },
     "query-string": {
       "version": "4.3.4",
-      "resolved": "http://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
         "object-assign": "^4.1.0",
@@ -13147,7 +13181,7 @@
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "querystringify": {
@@ -13163,7 +13197,7 @@
     },
     "raf": {
       "version": "3.4.0",
-      "resolved": "http://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
       "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
       "requires": {
         "performance-now": "^2.1.0"
@@ -13199,7 +13233,7 @@
     },
     "randombytes": {
       "version": "2.0.6",
-      "resolved": "http://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -13207,7 +13241,7 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
         "randombytes": "^2.0.5",
@@ -13216,7 +13250,7 @@
     },
     "range-parser": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
@@ -13710,7 +13744,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -13720,7 +13754,7 @@
         },
         "jsonfile": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
           "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -13728,7 +13762,7 @@
         },
         "promise": {
           "version": "8.0.1",
-          "resolved": "http://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
           "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
           "requires": {
             "asap": "~2.0.3"
@@ -13758,7 +13792,7 @@
     },
     "read-pkg": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
         "load-json-file": "^1.0.0",
@@ -13768,7 +13802,7 @@
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
         "find-up": "^1.0.0",
@@ -13777,7 +13811,7 @@
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
-          "resolved": "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
             "path-exists": "^2.0.0",
@@ -13786,7 +13820,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -14042,7 +14076,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "kind-of": {
@@ -14097,7 +14131,7 @@
     },
     "recursive-readdir": {
       "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
       "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
       "requires": {
         "minimatch": "3.0.3"
@@ -14105,7 +14139,7 @@
       "dependencies": {
         "minimatch": {
           "version": "3.0.3",
-          "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "requires": {
             "brace-expansion": "^1.0.0"
@@ -14115,7 +14149,7 @@
     },
     "redent": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
         "indent-string": "^2.1.0",
@@ -14134,7 +14168,7 @@
     },
     "reduce-function-call": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "requires": {
         "balanced-match": "^0.4.2"
@@ -14206,7 +14240,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -14335,7 +14369,7 @@
     },
     "registry-auth-token": {
       "version": "3.3.2",
-      "resolved": "http://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
         "rc": "^1.1.6",
@@ -14344,7 +14378,7 @@
     },
     "registry-url": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
         "rc": "^1.0.1"
@@ -14357,7 +14391,7 @@
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
         "jsesc": "~0.5.0"
@@ -14372,7 +14406,7 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "http://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remark-parse": {
@@ -14426,7 +14460,7 @@
       "dependencies": {
         "domhandler": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
           "requires": {
             "domelementtype": "1"
@@ -14489,7 +14523,7 @@
     },
     "replace-ext": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
@@ -14609,17 +14643,17 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-from-string": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
       "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "require-uncached": {
@@ -14642,7 +14676,7 @@
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
@@ -14655,7 +14689,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
         "resolve-from": "^3.0.0"
@@ -14663,7 +14697,7 @@
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
         "expand-tilde": "^2.0.0",
@@ -14672,7 +14706,7 @@
     },
     "resolve-from": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "resolve-global": {
@@ -14691,7 +14725,7 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
@@ -14705,12 +14739,12 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "http://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
         "align-text": "^0.1.1"
@@ -14769,12 +14803,12 @@
     },
     "rx-lite": {
       "version": "4.0.8",
-      "resolved": "http://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "resolved": "http://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
         "rx-lite": "*"
@@ -14808,7 +14842,7 @@
     },
     "sane": {
       "version": "1.6.0",
-      "resolved": "http://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
       "integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
       "requires": {
         "anymatch": "^1.3.0",
@@ -14822,7 +14856,7 @@
       "dependencies": {
         "bser": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
           "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
           "requires": {
             "node-int64": "^0.4.0"
@@ -14830,7 +14864,7 @@
         },
         "fb-watchman": {
           "version": "1.9.2",
-          "resolved": "http://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
           "integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
           "requires": {
             "bser": "1.0.2"
@@ -14845,7 +14879,7 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
@@ -14859,7 +14893,7 @@
     },
     "schema-utils": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
         "ajv": "^5.0.0"
@@ -14867,7 +14901,7 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selection-is-backward": {
@@ -14896,7 +14930,7 @@
     },
     "semver-diff": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
         "semver": "^5.0.3"
@@ -14924,7 +14958,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -14932,7 +14966,7 @@
         },
         "mime": {
           "version": "1.4.1",
-          "resolved": "http://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "statuses": {
@@ -14949,7 +14983,7 @@
     },
     "serve-index": {
       "version": "1.9.1",
-      "resolved": "http://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
         "accepts": "~1.3.4",
@@ -14963,7 +14997,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -14984,17 +15018,17 @@
     },
     "serviceworker-cache-polyfill": {
       "version": "4.0.0",
-      "resolved": "http://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
       "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -15005,7 +15039,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -15020,7 +15054,7 @@
     },
     "setprototypeof": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "sha.js": {
@@ -15047,7 +15081,7 @@
     },
     "shell-quote": {
       "version": "1.6.1",
-      "resolved": "http://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
         "array-filter": "~0.0.0",
@@ -15069,7 +15103,7 @@
     },
     "shellwords": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "signal-exit": {
@@ -15079,7 +15113,7 @@
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slate": {
@@ -15175,7 +15209,7 @@
     },
     "slick": {
       "version": "1.12.2",
-      "resolved": "http://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
       "integrity": "sha1-vQSN23TefRymkV+qSldXCzVQwtc="
     },
     "smart-buffer": {
@@ -15185,7 +15219,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "http://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
         "base": "^0.11.1",
@@ -15200,7 +15234,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -15208,7 +15242,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -15216,7 +15250,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -15224,14 +15258,14 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
         "define-property": "^1.0.0",
@@ -15241,7 +15275,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -15282,7 +15316,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "^3.2.0"
@@ -15299,7 +15333,7 @@
       "dependencies": {
         "faye-websocket": {
           "version": "0.10.0",
-          "resolved": "http://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
             "websocket-driver": ">=0.5.1"
@@ -15322,7 +15356,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -15350,7 +15384,7 @@
     },
     "sort-keys": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "requires": {
         "is-plain-obj": "^1.0.0"
@@ -15364,7 +15398,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-loader": {
       "version": "0.2.4",
@@ -15389,7 +15423,7 @@
     },
     "source-map-support": {
       "version": "0.4.18",
-      "resolved": "http://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
         "source-map": "^0.5.6"
@@ -15397,14 +15431,14 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "http://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spawn-sync": {
@@ -15447,7 +15481,7 @@
     },
     "spdy": {
       "version": "3.4.7",
-      "resolved": "http://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
         "debug": "^2.6.8",
@@ -15460,7 +15494,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -15484,7 +15518,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -15492,7 +15526,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
@@ -15518,7 +15552,7 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -15574,7 +15608,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "http://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
         "define-property": "^0.2.5",
@@ -15583,7 +15617,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -15603,7 +15637,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
         "inherits": "~2.0.1",
@@ -15612,7 +15646,7 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
@@ -15654,7 +15688,7 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
@@ -15686,12 +15720,12 @@
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "requires": {
         "strip-ansi": "^3.0.0"
@@ -15725,7 +15759,7 @@
     },
     "strip-bom": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
         "is-utf8": "^0.2.0"
@@ -15738,7 +15772,7 @@
     },
     "strip-indent": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
         "get-stdin": "^4.0.1"
@@ -15762,7 +15796,7 @@
     },
     "style-loader": {
       "version": "0.19.0",
-      "resolved": "http://registry.npmjs.org/style-loader/-/style-loader-0.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.0.tgz",
       "integrity": "sha512-9mx9sC9nX1dgP96MZOODpGC6l1RzQBITI2D5WJhu+wnbrSYVKLGuy14XJSLVQih/0GFrPpjelt+s//VcZQ2Evw==",
       "requires": {
         "loader-utils": "^1.0.2",
@@ -15841,7 +15875,7 @@
     },
     "svgo": {
       "version": "0.7.2",
-      "resolved": "http://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "requires": {
         "coa": "~1.0.1",
@@ -15855,7 +15889,7 @@
     },
     "sw-precache": {
       "version": "5.2.1",
-      "resolved": "http://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
       "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
       "requires": {
         "dom-urls": "^1.1.0",
@@ -15872,7 +15906,7 @@
     },
     "sw-precache-webpack-plugin": {
       "version": "0.11.4",
-      "resolved": "http://registry.npmjs.org/sw-precache-webpack-plugin/-/sw-precache-webpack-plugin-0.11.4.tgz",
+      "resolved": "https://registry.npmjs.org/sw-precache-webpack-plugin/-/sw-precache-webpack-plugin-0.11.4.tgz",
       "integrity": "sha1-ppUBflTu1XVVFJOlGdwdqNotxeA=",
       "requires": {
         "del": "^2.2.2",
@@ -15882,7 +15916,7 @@
     },
     "sw-toolbox": {
       "version": "3.6.0",
-      "resolved": "http://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "requires": {
         "path-to-regexp": "^1.0.1",
@@ -15891,22 +15925,22 @@
     },
     "symbol-observable": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "symbol-tree": {
       "version": "3.2.2",
-      "resolved": "http://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
     "tapable": {
       "version": "0.2.8",
-      "resolved": "http://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
     },
     "term-size": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
         "execa": "^0.7.0"
@@ -15914,7 +15948,7 @@
       "dependencies": {
         "execa": {
           "version": "0.7.0",
-          "resolved": "http://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -15948,12 +15982,12 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "throat": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
       "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
     },
     "throttleit": {
@@ -16027,7 +16061,7 @@
     },
     "timed-out": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "timers-browserify": {
@@ -16048,22 +16082,22 @@
     },
     "tmpl": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
     "to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -16071,7 +16105,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "http://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
         "define-property": "^2.0.2",
@@ -16082,7 +16116,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
         "is-number": "^3.0.0",
@@ -16091,11 +16125,28 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
             "kind-of": "^3.0.2"
           }
+        }
+      }
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "dev": true,
+      "requires": {
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+          "dev": true
         }
       }
     },
@@ -16114,17 +16165,17 @@
     },
     "tr46": {
       "version": "0.0.3",
-      "resolved": "http://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "trim": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-off-newlines": {
@@ -16135,7 +16186,7 @@
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "trim-trailing-lines": {
@@ -16193,7 +16244,7 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "babel-plugin-jest-hoist": {
@@ -16212,7 +16263,7 @@
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "chalk": {
@@ -16245,7 +16296,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "http://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -16259,7 +16310,7 @@
         },
         "fs-extra": {
           "version": "4.0.3",
-          "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -16453,7 +16504,7 @@
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
             "execa": "^0.7.0",
@@ -16491,7 +16542,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -16526,7 +16577,7 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "xml-name-validator": {
@@ -16565,7 +16616,7 @@
     },
     "ts-loader": {
       "version": "2.3.7",
-      "resolved": "http://registry.npmjs.org/ts-loader/-/ts-loader-2.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-2.3.7.tgz",
       "integrity": "sha512-8t3bu2FcEkXb+D4L+Cn8qiK2E2C6Ms4/GQChvz6IMbVurcFHLXrhW4EMtfaol1a1ASQACZGDUGit4NHnX9g7hQ==",
       "requires": {
         "chalk": "^2.0.1",
@@ -16613,14 +16664,14 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
     "tsconfig-paths-webpack-plugin": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-2.0.0.tgz",
       "integrity": "sha512-reAnVEGP7mNwOcXXYxQpsH7uY8blNJM/xgN2KYttVX+qkwfqA+nhRPpA7Fnomnlhm5Jz0EoSVwk4rtQu8hC54g==",
       "requires": {
         "chalk": "^2.3.0",
@@ -16665,7 +16716,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -16749,7 +16800,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
     },
     "tunnel-agent": {
@@ -16768,7 +16819,7 @@
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -16776,7 +16827,7 @@
     },
     "type-is": {
       "version": "1.6.16",
-      "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
@@ -16835,7 +16886,7 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
@@ -16948,7 +16999,7 @@
     },
     "union-value": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
         "arr-union": "^3.1.0",
@@ -16959,7 +17010,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -16967,7 +17018,7 @@
         },
         "set-value": {
           "version": "0.4.3",
-          "resolved": "http://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -16980,12 +17031,12 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
     },
     "unique-filename": {
@@ -17006,7 +17057,7 @@
     },
     "unique-string": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "^1.0.0"
@@ -17060,12 +17111,12 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
         "has-value": "^0.3.1",
@@ -17074,7 +17125,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "http://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
             "get-value": "^2.0.3",
@@ -17084,7 +17135,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
                 "isarray": "1.0.0"
@@ -17094,19 +17145,19 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "http://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
     },
     "unzip-response": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
     },
     "upath": {
@@ -17145,7 +17196,7 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
@@ -17165,12 +17216,12 @@
     },
     "urijs": {
       "version": "1.19.1",
-      "resolved": "http://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
       "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
@@ -17191,7 +17242,7 @@
     },
     "url-loader": {
       "version": "0.6.2",
-      "resolved": "http://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
       "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
       "requires": {
         "loader-utils": "^1.0.2",
@@ -17210,7 +17261,7 @@
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
         "prepend-http": "^1.0.1"
@@ -17246,12 +17297,12 @@
     },
     "utila": {
       "version": "0.4.0",
-      "resolved": "http://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
@@ -17275,7 +17326,7 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vendors": {
@@ -17296,7 +17347,7 @@
     "vfile": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-      "integrity": "sha1-5i2OcrIOg8MkvGxnJ47ickiL+Eo=",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
         "is-buffer": "^1.1.4",
         "replace-ext": "1.0.0",
@@ -17332,7 +17383,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "requires": {
         "indexof": "0.0.1"
@@ -17346,9 +17397,36 @@
         "browser-process-hrtime": "^0.1.2"
       }
     },
+    "wait-on": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.2.0.tgz",
+      "integrity": "sha512-QUGNKlKLDyY6W/qHdxaRlXUAgLPe+3mLL/tRByHpRNcHs/c7dZXbu+OnJWGNux6tU1WFh/Z8aEwvbuzSAu79Zg==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "joi": "^13.0.0",
+        "minimist": "^1.2.0",
+        "request": "^2.88.0",
+        "rx": "^4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "walker": {
       "version": "1.0.7",
-      "resolved": "http://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
@@ -17364,7 +17442,7 @@
     },
     "watch": {
       "version": "0.10.0",
-      "resolved": "http://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
       "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
     },
     "watchpack": {
@@ -17379,7 +17457,7 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "requires": {
             "micromatch": "^3.1.4",
@@ -17388,12 +17466,12 @@
         },
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "braces": {
@@ -17415,7 +17493,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "http://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -17445,7 +17523,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -17453,7 +17531,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
             "debug": "^2.3.3",
@@ -17467,7 +17545,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "http://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -17475,7 +17553,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "http://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -17519,7 +17597,7 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "http://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
@@ -17529,14 +17607,14 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             }
           }
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
             "array-unique": "^0.3.2",
@@ -17551,7 +17629,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "http://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -17559,7 +17637,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "http://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -17569,7 +17647,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -17580,7 +17658,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "http://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -17590,7 +17668,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
             "is-glob": "^3.1.0",
@@ -17599,7 +17677,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
                 "is-extglob": "^2.1.0"
@@ -17635,12 +17713,12 @@
         },
         "is-extglob": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-glob": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
             "is-extglob": "^2.1.1"
@@ -17648,7 +17726,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -17656,7 +17734,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -17666,7 +17744,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "micromatch": {
@@ -17693,7 +17771,7 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "http://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
         "minimalistic-assert": "^1.0.0"
@@ -17701,12 +17779,12 @@
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webpack": {
       "version": "3.8.1",
-      "resolved": "http://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
       "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "requires": {
         "acorn": "^5.0.0",
@@ -17745,7 +17823,7 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
@@ -17765,7 +17843,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "http://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -17779,7 +17857,7 @@
         },
         "has-flag": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         },
         "load-json-file": {
@@ -17795,7 +17873,7 @@
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
             "execa": "^0.7.0",
@@ -17805,7 +17883,7 @@
         },
         "path-type": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "requires": {
             "pify": "^2.0.0"
@@ -17813,7 +17891,7 @@
         },
         "read-pkg": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "requires": {
             "load-json-file": "^2.0.0",
@@ -17823,7 +17901,7 @@
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "requires": {
             "find-up": "^2.0.0",
@@ -17832,12 +17910,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -17846,12 +17924,12 @@
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -17861,12 +17939,12 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "supports-color": {
           "version": "4.5.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
             "has-flag": "^2.0.0"
@@ -17907,7 +17985,7 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "wordwrap": {
@@ -17917,7 +17995,7 @@
         },
         "yargs": {
           "version": "8.0.2",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "requires": {
             "camelcase": "^4.1.0",
@@ -17966,7 +18044,7 @@
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "requires": {
             "camelcase": "^4.1.0"
@@ -17983,7 +18061,7 @@
     },
     "webpack-dev-middleware": {
       "version": "1.12.2",
-      "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "requires": {
         "memory-fs": "~0.4.1",
@@ -18095,7 +18173,7 @@
         },
         "del": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/del/-/del-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
           "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
           "requires": {
             "globby": "^6.1.0",
@@ -18272,7 +18350,7 @@
         },
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
             "array-union": "^1.0.1",
@@ -18373,7 +18451,7 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "yargs": {
@@ -18408,7 +18486,7 @@
     },
     "webpack-manifest-plugin": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-1.3.2.tgz",
       "integrity": "sha512-MX60Bv2G83Zks9pi3oLOmRgnPAnwrlMn+lftMrWBm199VQjk46/xgzBi9lPfpZldw2+EI2S+OevuLIaDuxCWRw==",
       "requires": {
         "fs-extra": "^0.30.0",
@@ -18417,7 +18495,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "0.30.0",
-          "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -18448,7 +18526,7 @@
     },
     "websocket-driver": {
       "version": "0.7.0",
-      "resolved": "http://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
         "http-parser-js": ">=0.4.0",
@@ -18457,7 +18535,7 @@
     },
     "websocket-extensions": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "whatwg-encoding": {
@@ -18490,7 +18568,7 @@
     },
     "whatwg-url": {
       "version": "4.8.0",
-      "resolved": "http://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "requires": {
         "tr46": "~0.0.3",
@@ -18499,14 +18577,14 @@
       "dependencies": {
         "webidl-conversions": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         }
       }
     },
     "whet.extend": {
       "version": "0.9.9",
-      "resolved": "http://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
       "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
     },
     "which": {
@@ -18519,7 +18597,7 @@
     },
     "which-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "widest-line": {
@@ -18532,17 +18610,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -18551,7 +18629,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -18561,7 +18639,7 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
     },
     "word-wrap": {
@@ -18577,7 +18655,7 @@
     },
     "worker-farm": {
       "version": "1.6.0",
-      "resolved": "http://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
       "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
       "requires": {
         "errno": "~0.1.7"
@@ -18599,7 +18677,7 @@
     },
     "write-file-atomic": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -18617,12 +18695,12 @@
     },
     "x-is-string": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xml": {
@@ -18633,7 +18711,7 @@
     },
     "xml-name-validator": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
     },
     "xregexp": {
@@ -18648,7 +18726,7 @@
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "http://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
@@ -18658,7 +18736,7 @@
     },
     "yargs": {
       "version": "7.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "requires": {
         "camelcase": "^3.0.0",
@@ -18678,7 +18756,7 @@
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "requires": {
         "camelcase": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "tslint-config-prettier": "^1.15.0",
     "tslint-config-standard": "^7.1.0",
     "tslint-microsoft-contrib": "^5.2.1",
-    "typescript": "3.0.3"
+    "typescript": "3.0.3",
+    "wait-on": "3.2.0"
   },
   "scripts": {
     "lint": "tslint -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
@@ -111,7 +112,8 @@
     "tsc": "tsc",
     "builduipackage": "tsc -p ./publish/tsconfig.json --listFiles && tsc -p ./scripts/tsconfig.json --listFiles && node ./scripts/publish.js",
     "commit": "git-cz",
-    "servebuild": "tsc -p ./server/tsconfig.json && node ./server/server.js"
+    "servebuild": "tsc -p ./server/tsconfig.json && node ./server/server.js",
+    "wait-on": "wait-on"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Adds 'wait-on' to CI builds to be more proper.

Current CI builds rely on cypress waits in the cy.visit() command. It should rely not start tests unless the bot and ui are started successfully.