### PR TITLE
 fix: prevent poller undefined issue

### DIFF
--- a/src/services/poller.ts
+++ b/src/services/poller.ts
@@ -32,7 +32,7 @@ export interface IPollerOptions {
 const global = window
 export class Poller {
     // Need some random character for visual difference in logs. Could use uuid() library but don't want dependency
-    private id = Symbol(Math.floor(Math.random() * 100))
+    // private id = Symbol(Math.floor(Math.random() * 100))
     private polls: ActivePoll[] = []
     constructor(options: IPollerOptions) {
         global.setInterval(async () => await this.poll(), options.interval)
@@ -45,14 +45,14 @@ export class Poller {
         const activeApp = this.polls.find(p => p && p.id === id)
 
         if (activeApp) {
-            console.debug(`Poller: ${this.id.toString()} - Existing polling found for id: ${id} increasing end from ${activeApp.end} to: ${end}`)
+            // console.log(`Poller: ${this.id.toString()} - Existing polling found for id: ${id} increasing end from ${activeApp.end} to: ${end}`)
             activeApp.end = end
             return new Promise((resolve, reject) => {
                 activeApp.deferred.push({ resolve, reject, pollConfig })
             })
         }
 
-        console.debug(`Poller: ${this.id.toString()} - No polling found for id: ${id}. Starting new polling until: ${end}`)
+        // console.log(`Poller: ${this.id.toString()} - No polling found for id: ${id}. Starting new polling until: ${end}`)
         return new Promise((resolve, reject) => {
             this.polls.push({
                 id,

--- a/src/services/poller.ts
+++ b/src/services/poller.ts
@@ -68,6 +68,7 @@ export class Poller {
 
     private async poll() {
         const now = (new Date()).getTime()
+        // TODO: Think the issue is poll being mapped to undefined, then future operation tries to access that poll id.
         // Alternate approach is to split this into three phases: Filter those expired, await all requests, then filter all resolved.
         this.polls = (await Promise.all(this.polls.map(async poll => {
             const { end } = poll

--- a/src/services/poller.ts
+++ b/src/services/poller.ts
@@ -32,7 +32,7 @@ export interface IPollerOptions {
 const global = window
 export class Poller {
     // Need some random character for visual difference in logs. Could use uuid() library but don't want dependency
-    // For Console.log : private id = Symbol(Math.floor(Math.random() * 100))
+    private id = Symbol(Math.floor(Math.random() * 100))
     private polls: ActivePoll[] = []
     constructor(options: IPollerOptions) {
         global.setInterval(async () => await this.poll(), options.interval)
@@ -45,14 +45,14 @@ export class Poller {
         const activeApp = this.polls.find(p => p.id === id)
 
         if (activeApp) {
-            // console.log(`Poller: ${this.id.toString()} - Existing polling found for id: ${id} increasing end from ${activeApp.end} to: ${end}`)
+            console.debug(`Poller: ${this.id.toString()} - Existing polling found for id: ${id} increasing end from ${activeApp.end} to: ${end}`)
             activeApp.end = end
             return new Promise((resolve, reject) => {
                 activeApp.deferred.push({ resolve, reject, pollConfig })
             })
         }
 
-        // console.log(`Poller: ${this.id.toString()} - No polling found for id: ${id}. Starting new polling until: ${end}`)
+        console.debug(`Poller: ${this.id.toString()} - No polling found for id: ${id}. Starting new polling until: ${end}`)
         return new Promise((resolve, reject) => {
             this.polls.push({
                 id,

--- a/src/services/poller.ts
+++ b/src/services/poller.ts
@@ -42,7 +42,7 @@ export class Poller {
         const { id, maxDuration } = pollConfig
         const start = new Date().getTime()
         const end = start + maxDuration
-        const activeApp = this.polls.find(p => p.id === id)
+        const activeApp = this.polls.find(p => p && p.id === id)
 
         if (activeApp) {
             console.debug(`Poller: ${this.id.toString()} - Existing polling found for id: ${id} increasing end from ${activeApp.end} to: ${end}`)


### PR DESCRIPTION
There was ADO bug 2135 which has since been closed and not reproducable but these changes might mitigate if it happens again.

As comment says, I believe there is weird condtion where the array has an `undefined` injected into it which is then processed later. This shouldn't be possible based on single threaded code and executing till completion which ensure the `undefined`s are filtered out before processed however it's the only way I think this bug can occur.