### PR TITLE
fix: use react ref objects instead of callback refs

### DIFF
--- a/src/components/modals/ActionPayloadEditor/PayloadEditor.tsx
+++ b/src/components/modals/ActionPayloadEditor/PayloadEditor.tsx
@@ -59,7 +59,7 @@ const initialState: Readonly<State> = {
 
 export default class PayloadEditor extends React.Component<Props, State> {
     fuse: Fuse
-    menu: HTMLElement
+    menuRef = React.createRef<HTMLDivElement>()
     plugins: any[]
 
     constructor(props: Props) {
@@ -103,7 +103,7 @@ export default class PayloadEditor extends React.Component<Props, State> {
 
         // If we've somehow executed before the menu onRef and don't have a reference to the menu element return
         // We need to menu to compute the position so there is no point to continue
-        const menu = this.menu
+        const menu = this.menuRef.current
         if (!menu) {
             return
         }
@@ -117,7 +117,7 @@ export default class PayloadEditor extends React.Component<Props, State> {
             return
         }
 
-        const relativeParent = Utilities.getRelativeParent(this.menu.parentElement)
+        const relativeParent = Utilities.getRelativeParent(menu.parentElement)
         const relativeRect = relativeParent.getBoundingClientRect()
 
         const selection = window.getSelection()
@@ -290,7 +290,9 @@ export default class PayloadEditor extends React.Component<Props, State> {
             .collapseToStartOfNextText()
 
         // Reset Scroll position of menuRef
-        this.menu.scrollTop = 0
+        if (this.menuRef.current) {
+            this.menuRef.current.scrollTop = 0
+        }
 
         // Reset highlight index to be ready for next node
         this.setState({
@@ -345,10 +347,6 @@ export default class PayloadEditor extends React.Component<Props, State> {
         return true
     }
 
-    onMenuRef = (element: HTMLElement) => {
-        this.menu = element
-    }
-
     onClickOption = (option: IOption) => {
         const change = this.props.value.change()
         this.onCompleteNode(undefined, change, option)
@@ -367,7 +365,7 @@ export default class PayloadEditor extends React.Component<Props, State> {
 
         return <div className="editor-container" data-testid={this.props[testAttribute]}>
             <Picker
-                menuRef={this.onMenuRef}
+                ref={this.menuRef}
                 {...this.state.menuProps}
                 matchedOptions={matchedOptions}
                 onClickOption={this.onClickOption}

--- a/src/components/modals/ActionPayloadEditor/Picker.tsx
+++ b/src/components/modals/ActionPayloadEditor/Picker.tsx
@@ -15,22 +15,20 @@ interface Props {
     left: number
     top: number
     searchText: string
-    menuRef: (element: HTMLDivElement) => void
     onClickOption: (option: IOption) => void
 }
 
-interface State {
-    listRef: React.RefObject<HTMLDivElement>
+interface PropsWithRef extends Props {
+    menuRef: React.Ref<HTMLDivElement>
 }
 
-export default class Picker extends React.Component<Props, State> {
-    state: State = {
-        listRef: React.createRef<HTMLDivElement>()
-    }
+
+class Picker extends React.Component<PropsWithRef> {
+    listRef=  React.createRef<HTMLDivElement>()
 
     componentDidUpdate() {
-        if (this.state.listRef.current) {
-            this.scrollHighlightedElementIntoView(this.state.listRef.current)
+        if (this.listRef.current) {
+            this.scrollHighlightedElementIntoView(this.listRef.current)
         }
     }
 
@@ -58,7 +56,7 @@ export default class Picker extends React.Component<Props, State> {
             ref={this.props.menuRef}
             style={style}
         >
-            <div className="mention-picker-list" ref={this.state.listRef}>
+            <div className="mention-picker-list" ref={this.listRef}>
                 {this.props.matchedOptions.length === 0
                     ? <div className="mention-picker-button">No Results</div>
                     : this.props.matchedOptions.map((matchedOption, i) =>
@@ -75,3 +73,5 @@ export default class Picker extends React.Component<Props, State> {
         </div>
     }
 }
+
+export default React.forwardRef<HTMLDivElement, Props>((props, ref) => <Picker {...props} menuRef={ref} />)

--- a/src/components/modals/ActionScorer.tsx
+++ b/src/components/modals/ActionScorer.tsx
@@ -90,7 +90,7 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
                 }
                 else {
                     const refFn = (index === 0)
-                        ? (ref: any) => { component.primaryScoreButton = ref }
+                        ? component.primaryScoreButtonRef
                         : undefined
                     return (
                         <OF.PrimaryButton
@@ -260,7 +260,7 @@ interface ComponentState {
 }
 
 class ActionScorer extends React.Component<Props, ComponentState> {
-    primaryScoreButton: OF.IButton | null = null;
+    primaryScoreButtonRef = React.createRef<OF.IButton>()
 
     constructor(p: Props) {
         super(p);
@@ -333,8 +333,8 @@ class ActionScorer extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     focusPrimaryButton(): void {
-        if (this.primaryScoreButton) {
-            this.primaryScoreButton.focus();
+        if (this.primaryScoreButtonRef.current) {
+            this.primaryScoreButtonRef.current.focus();
         }
         else {
             setTimeout(this.focusPrimaryButton, 100)
@@ -657,8 +657,9 @@ class ActionScorer extends React.Component<Props, ComponentState> {
             if (column.key === 'select') {
                 // Will focus on new action button if no scores
                 const ref = (index === 0)
-                    ? (r: OF.IButton) => { this.primaryScoreButton = r }
-                    : undefined;
+                    ? this.primaryScoreButtonRef
+                    : undefined
+
                 return (
                     <OF.PrimaryButton
                         data-testid="action-scorer-add-action-button"

--- a/src/components/modals/EntityCreatorEditor/EntityCreatorComponent.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorComponent.tsx
@@ -85,7 +85,14 @@ interface ReceivedProps {
 
 type Props = ReceivedProps & InjectedIntlProps
 
-const EditComponent: React.SFC<Props> = (props) => {
+const EditComponent: React.FC<Props> = (props) => {
+    const nameRef = React.createRef<OF.ITextField>()
+    React.useEffect(() => {
+        if (nameRef.current) {
+            nameRef.current.focus()
+        }
+    }, [nameRef.current])
+
     return <div className="cl-entity-creator-form">
         <TC.Dropdown
             data-testid="entity-creator-entity-type-dropdown"
@@ -112,7 +119,7 @@ const EditComponent: React.SFC<Props> = (props) => {
             required={true}
             value={props.name}
             disabled={props.isNameDisabled}
-            componentRef={setFocused}
+            componentRef={nameRef}
             autoComplete="off"
         />
         {props.entityTypeKey === CLM.EntityType.LUIS &&
@@ -331,10 +338,6 @@ const Component: React.SFC<Props> = (props) => {
             </div>}
         />
     </OF.Modal>
-}
-
-function setFocused(ref: OF.ITextField) {
-    if (ref) ref.focus()
 }
 
 export default Component

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -47,7 +47,7 @@ interface ComponentState {
 // TODO: Need to re-define TextVariation / ExtractResponse class defs so we don't need
 // to do all the messy conversion back and forth
 class EntityExtractor extends React.Component<Props, ComponentState> {
-    private doneExtractingButton: any = null;
+    private doneExtractingButtonRef = React.createRef<OF.IButton>()
 
     constructor(p: any) {
         super(p);
@@ -72,8 +72,8 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     focusPrimaryButton(): void {
-        if (this.doneExtractingButton) {
-            this.doneExtractingButton.focus();
+        if (this.doneExtractingButtonRef.current) {
+            this.doneExtractingButtonRef.current.focus();
         }
         else {
             setTimeout(this.focusPrimaryButton, 100)
@@ -532,7 +532,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                             onClick={this.onSubmitTextVariation}
                             ariaDescription={'Add'}
                             text={'Add'}
-                            componentRef={(ref: any) => { this.doneExtractingButton = ref }}
+                            componentRef={this.doneExtractingButtonRef}
                             iconProps={{ iconName: 'Add' }}
                         />
                         <OF.TextField
@@ -561,7 +561,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                                 onClick={this.onClickSubmitExtractions}
                                 ariaDescription={'Submit Changes'}
                                 text={'Submit Changes'}
-                                componentRef={(ref: any) => { this.doneExtractingButton = ref }}
+                                componentRef={this.doneExtractingButtonRef}
                                 iconProps={{ iconName: 'Accept' }}
                             />
                             <OF.PrimaryButton
@@ -578,7 +578,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                             onClick={this.onClickSubmitExtractions}
                             ariaDescription={'Score Actions'}
                             text={'Score Actions'}
-                            componentRef={(ref: any) => { this.doneExtractingButton = ref }}
+                            componentRef={this.doneExtractingButtonRef}
                         />
                     }
 

--- a/src/components/modals/TreeView/TreeView.tsx
+++ b/src/components/modals/TreeView/TreeView.tsx
@@ -35,20 +35,19 @@ interface ComponentState {
     selectedNode: TreeNode | null
     expandedNode: TreeNode | null
     translateX: number | null,
-    treeContainer: any,
     treeElement: any,
     fullScreen: boolean,
     showBanner: boolean,
 }
 
 class TreeView extends React.Component<Props, ComponentState> {
+    private treeContainerRef = React.createRef<any>()
 
     state: ComponentState = {
         tree: null,
         selectedNode: null,
         expandedNode: null,
         translateX: null,
-        treeContainer: null,
         treeElement: null,
         fullScreen: false,
         showBanner: true
@@ -61,13 +60,13 @@ class TreeView extends React.Component<Props, ComponentState> {
         if (this.props.trainDialogs !== prevProps.trainDialogs) {
             this.updateTree()
         }
-        if (this.state.treeContainer) {
+        if (this.treeContainerRef.current) {
             if (!this.state.translateX || (this.state.selectedNode !== prevState.selectedNode)) {
                 if (this.state.selectedNode) {
                     this.setState({translateX: NODE_WIDTH})
                 }
                 else {
-                        const dimensions = this.state.treeContainer.getBoundingClientRect();
+                        const dimensions = this.treeContainerRef.current.getBoundingClientRect();
                         this.setState({
                             translateX: dimensions.width / 2.5,
                         })
@@ -344,11 +343,6 @@ class TreeView extends React.Component<Props, ComponentState> {
     }
 
     @OF.autobind
-    setContainerRef(treeContainer: any): void {
-        this.setState({treeContainer})
-    }
-
-    @OF.autobind
     toggleFullScreen(): void {
         this.setState({fullScreen: !this.state.fullScreen})
     }
@@ -387,9 +381,9 @@ class TreeView extends React.Component<Props, ComponentState> {
                     <div className="cl-treeview-columnRight">
                         <div 
                             className="cl-treeview-container"
-                            ref={this.setContainerRef}
+                            ref={this.treeContainerRef}
                         >
-                            {this.state.tree && this.state.treeContainer &&
+                            {this.state.tree && this.treeContainerRef.current &&
                                 <Tree 
                                     data={this.state.tree!}
                                     ref={this.setTreeRef}

--- a/src/routes/Apps/App/Actions.tsx
+++ b/src/routes/Apps/App/Actions.tsx
@@ -27,7 +27,7 @@ interface ComponentState {
 }
 
 class Actions extends React.Component<Props, ComponentState> {
-    newActionButton: OF.IButton
+    private newActionButtonRef = React.createRef<OF.IButton>()
 
     constructor(p: any) {
         super(p);
@@ -45,7 +45,7 @@ class Actions extends React.Component<Props, ComponentState> {
     }
 
     componentDidMount() {
-        this.newActionButton.focus();
+        this.focusNewActionButton()
     }
 
     onSelectAction(action: ActionBase) {
@@ -70,7 +70,7 @@ class Actions extends React.Component<Props, ComponentState> {
             isActionEditorOpen: false,
             actionSelected: null
         }, () => {
-            setTimeout(() => this.newActionButton.focus(), 500)
+            setTimeout(() => this.focusNewActionButton(), 500)
         })
     }
 
@@ -82,7 +82,7 @@ class Actions extends React.Component<Props, ComponentState> {
         })
 
         this.props.deleteActionThunkAsync(this.props.app.appId, action.actionId, removeFromDialogs)
-        setTimeout(() => this.newActionButton.focus(), 1000)
+        setTimeout(() => this.focusNewActionButton(), 1000)
     }
 
     @OF.autobind
@@ -97,7 +97,13 @@ class Actions extends React.Component<Props, ComponentState> {
             ? () => this.props.editActionThunkAsync(this.props.app.appId, action)
             : () => this.props.createActionThunkAsync(this.props.app.appId, action)
         apiFunc()
-        setTimeout(() => this.newActionButton.focus(), 500)
+        setTimeout(() => this.focusNewActionButton(), 500)
+    }
+
+    private focusNewActionButton() {
+        if (this.newActionButtonRef.current) {
+            this.newActionButtonRef.current.focus()
+        }
     }
 
     getFilteredActions(): ActionBase[] {
@@ -149,7 +155,7 @@ class Actions extends React.Component<Props, ComponentState> {
                             defaultMessage: 'New Action'
                         })}
                         iconProps={{ iconName: 'Add' }}
-                        componentRef={component => this.newActionButton = component!}
+                        componentRef={this.newActionButtonRef}
                     />
                 </div>
                 {actions.length === 0


### PR DESCRIPTION
With the upgrade to 6.x we can use proper react refs now:
https://reactjs.org/docs/refs-and-the-dom.html#creating-refs

Also learned a bit about the `forwardRef` component that allows getting refs of internal DOM elements which is nice as it exposes standard `ref` prop instead of needing a custom prop
