### PR TITLE
fix: visual defects due to office 6.x 

### DIFF
--- a/src/components/CLTagPicker.css
+++ b/src/components/CLTagPicker.css
@@ -17,3 +17,17 @@
 .cl-tagpicker .ms-BasePicker-text:not(.ms-BasePicker-text--static) {
     border-left: none;
 }
+
+.ms-BasePicker-text--static {
+    display: flex;
+    position: relative;
+    flex-wrap: wrap;
+    align-items: center;
+    box-sizing: border-box;
+    min-width: 180px;
+    min-height: 30px;
+    border-width: 1px;
+    border-style: solid;
+    border-image: initial;
+    border-color: rgb(0, 120, 212);
+}

--- a/src/components/CLTagPicker.tsx
+++ b/src/components/CLTagPicker.tsx
@@ -29,7 +29,7 @@ export const component = (props: ICLTagPickerProps) => {
                 <HelpIcon tipType={props.tipType} />
             </OF.Label>
             <div className="cl-tagpicker">
-                <div className="ms-BasePicker-text ms-BasePicker-text--static text-175" role="list">
+                <div className="ms-BasePicker-text ms-BasePicker-text--static" role="list">
                     {nonRemovableTags.map(tag => (
                         <div className={`ms-TagItem ${nonRemoveableHighlight ? 'ms-TagItem-text--highlight' : ''}`} tabIndex={0} key={tag.key}>
                             <span data-testid="picker-tag-nonRemovable" className={`ms-TagItem-text ${nonRemoveableStrikethrough ? 'ms-TagItem-text--strike' : ''}`} aria-label={tag.name}>{tag.name}</span>

--- a/src/components/modals/MergeModal.tsx
+++ b/src/components/modals/MergeModal.tsx
@@ -79,7 +79,7 @@ class MergeModal extends React.Component<Props, ComponentState> {
 
         const { intl } = this.props
 
-        const savedInput =  DialogUtils.dialogSampleInput(this.props.savedTrainDialog)
+        const savedInput = DialogUtils.dialogSampleInput(this.props.savedTrainDialog)
         const existingInput = DialogUtils.dialogSampleInput(this.props.existingTrainDialog)
         const isSavedLonger = DialogUtils.isTrainDialogLonger(this.props.savedTrainDialog, this.props.existingTrainDialog)
 
@@ -105,18 +105,18 @@ class MergeModal extends React.Component<Props, ComponentState> {
                     <div>
                         {Util.formatMessageId(intl, FM.MERGE_BODY3)}
                     </div>
-                </div>    
+                </div>
                 <div>
                     <OF.Label className="ms-Label--tight cl-label">
                         {Util.formatMessageId(intl, FM.MERGE_LABEL_SAVED)}
                     </OF.Label>
                     <div className="cl-merge-box cl-merge-box--readonly">
                         <DialogMetadata
-                                description={this.props.savedTrainDialog.description}
-                                userInput={savedInput}
-                                tags={this.props.savedTrainDialog.tags}
-                                allUniqueTags={[]}
-                                readOnly={true}
+                            description={this.props.savedTrainDialog.description}
+                            userInput={savedInput}
+                            tags={this.props.savedTrainDialog.tags}
+                            allUniqueTags={[]}
+                            readOnly={true}
                         />
                     </div>
                     <OF.Label className="ms-Label--tight cl-label">
@@ -124,11 +124,11 @@ class MergeModal extends React.Component<Props, ComponentState> {
                     </OF.Label>
                     <div className="cl-merge-box cl-merge-box--readonly">
                         <DialogMetadata
-                                description={this.props.existingTrainDialog.description}
-                                userInput={existingInput}
-                                tags={this.props.existingTrainDialog.tags}
-                                allUniqueTags={[]}
-                                readOnly={true}
+                            description={this.props.existingTrainDialog.description}
+                            userInput={existingInput}
+                            tags={this.props.existingTrainDialog.tags}
+                            allUniqueTags={[]}
+                            readOnly={true}
                         />
                     </div>
                     <OF.Label className="ms-Label--tight cl-label">
@@ -136,32 +136,37 @@ class MergeModal extends React.Component<Props, ComponentState> {
                     </OF.Label>
                     <div className="cl-merge-box">
                         <DialogMetadata
-                                description={this.state.description}
-                                tags={this.state.tags}
-                                userInput={isSavedLonger ? savedInput : existingInput}
-                                altInput={isSavedLonger ? existingInput : savedInput}
-                                allUniqueTags={this.props.allUniqueTags}
-                                onChangeDescription={this.onChangeDescription}
-                                onAddTag={this.onAddTag}
-                                onRemoveTag={this.onRemoveTag}
+                            description={this.state.description}
+                            tags={this.state.tags}
+                            userInput={isSavedLonger ? savedInput : existingInput}
+                            altInput={isSavedLonger ? existingInput : savedInput}
+                            allUniqueTags={this.props.allUniqueTags}
+                            onChangeDescription={this.onChangeDescription}
+                            onAddTag={this.onAddTag}
+                            onRemoveTag={this.onRemoveTag}
                         />
                     </div>
-                </div>              
-                <OF.DialogFooter>
-                    <OF.PrimaryButton
-                        onClick={() => this.props.onMerge(this.state.description, this.state.tags)}
-                        className="cl-rotate"
-                        text={Util.formatMessageId(intl, FM.MERGE_BUTTON_MERGE)}
-                        iconProps={{ iconName: 'Merge' }}
-                        data-testid="merge-modal-merge-button"
-                    />
-                    <OF.DefaultButton
-                        onClick={() => this.props.onCancel()}
-                        text={Util.formatMessageId(intl, FM.MERGE_BUTTON_SAVE)}
-                        iconProps={{ iconName: 'Accept' }}
-                        data-testid="merge-modal-save-as-is-button"
-                    />
-                </OF.DialogFooter>        
+                </div>
+                <div className='cl-modal_footer'>
+                    <div className="cl-modal-buttons">
+                        <div className="cl-modal-buttons_secondary" />
+                        <div className="cl-modal-buttons_primary">
+                            <OF.PrimaryButton
+                                onClick={() => this.props.onMerge(this.state.description, this.state.tags)}
+                                className="cl-rotate"
+                                text={Util.formatMessageId(intl, FM.MERGE_BUTTON_MERGE)}
+                                iconProps={{ iconName: 'Merge' }}
+                                data-testid="merge-modal-merge-button"
+                            />
+                            <OF.DefaultButton
+                                onClick={() => this.props.onCancel()}
+                                text={Util.formatMessageId(intl, FM.MERGE_BUTTON_SAVE)}
+                                iconProps={{ iconName: 'Accept' }}
+                                data-testid="merge-modal-save-as-is-button"
+                            />
+                        </div>
+                    </div>
+                </div>
             </Modal>
         )
     }


### PR DESCRIPTION
The rendering and classes of the TagPicker changed and this updates the classes.

Before:
![image](https://user-images.githubusercontent.com/2856501/59379703-22886980-8d0c-11e9-83b0-a61a3c178897.png)

After:
![image](https://user-images.githubusercontent.com/2856501/59379714-2caa6800-8d0c-11e9-8617-0d64220e8cb4.png)

There was also use of `DialogFooter` component outside of a `Dialog` which caused horizontal scrolling on the MergeModal. This now uses the `cl-modal-footer` with button s

It seems we would have to refactor a lot modal in future, but should fix the bug for now.