### PR TITLE
fix: file import selector

### DIFF
--- a/cypress/support/components/HomePage.js
+++ b/cypress/support/components/HomePage.js
@@ -15,7 +15,7 @@ export function ClickImportModelButton() { return cy.Get('[data-testid="model-li
 export function TypeModelName(name) { return cy.Get('[data-testid="model-creator-input-name"]', {timeout: 10000}).type(name) }
 export function ClickSubmitButton() { return cy.Get('[data-testid="model-creator-submit-button"]').Click() }
 
-export function UploadImportModelFile(name) { return cy.UploadFile(name, `[data-testid="model-creator-import-file-picker"] > div > input[type="file"]`) }
+export function UploadImportModelFile(name) { return cy.UploadFile(name, `[data-testid="model-creator-import-file-picker"] input[type="file"]`) }
 
 export function ClickDeleteModelButton(row) { return cy.Get(`[data-list-index="${row}"] > .ms-FocusZone > .ms-DetailsRow-fields`).find('i[data-icon-name="Delete"]').Click() }
 export function ClickConfirmButton() { return cy.Get('.ms-Dialog-main').contains('Confirm').Click() }


### PR DESCRIPTION
I'm not quite sure what happened here.  I assume this broke because of change to 6.x office fabric where they removed a `div` yet it was said tests had been passing. You can see DOM doesn't have the div.  This selector was overly specific anyways.

`CypressError: Timed out retrying: Expected to find element: '[data-testid="model-creator-import-file-picker"] > div > input[type="file"]', but never found it.`

![image](https://user-images.githubusercontent.com/2856501/60117670-60838580-972f-11e9-96ee-b21860bd61e1.png)
