### PR TITLE
feat: add button to clear/reset dialog filters

### DIFF
--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -549,6 +549,7 @@ export enum FM {
     TRAINDIALOGS_FILTERING_ENTITIES = 'TrainDialogs.FilteringEntities',
     TRAINDIALOGS_FILTERING_ACTIONS_LABEL = 'TrainDialogs.FilteringActions.Label',
     TRAINDIALOGS_FILTERING_ACTIONS = 'TrainDialogs.FilteringActions',
+    TRAINDIALOGS_FILTERING_RESET = 'TrainDialogs.Filters.reset',
     TRAINDIALOGS_LISTVIEW_BUTTON = 'TrainDialogs.ListView.Button',
     TRAINDIALOGS_TREEVIEW_BUTTON = 'TrainDialogs.TreeView.Button',
 
@@ -930,6 +931,7 @@ export default {
         [FM.TRAINDIALOGS_FILTERING_ENTITIES]: 'All entities',
         [FM.TRAINDIALOGS_FILTERING_ACTIONS_LABEL]: 'Filter by Actions:',
         [FM.TRAINDIALOGS_FILTERING_ACTIONS]: 'All actions',
+        [FM.TRAINDIALOGS_FILTERING_RESET]: 'Clear',
         [FM.TRAINDIALOGS_LISTVIEW_BUTTON]: 'List View',
         [FM.TRAINDIALOGS_TREEVIEW_BUTTON]: 'Tree View',
 

--- a/src/routes/Apps/App/TrainDialogs.css
+++ b/src/routes/Apps/App/TrainDialogs.css
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Licensed under the MIT License.
+ */
+.cl-traindialogs-filter-search {
+    display: grid;
+    grid-template-columns: auto max-content;
+    grid-gap: 1em;
+}


### PR DESCRIPTION
Adds button to clear filters.

If you manually added a filter or implicitly added by coming from an action this helps to clera the filters.
Before you would have to manually select the dropdown and scroll to select the "All *" option. This does it one click and is also a visual indicator if the filter is set.  For examplle if you enter a search term it might be only showing 9 of the total 10 dialogs and you could think you're looking at the complete set but you are not. 

![http://g.recordit.co/do7T8t10xS.gif](http://g.recordit.co/do7T8t10xS.gif)

Update: Temporarily disregard the amount of files and changes in the PR. I had to rebase on another PR to get the models change and that PR is stuck.  Will fix this when that PR is fixed.