### PR TITLE
fix: log dialog delete confirmation

### DIFF
--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -1116,7 +1116,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                 <ConfirmCancelModal
                     open={this.state.isConfirmDeleteModalOpen}
                     onCancel={this.onClickCancelDelete}
-                    onOk={this.onClickConfirmDelete}
+                    onConfirm={this.onClickConfirmDelete}
                     title={Util.formatMessageId(intl, FM.LOGDIALOGS_CONFIRMCANCEL_DELETESELECTED, { selectionCount: this.state.selectionCount })}
                 />
             </div>


### PR DESCRIPTION
I assume you wanted the modal to use confirmation button instead of ok:

![image](https://user-images.githubusercontent.com/2856501/60218447-42e41800-9824-11e9-902f-0570153873d7.png)

Fixes ADO#2189
