### PR TITLE
fix: prevent Cannot read property 'focus' of null

### DIFF
--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -145,7 +145,7 @@ interface ComponentState {
 }
 
 class Entities extends React.Component<Props, ComponentState> {
-    newEntityButton: OF.IButton
+    newEntityButtonRef = React.createRef<OF.IButton>()
     state: ComponentState
 
     constructor(props: Props) {
@@ -161,7 +161,13 @@ class Entities extends React.Component<Props, ComponentState> {
     }
 
     componentDidMount() {
-        this.newEntityButton.focus()
+        this.focusNewEntityButton()
+    }
+
+    private focusNewEntityButton() {
+        if (this.newEntityButtonRef.current) {
+            this.newEntityButtonRef.current.focus()
+        }
     }
 
     @OF.autobind
@@ -171,7 +177,7 @@ class Entities extends React.Component<Props, ComponentState> {
             entitySelected: null
         })
         this.props.deleteEntityThunkAsync(this.props.app.appId, entity)
-        setTimeout(() => this.newEntityButton.focus(), 1000)
+        setTimeout(() => this.focusNewEntityButton(), 1000)
     }
 
     @OF.autobind
@@ -189,7 +195,7 @@ class Entities extends React.Component<Props, ComponentState> {
             entitySelected: null
         })
         setTimeout(() => {
-            this.newEntityButton.focus();
+            this.focusNewEntityButton();
         }, 500);
     }
 
@@ -285,7 +291,7 @@ class Entities extends React.Component<Props, ComponentState> {
                             defaultMessage: 'New Entity'
                         })}
                         iconProps={{ iconName: 'Add' }}
-                        componentRef={component => this.newEntityButton = component!}
+                        componentRef={this.newEntityButtonRef}
                     />
                 </div>
                 {entities.length === 0

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -145,7 +145,7 @@ const defaultAcceptConflictResolutionFn = async () => { throw new Error(`acceptC
 // TODO: This component is highly redundant with TrainDialogs.  Should collapse
 class LogDialogs extends React.Component<Props, ComponentState> {
     acceptConflictResolutionFn: (conflictFreeDialog: CLM.TrainDialog) => Promise<void> = defaultAcceptConflictResolutionFn
-    newChatSessionButton: OF.IButton
+    newChatSessionButtonRef = React.createRef<OF.IButton>()
     state: ComponentState
 
     static GetConflicts(rounds: CLM.TrainRound[], previouslySubmittedTextVariations: CLM.TextVariation[]) {
@@ -263,7 +263,13 @@ class LogDialogs extends React.Component<Props, ComponentState> {
     }
 
     componentDidMount() {
-        this.newChatSessionButton.focus()
+        this.focusNewChatButton()
+    }
+
+    private focusNewChatButton() {
+        if (this.newChatSessionButtonRef.current) {
+            this.newChatSessionButtonRef.current.focus()
+        }
     }
 
     componentWillReceiveProps(newProps: Props) {
@@ -969,7 +975,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                         onClick={this.onClickNewChatSession}
                         ariaDescription={Util.formatMessageId(this.props.intl, FM.LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION)}
                         text={Util.formatMessageId(this.props.intl, FM.LOGDIALOGS_CREATEBUTTONTITLE)}
-                        componentRef={component => this.newChatSessionButton = component!}
+                        componentRef={this.newChatSessionButtonRef}
                         iconProps={{ iconName: 'Add' }}
                     />
                     <OF.DefaultButton

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -198,7 +198,7 @@ interface ComponentState {
 }
 
 class TrainDialogs extends React.Component<Props, ComponentState> {
-    newTeachSessionButton: OF.IButton
+    newTeachSessionButtonRef = React.createRef<OF.IButton>()
     state: ComponentState
 
     constructor(props: Props) {
@@ -238,7 +238,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     componentDidMount() {
-        this.newTeachSessionButton.focus();
+        this.focusNewTeachSessionButton()
         if (this.props.filteredAction) {
             this.setState({
                 actionFilter: this.toActionFilter(this.props.filteredAction, this.props.entities)
@@ -248,6 +248,12 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             this.setState({
                 entityFilter: this.toEntityFilter(this.props.filteredEntity)
             })
+        }
+    }
+
+    private focusNewTeachSessionButton() {
+        if (this.newTeachSessionButtonRef.current) {
+            this.newTeachSessionButtonRef.current.focus();
         }
     }
 
@@ -272,7 +278,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         }
         // If train dialogs have been updated, update selected trainDialog too
         if (this.props.trainDialogs !== newProps.trainDialogs) {
-            this.newTeachSessionButton.focus();
+            this.focusNewTeachSessionButton();
         }
     }
 
@@ -1531,7 +1537,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                         onClick={() => this.onClickNewTeachSession()}
                         ariaDescription={Util.formatMessageId(intl, FM.TRAINDIALOGS_CREATEBUTTONARIALDESCRIPTION)}
                         text={Util.formatMessageId(intl, FM.TRAINDIALOGS_CREATEBUTTONTITLE)}
-                        componentRef={component => this.newTeachSessionButton = component!}
+                        componentRef={this.newTeachSessionButtonRef}
                         iconProps={{ iconName: 'Add' }}
                     />
                     <OF.DefaultButton


### PR DESCRIPTION
I'm seeing these errors in some of the tests. 
```
Uncaught TypeError: Cannot read property 'focus' of null

This error originated from your application code, not from Cypress.

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

This behavior is configurable, and you can choose to turn this off by listening to the 'uncaught:exception' event.

https://on.cypress.io/uncaught-exception-from-application
```

I'm guessing it is another race condition where most of the time the button is assigned before we call `focus()` but in some cases it isn't assigned yet.

I need to find a way to reproduce this and debug, but my guess is there is problem with this pattern:
```
// Wrong type - should be OF.IButton | undefined since it's temporarily in that state
newEntityButton: OF.IButton 
...
componentDidMount() {
     // call focus() but the button is still null or undefine
    this.newEntityButton.focus()
}
```

I meant to catch all of these when I changed it to use React.RefObjects but I missed these.

