### PR TITLE
fix: office fabric warnings

### DIFF
--- a/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/ApiPayloadRenderer.tsx
@@ -37,7 +37,7 @@ export default class Component extends React.Component<Props, State> {
         isOriginalVisible: false
     }
 
-    onChangedVisible = () => {
+    onChangeVisible = () => {
         this.setState(prevState => ({
             isOriginalVisible: !prevState.isOriginalVisible
         }))
@@ -88,7 +88,7 @@ export default class Component extends React.Component<Props, State> {
                 && <div>
                     <OF.Toggle
                         checked={this.state.isOriginalVisible}
-                        onChanged={this.onChangedVisible}
+                        onChange={this.onChangeVisible}
                     />
                 </div>}
         </div>

--- a/src/components/actionPayloadRenderers/CardPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/CardPayloadRenderer.tsx
@@ -34,7 +34,7 @@ export default class Component extends React.Component<Props, State> {
         isOriginalVisible: false
     }
 
-    onChangedVisible = () => {
+    onChangeVisible = () => {
         this.setState(prevState => ({
             isOriginalVisible: !prevState.isOriginalVisible
         }))
@@ -88,7 +88,7 @@ export default class Component extends React.Component<Props, State> {
                 {showToggle
                     && <OF.Toggle
                         checked={this.state.isOriginalVisible}
-                        onChanged={this.onChangedVisible}
+                        onChange={this.onChangeVisible}
                     />}
                 <OF.IconButton
                     disabled={this.props.isValidationError}

--- a/src/components/actionPayloadRenderers/TextPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/TextPayloadRenderer.tsx
@@ -20,7 +20,7 @@ export default class Component extends React.Component<Props, State> {
         isOriginalVisible: false
     }
 
-    onChangedVisible = () => {
+    onChangeVisible = () => {
         this.setState(prevState => ({
             isOriginalVisible: !prevState.isOriginalVisible
         }))
@@ -37,7 +37,7 @@ export default class Component extends React.Component<Props, State> {
             {showToggle && <div>
                 <OF.Toggle
                     checked={this.state.isOriginalVisible}
-                    onChanged={this.onChangedVisible}
+                    onChange={this.onChangeVisible}
                 />
             </div>}
         </div>

--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -243,7 +243,7 @@ interface IConditionalTag extends OF.ITag {
 }
 
 export interface NewActionPreset {
-    text: string, 
+    text: string,
     isTerminal: boolean
 }
 
@@ -541,7 +541,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         this.setState(prevState => nextState as ComponentState)
 
         // Set initial text value (used for dummy import actions)
-        if (nextProps.open === true && this.props.open === false) { 
+        if (nextProps.open === true && this.props.open === false) {
             this.initializeActionPresets(nextProps)
         }
     }
@@ -550,13 +550,13 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         if (props.newActionPreset) {
             let values = Plain.deserialize(this.presetText(props.newActionPreset.text))
             this.onChangePayloadEditor(values, TEXT_SLOT)
-            this.setState({isTerminal: props.newActionPreset.isTerminal})
+            this.setState({ isTerminal: props.newActionPreset.isTerminal })
 
             // If a good card match exists switch to card view
             const bestCard = this.bestCardMatch(props.newActionPreset.text, CARD_MATCH_THRESHOLD)
             if (bestCard) {
                 let index = actionTypeOptions.findIndex(ao => ao.key === CLM.ActionTypes.CARD)
-                this.onChangedActionType(actionTypeOptions[index])
+                this.onChangeActionType(actionTypeOptions[index])
             }
         }
     }
@@ -664,7 +664,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         }))
     }
 
-    onChangedEntityOption = (entityOption: OF.IDropdownOption) => {
+    onChangeEntityOption = (event: React.FormEvent<HTMLDivElement>, entityOption: OF.IDropdownOption) => {
         const entity = this.props.entities.find(e => e.entityId === entityOption.key)
 
         if (entity && entity.enumValues) {
@@ -679,7 +679,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         }
     }
 
-    onChangedEnumValueOption = (enumValueOption: OF.IDropdownOption) => {
+    onChangeEnumValueOption = (event: React.FormEvent<HTMLDivElement>, enumValueOption: OF.IDropdownOption) => {
         this.setState({
             selectedEnumValueOptionKey: typeof enumValueOption.key === 'string'
                 ? enumValueOption.key
@@ -687,7 +687,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         })
     }
 
-    onChangedApiOption = (apiOption: OF.IDropdownOption) => {
+    onChangeApiOption = (event: React.FormEvent<HTMLDivElement>, apiOption: OF.IDropdownOption) => {
         const callback = this.props.botInfo.callbacks.find(t => t.name === apiOption.key)
         if (!callback) {
             throw new Error(`Could not find api callback with name: ${apiOption.key}`)
@@ -717,7 +717,12 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         })
     }
 
-    async onChangedCardOption(cardOption: OF.IDropdownOption) {
+    @OF.autobind
+    async onChangeCardOption(cardOption: OF.IDropdownOption | undefined) {
+        if (!cardOption) {
+            return
+        }
+
         const template = this.props.botInfo.templates.find(t => t.name === cardOption.key)
         if (!template) {
             throw new Error(`Could not find template with name: ${cardOption.key}`)
@@ -745,7 +750,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                 // If no question mark, assume is first period
                 if (firstSplit.length === 1) {
                     firstSplit = semiSplit[0].split('.')
-                } 
+                }
                 const rawTitle = firstSplit.slice(0, firstSplit.length - 1).join()
 
                 const title = Plain.deserialize(`${rawTitle}?`)
@@ -794,7 +799,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         if (index === this.state.cardOptions.length) {
             index = 0
         }
-        this.onChangedCardOption(this.state.cardOptions[index])
+        this.onChangeCardOption(this.state.cardOptions[index])
     }
 
     onPreviousCard = () => {
@@ -803,7 +808,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         if (index < 0) {
             index = this.state.cardOptions.length - 1
         }
-        this.onChangedCardOption(this.state.cardOptions[index])
+        this.onChangeCardOption(this.state.cardOptions[index])
     }
 
     getActionArguments(slateValuesMap: { [slot: string]: ActionPayloadEditor.SlateValue }): CLM.IActionArgument[] {
@@ -1099,7 +1104,11 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
     }
 
     @OF.autobind
-    async onChangedActionType(actionTypeOption: OF.IDropdownOption) {
+    async onChangeActionType(actionTypeOption: OF.IDropdownOption | undefined) {
+        if (!actionTypeOption) {
+            return
+        }
+
         const textPayload = this.state.slateValuesMap[TEXT_SLOT]
         const isPayloadMissing = (actionTypeOption.key === CLM.ActionTypes.TEXT && textPayload && textPayload.document.text.length === 0)
         const isTerminal = actionTypeOption.key === CLM.ActionTypes.END_SESSION
@@ -1130,7 +1139,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
         if (this.state.selectedActionTypeOptionKey === CLM.ActionTypes.CARD && this.props.newActionPreset) {
             const bestCard = this.bestCardMatch(this.props.newActionPreset.text)
             if (bestCard) {
-                this.onChangedCardOption(bestCard)
+                this.onChangeCardOption(bestCard)
             }
         }
     }
@@ -1391,7 +1400,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                             data-testid="dropdown-action-type"
                             label="Action Type"
                             options={actionTypeOptions}
-                            onChanged={actionTypeOption => this.onChangedActionType(actionTypeOption)}
+                            onChange={(event, actionTypeOption) => this.onChangeActionType(actionTypeOption)}
                             selectedKey={this.state.selectedActionTypeOptionKey}
                             disabled={disabled}
                             tipType={ToolTip.TipType.ACTION_TYPE}
@@ -1411,10 +1420,10 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                         data-testid="dropdown-api-option"
                                         label="API"
                                         options={this.state.apiOptions}
-                                        onChanged={this.onChangedApiOption}
+                                        onChange={this.onChangeApiOption}
                                         selectedKey={this.state.selectedApiOptionKey}
                                         disabled={this.state.apiOptions.length === 0}
-                                        placeHolder={this.state.apiOptions.length === 0 ? 'NONE DEFINED' : 'API name...'}
+                                        placeholder={this.state.apiOptions.length === 0 ? 'NONE DEFINED' : 'API name...'}
                                         tipType={ToolTip.TipType.ACTION_API1}
                                     />
                                     <OF.IconButton
@@ -1472,9 +1481,9 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                         </div>
                                         : <div className="cl-errorpanel" data-testid="action-creator-editor-error-callback">
                                             <div>
-                                                {this.props.action && CLM.ActionBase.isStubbedAPI(this.props.action) 
-                                                ? `Stub API: ${this.state.selectedApiOptionKey}`
-                                                : `ERROR: Bot Missing Callback: ${this.state.selectedApiOptionKey}`}
+                                                {this.props.action && CLM.ActionBase.isStubbedAPI(this.props.action)
+                                                    ? `Stub API: ${this.state.selectedApiOptionKey}`
+                                                    : `ERROR: Bot Missing Callback: ${this.state.selectedApiOptionKey}`}
                                             </div>
                                         </div>)
                                 }
@@ -1488,10 +1497,10 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                         data-testid="action-card-template"
                                         label="Template"
                                         options={this.state.cardOptions}
-                                        onChanged={(cardOption) => this.onChangedCardOption(cardOption)}
+                                        onChange={(event, cardOption) => this.onChangeCardOption(cardOption)}
                                         selectedKey={this.state.selectedCardOptionKey}
                                         disabled={this.state.cardOptions.length === 0}
-                                        placeHolder={this.state.cardOptions.length === 0 ? 'NONE DEFINED' : 'Template name...'}
+                                        placeholder={this.state.cardOptions.length === 0 ? 'NONE DEFINED' : 'Template name...'}
                                         tipType={ToolTip.TipType.ACTION_CARD}
                                     />
                                     <OF.IconButton
@@ -1590,9 +1599,9 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                             data-testid="action-set-entity"
                                             label="Entity"
                                             options={this.state.entityOptions}
-                                            onChanged={this.onChangedEntityOption}
+                                            onChange={this.onChangeEntityOption}
                                             selectedKey={this.state.selectedEntityOptionKey}
-                                            placeHolder={this.state.entityOptions.length === 0 ? 'NONE DEFINED' : 'Entity name...'}
+                                            placeholder={this.state.entityOptions.length === 0 ? 'NONE DEFINED' : 'Entity name...'}
                                             disabled={this.state.entityOptions.length === 0}
                                             tipType={ToolTip.TipType.ACTION_SET_ENTITY}
                                         />
@@ -1603,9 +1612,9 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                             data-testid="action-set-enum"
                                             label="Enum Value"
                                             options={this.state.enumValueOptions}
-                                            onChanged={this.onChangedEnumValueOption}
+                                            onChange={this.onChangeEnumValueOption}
                                             selectedKey={this.state.selectedEnumValueOptionKey}
-                                            placeHolder={this.state.enumValueOptions.length === 0 ? 'NONE DEFINED' : 'Enum value...'}
+                                            placeholder={this.state.enumValueOptions.length === 0 ? 'NONE DEFINED' : 'Enum value...'}
                                             disabled={!this.state.selectedEntityOptionKey}
                                             tipType={ToolTip.TipType.ACTION_SET_ENTITY_VALUE}
                                         />

--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -35,15 +35,6 @@ class AppCreator extends React.Component<Props, ComponentState> {
 
     private fileInput: any
 
-    constructor(p: Props) {
-        super(p)
-
-        this.onKeyDown = this.onKeyDown.bind(this)
-        this.localeChanged = this.localeChanged.bind(this)
-        this.onClickCreate = this.onClickCreate.bind(this)
-        this.onClickCancel = this.onClickCancel.bind(this)
-    }
-
     async componentDidMount() {
         const cultures = await getLuisApplicationCultures()
         const cultureOptions = cultures.map<OF.IDropdownOption>(c =>
@@ -70,17 +61,21 @@ class AppCreator extends React.Component<Props, ComponentState> {
         }
     }
 
-    nameChanged(text: string) {
+    @OF.autobind
+    onChangeName(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) {
         this.setState({
             appNameVal: text.trim().length ? text : ""
         })
     }
-    localeChanged(obj: OF.IDropdownOption) {
+
+    @OF.autobind
+    onChangeLocale(event: React.FormEvent<HTMLDivElement>, localeOption: OF.IDropdownOption) {
         this.setState({
-            localeVal: obj.text
+            localeVal: localeOption.text
         })
     }
 
+    @OF.autobind
     onClickCancel() {
         this.props.onCancel()
     }
@@ -107,6 +102,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
 
     // TODO: Refactor to use default form submission instead of manually listening for keys
     // Also has benefit of native browser validation for required fields
+    @OF.autobind
     onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
         // On enter attempt to create the model if required fields are set
         // Not on import as explicit button press is required to pick the file
@@ -224,7 +220,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                     <OF.TextField
                         data-testid="model-creator-input-name"
                         onGetErrorMessage={value => this.onGetNameErrorMessage(value)}
-                        onChanged={text => this.nameChanged(text)}
+                        onChange={this.onChangeName}
                         label={this.getLabel(intl)}
                         placeholder={Utils.formatMessageId(intl, FM.APPCREATOR_FIELDS_NAME_PLACEHOLDER)}
                         onKeyDown={key => this.onKeyDown(key)}
@@ -236,7 +232,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                             label={Utils.formatMessageId(intl, FM.APPCREATOR_FIELDS_LOCALE_LABEL)}
                             defaultSelectedKey={this.state.localeVal}
                             options={this.state.localeOptions}
-                            onChanged={this.localeChanged}
+                            onChange={this.onChangeLocale}
                             disabled={true}
                         // Disabled until trainer can support more than english
                         />

--- a/src/components/modals/EditApiStub.tsx
+++ b/src/components/modals/EditApiStub.tsx
@@ -86,7 +86,7 @@ class EditApiStub extends React.Component<Props, ComponentState> {
     }
 
     @OF.autobind
-    onChangedName(text: string) {
+    onChangeName(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) {
         this.setState({
             apiNameVal: text
         })
@@ -155,7 +155,7 @@ class EditApiStub extends React.Component<Props, ComponentState> {
                         <OF.TextField
                             className={OF.FontClassNames.mediumPlus}
                             readOnly={this.state.editingExisting}
-                            onChanged={(text) => this.onChangedName(text)}
+                            onChange={this.onChangeName}
                             label={Util.formatMessageId(intl, FM.SETTINGS_FIELDS_NAMELABEL)}
                             onGetErrorMessage={value => this.onGetNameErrorMessage(value)}
                             value={this.state.apiNameVal}

--- a/src/components/modals/EntityCreatorEditor/EntityCreatorComponent.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorComponent.tsx
@@ -29,12 +29,12 @@ interface ReceivedProps {
 
     entityTypeKey: CLM.EntityType | string
     isTypeDisabled: boolean
-    onChangedType: (option: OF.IDropdownOption) => void
+    onChangeType: (option: OF.IDropdownOption | undefined) => void
 
     name: string
     isNameDisabled: boolean
     onGetNameErrorMessage: (value: string) => string
-    onChangedName: (name: string) => void
+    onChangeName: (name?: string) => void
     onKeyDownName: React.KeyboardEventHandler<HTMLInputElement>
 
     isMultiValue: boolean
@@ -72,10 +72,10 @@ interface ReceivedProps {
 
     selectedResolverKey: string
     resolverOptions: OF.IDropdownOption[]
-    onResolverChanged: (option: OF.IDropdownOption) => void
+    onChangeResolver: (option?: OF.IDropdownOption) => void
 
     enumValues: (IEnumValueForDisplay | null)[]
-    onChangedEnum: (index: number, value: string) => void
+    onChangeEnum: (index: number, value?: string) => void
     onDeleteEnum: (enumValue: CLM.EnumValue) => void
     onGetEnumErrorMessage: (enumValue: CLM.EnumValue | null) => string
     onCancelEnumDelete: () => void
@@ -99,7 +99,7 @@ const EditComponent: React.FC<Props> = (props) => {
             ariaLabel={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_FIELDS_TYPE_LABEL)}
             label={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_FIELDS_TYPE_LABEL)}
             options={props.entityOptions}
-            onChanged={props.onChangedType}
+            onChange={(event, typeOption) => props.onChangeType(typeOption)}
             onRenderOption={(option: CLDropdownOption) =>
                 <div className="dropdownExample-option">
                     <span className={option.style}>{option.text}</span>
@@ -112,7 +112,7 @@ const EditComponent: React.FC<Props> = (props) => {
         <OF.TextField
             data-testid="entity-creator-entity-name-text"
             onGetErrorMessage={props.onGetNameErrorMessage}
-            onChanged={props.onChangedName}
+            onChange={(event, name) => props.onChangeName(name)}
             onKeyDown={props.onKeyDownName}
             label={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_FIELDS_NAME_LABEL)}
             placeholder={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_FIELDS_NAME_PLACEHOLDER)}
@@ -128,7 +128,7 @@ const EditComponent: React.FC<Props> = (props) => {
                 ariaLabel={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_FIELDS_RESOLVER_LABEL)}
                 label={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_FIELDS_RESOLVER_LABEL)}
                 options={props.resolverOptions}
-                onChanged={props.onResolverChanged}
+                onChange={(event, resolverOption) => props.onChangeResolver(resolverOption)}
                 onRenderOption={(option: CLDropdownOption) =>
                     <div className="dropdownExample-option">
                         <span className={option.style}>{option.text}</span>
@@ -150,7 +150,7 @@ const EditComponent: React.FC<Props> = (props) => {
                         <OF.TextField
                             key={index}
                             className={OF.FontClassNames.mediumPlus}
-                            onChanged={(text) => props.onChangedEnum(index, text)}
+                            onChange={(event, text) => props.onChangeEnum(index, text)}
                             label={index === 0 ? Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_FIELDS_ENUM_LABEL) : ""}
                             errorMessage={props.onGetEnumErrorMessage(value)}
                             value={value ? value.enumValue : ""}

--- a/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
@@ -341,13 +341,13 @@ class Container extends React.Component<Props, ComponentState> {
         this.props.handleClose()
     }
 
-    onChangedName = (text: string) => {
+    onChangeName = (text: string) => {
         this.setState({
             entityNameVal: text
         })
     }
 
-    onChangedType = (obj: CLDropdownOption) => {
+    onChangeType = (obj: CLDropdownOption) => {
         const isPrebuilt = obj.key !== CLM.EntityType.LUIS && obj.key !== CLM.EntityType.LOCAL && obj.key !== CLM.EntityType.ENUM
         const isNegatableVal = isPrebuilt ? false : this.state.isNegatableVal
         const isMultivalueVal = this.state.isMultivalueVal
@@ -374,7 +374,7 @@ class Container extends React.Component<Props, ComponentState> {
         }
     }
 
-    onChangedEnum = (index: number, value: string) => {
+    onChangeEnum = (index: number, value: string) => {
         const enumValuesObjs = [...this.state.enumValues]
         const newValue = value.toUpperCase().trim()
         const enumValueObj = enumValuesObjs[index]
@@ -756,12 +756,12 @@ class Container extends React.Component<Props, ComponentState> {
 
             entityTypeKey={this.state.entityTypeVal}
             isTypeDisabled={this.state.isEditing || this.props.entityTypeFilter != null}
-            onChangedType={this.onChangedType}
+            onChangeType={this.onChangeType}
 
             name={name}
             isNameDisabled={this.state.isPrebuilt}
             onGetNameErrorMessage={this.onGetNameErrorMessage}
-            onChangedName={this.onChangedName}
+            onChangeName={this.onChangeName}
             onKeyDownName={this.onKeyDownName}
 
             isMultiValue={this.state.isMultivalueVal}
@@ -800,10 +800,10 @@ class Container extends React.Component<Props, ComponentState> {
 
             selectedResolverKey={this.state.entityResolverVal}
             resolverOptions={this.resolverOptions}
-            onResolverChanged={this.onChangeResolverType}
+            onChangeResolver={this.onChangeResolverType}
 
             enumValues={enumValues}
-            onChangedEnum={this.onChangedEnum}
+            onChangeEnum={this.onChangeEnum}
             onGetEnumErrorMessage={this.onGetEnumErrorMessage}
             onDeleteEnum={this.onDeleteEnum}
             onCancelEnumDelete={this.onCancelEnumDelete}

--- a/src/components/modals/EntityExtractor.tsx
+++ b/src/components/modals/EntityExtractor.tsx
@@ -310,7 +310,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
         }
     }
 
-    onChangeTextVariation = (value: string): void => {
+    onChangeTextVariation = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string): void => {
         this.setState({
             textVariationValue: value,
             pendingVariationChange: (value.trim().length > 0)
@@ -537,7 +537,7 @@ class EntityExtractor extends React.Component<Props, ComponentState> {
                         <OF.TextField
                             data-testid="entity-extractor-alternative-input-text"
                             value={this.state.textVariationValue}
-                            onChanged={this.onChangeTextVariation}
+                            onChange={this.onChangeTextVariation}
                             placeholder={Util.formatMessageId(this.props.intl, FM.TEXTVARIATION_PLACEHOLDER)}
                             onKeyPress={(event) => {
                                 if (event.key === 'Enter') {

--- a/src/components/modals/MemorySetter.tsx
+++ b/src/components/modals/MemorySetter.tsx
@@ -110,7 +110,11 @@ class MemorySetter extends React.Component<Props> {
         }
     }
 
-    onEnumChanged(item: OF.IDropdownOption, entity: CLM.EntityBase) {
+    onEnumChange(item: OF.IDropdownOption | undefined, entity: CLM.EntityBase) {
+        if (!item) {
+            return
+        }
+
         const map = Util.deepCopy(this.props.map)
         map[entity.entityName].values[0].displayText = item.text
         map[entity.entityName].values[0].userText = item.text
@@ -118,7 +122,11 @@ class MemorySetter extends React.Component<Props> {
         this.props.onUpdate(map)
     }
 
-    onChanged(index: number, text: string, entity: CLM.EntityBase) {  
+    onChange(index: number, text: string | undefined, entity: CLM.EntityBase) {
+        if (!text) {
+            return
+        }
+
         const map = Util.deepCopy(this.props.map)
         map[entity.entityName].values[index].userText = text
         this.props.onUpdate(map)
@@ -150,65 +158,66 @@ class MemorySetter extends React.Component<Props> {
                                 this.props.map[entity.entityName].values.map((memoryValue, index) => {
                                     const key = `${entity.entityId}+${index}`
                                     return (
-                                    <div 
-                                        className="cl-modal-buttons_primary" 
-                                        key={key}
-                                    >
-                                        {entity.entityType === CLM.EntityType.ENUM ?
-                                            <OF.Dropdown
-                                                className="cl-input--inline"
-                                                selectedKey={memoryValue.enumValueId || undefined}
-                                                onChanged={item => this.onEnumChanged(item, entity)}
-                                                options={entity.enumValues!.map<OF.IDropdownOption>(ev => {
-                                                    return {
-                                                        key: ev.enumValueId!,
-                                                        text: ev.enumValue!
-                                                    }
-                                                })}
-                                            />
-                                        :
-                                            <OF.TextField
-                                                data-testid="teach-session-initial-value"
-                                                className="cl-input--inline"
-                                                key={key}
-                                                onChanged={text => this.onChanged(index, text, entity)}
-                                                placeholder={intl.formatMessage({
-                                                    id: FM.TEACHSESSIONINIT_INPUT_PLACEHOLDER,
-                                                    defaultMessage: "Value..."
-                                                })}
-                                                value={memoryValue.userText || ''}
-                                            />
-                                        }
-                                        {(editableEntities.length > 1) &&
+                                        <div
+                                            className="cl-modal-buttons_primary"
+                                            key={key}
+                                        >
+                                            {entity.entityType === CLM.EntityType.ENUM ?
+                                                <OF.Dropdown
+                                                    className="cl-input--inline"
+                                                    selectedKey={memoryValue.enumValueId || undefined}
+                                                    onChange={(event, item) => this.onEnumChange(item, entity)}
+                                                    options={entity.enumValues!.map<OF.IDropdownOption>(ev => {
+                                                        return {
+                                                            key: ev.enumValueId!,
+                                                            text: ev.enumValue!
+                                                        }
+                                                    })}
+                                                />
+                                                :
+                                                <OF.TextField
+                                                    data-testid="teach-session-initial-value"
+                                                    className="cl-input--inline"
+                                                    key={key}
+                                                    onChange={(event, text) => this.onChange(index, text, entity)}
+                                                    placeholder={intl.formatMessage({
+                                                        id: FM.TEACHSESSIONINIT_INPUT_PLACEHOLDER,
+                                                        defaultMessage: "Value..."
+                                                    })}
+                                                    value={memoryValue.userText || ''}
+                                                />
+                                            }
+                                            {(editableEntities.length > 1) &&
+                                                <OF.IconButton
+                                                    className="cl-icon-plain"
+                                                    onClick={() => this.onClickNext(index, entity)}
+                                                    ariaDescription="Move to next Entity"
+                                                    text=""
+                                                    iconProps={{ iconName: 'Down' }}
+                                                />
+                                            }
+                                            {(editableEntities.length > 1) &&
+                                                <OF.IconButton
+                                                    className="cl-icon-plain"
+                                                    onClick={() => this.onClickPrev(index, entity)}
+                                                    ariaDescription="Move to previous Entity"
+                                                    text=""
+                                                    iconProps={{ iconName: 'Up' }}
+                                                />
+                                            }
                                             <OF.IconButton
-                                                className="cl-icon-plain"
-                                                onClick={() => this.onClickNext(index, entity)}
-                                                ariaDescription="Move to next Entity"
-                                                text=""
-                                                iconProps={{ iconName: 'Down' }}
-                                            /> 
-                                        }
-                                        {(editableEntities.length > 1) &&  
-                                            <OF.IconButton
-                                                className="cl-icon-plain"
-                                                onClick={() => this.onClickPrev(index, entity)}
-                                                ariaDescription="Move to previous Entity"
-                                                text=""
-                                                iconProps={{ iconName: 'Up' }}
+                                                className="cl-icon-warning"
+                                                onClick={() => this.onClickRemove(index, entity)}
+                                                ariaDescription="Remove Value"
+                                                iconProps={{ iconName: 'Delete' }}
                                             />
-                                        }
-                                        <OF.IconButton
-                                            className="cl-icon-warning"
-                                            onClick={() => this.onClickRemove(index, entity)}
-                                            ariaDescription="Remove Value"
-                                            iconProps={{ iconName: 'Delete' }}
-                                        />
-                                    </div>
+                                        </div>
                                     )
                                 })
                             }
                         </div>
-                    )}
+                    )
+                }
                 )}
             </div>
         )

--- a/src/components/modals/PackageCreator.tsx
+++ b/src/components/modals/PackageCreator.tsx
@@ -34,7 +34,8 @@ class PackageCreator extends React.Component<Props, ComponentState> {
         })
     }
 
-    nameChanged(text: string) {
+    @OF.autobind
+    onChangeName(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) {
         this.setState({
             versionName: text
         })
@@ -107,7 +108,7 @@ class PackageCreator extends React.Component<Props, ComponentState> {
                     <OF.TextField
                         data-testid="package-creator-input-version-name"
                         onGetErrorMessage={value => this.onGetNameErrorMessage(value)}
-                        onChanged={text => this.nameChanged(text)}
+                        onChange={this.onChangeName}
                         label={intl.formatMessage({
                             id: FM.PACKAGECREATOR_TAG_LABEL,
                             defaultMessage: 'Name'

--- a/src/components/modals/TextboxRestrictable.tsx
+++ b/src/components/modals/TextboxRestrictable.tsx
@@ -19,7 +19,8 @@ class TextboxRestrictableModal extends React.Component<Props, ComponentState> {
         value: '',
     }
 
-    userInputChanged(text: string) {
+    @OF.autobind
+    onChangeText(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) {
         this.setState({
             value: text
         })
@@ -68,7 +69,7 @@ class TextboxRestrictableModal extends React.Component<Props, ComponentState> {
                 <div className="cl-fieldset">
                     <OF.TextField
                         data-testid="user-input-modal-new-message-input"
-                        onChanged={text => this.userInputChanged(text)}
+                        onChange={this.onChangeText}
                         placeholder={this.props.placeholder}
                         onKeyDown={key => this.onKeyDown(key)}
                         value={this.state.value}

--- a/src/components/modals/UserInputModal.tsx
+++ b/src/components/modals/UserInputModal.tsx
@@ -22,7 +22,8 @@ class UserInputModal extends React.Component<Props, ComponentState> {
         userInputVal: '',
     }
 
-    userInputChanged(text: string) {
+    @OF.autobind
+    onChangeUserInputChange(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) {
         this.setState({
             userInputVal: text
         })
@@ -87,7 +88,7 @@ class UserInputModal extends React.Component<Props, ComponentState> {
                     <OF.TextField
                         data-testid="user-input-modal-new-message-input"
                         onGetErrorMessage={value => this.onGetInputErrorMessage(value)}
-                        onChanged={text => this.userInputChanged(text)}
+                        onChange={this.onChangeUserInputChange}
                         placeholder={Util.formatMessageId(intl, FM.USERINPUT_PLACEHOLDER)}
                         onKeyDown={key => this.onKeyDown(key)}
                         value={this.state.userInputVal}

--- a/src/routes/Apps/App/Settings.tsx
+++ b/src/routes/Apps/App/Settings.tsx
@@ -101,7 +101,7 @@ class Settings extends React.Component<Props, ComponentState> {
     }
 
     @OF.autobind
-    onChangedName(text: string) {
+    onChangeName(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) {
         this.setState({
             appNameVal: text,
             edited: true
@@ -109,15 +109,7 @@ class Settings extends React.Component<Props, ComponentState> {
     }
 
     @OF.autobind
-    onChangedBotId(text: string) {
-        this.setState({
-            newBotVal: text,
-            edited: true
-        })
-    }
-
-    @OF.autobind
-    onChangedMarkdown(text: string) {
+    onChangeMarkdown(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) {
         this.setState({
             markdownVal: text,
             edited: true
@@ -125,7 +117,7 @@ class Settings extends React.Component<Props, ComponentState> {
     }
 
     @OF.autobind
-    onChangedVideo(text: string) {
+    onChangeVideo(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) {
         this.setState({
             videoVal: text,
             edited: true
@@ -252,14 +244,16 @@ class Settings extends React.Component<Props, ComponentState> {
         })
     }
 
-    onChangedEditingVersion = (editingOption: OF.IDropdownOption) => {
+    @OF.autobind
+    onChangeEditingVersion(event: React.FormEvent<HTMLDivElement>, editingOption: OF.IDropdownOption) {
         this.props.editAppEditingTagThunkAsync(this.props.app.appId, editingOption.key as string)
         this.setState({
             selectedEditingVersionOptionKey: editingOption.key,
         })
     }
 
-    onChangedLiveVersion = (liveOption: OF.IDropdownOption) => {
+    @OF.autobind
+    onChangeLiveVersion(event: React.FormEvent<HTMLDivElement>, liveOption: OF.IDropdownOption) {
         this.props.editAppLiveTagThunkAsync(this.props.app, liveOption.key as string)
         this.setState({
             selectedLiveVersionOptionKey: liveOption.key,
@@ -373,7 +367,7 @@ class Settings extends React.Component<Props, ComponentState> {
                     <OF.TextField
                         data-testid="settings-input-model-name"
                         className={OF.FontClassNames.mediumPlus}
-                        onChanged={(text) => this.onChangedName(text)}
+                        onChange={this.onChangeName}
                         label={Util.formatMessageId(intl, FM.SETTINGS_FIELDS_NAMELABEL)}
                         onGetErrorMessage={value => this.onGetNameErrorMessage(value)}
                         value={this.state.appNameVal}
@@ -435,14 +429,14 @@ class Settings extends React.Component<Props, ComponentState> {
                             <TC.Dropdown
                                 label={Util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSION_EDITING)}
                                 options={packageOptions}
-                                onChanged={this.onChangedEditingVersion}
+                                onChange={this.onChangeEditingVersion}
                                 selectedKey={this.state.selectedEditingVersionOptionKey}
                                 tipType={ToolTip.TipType.MODEL_VERSION_EDITING}
                             />
                             <TC.Dropdown
                                 label={Util.formatMessageId(this.props.intl, FM.SETTINGS_MODEL_VERSION_LIVE)}
                                 options={packageOptions}
-                                onChanged={this.onChangedLiveVersion}
+                                onChange={this.onChangeLiveVersion}
                                 selectedKey={this.state.selectedLiveVersionOptionKey}
                                 tipType={ToolTip.TipType.MODEL_VERSION_LIVE}
                             />
@@ -497,7 +491,7 @@ class Settings extends React.Component<Props, ComponentState> {
                             <div>
                                 <OF.TextField
                                     className={OF.FontClassNames.mediumPlus}
-                                    onChanged={(text) => this.onChangedMarkdown(text)}
+                                    onChange={this.onChangeMarkdown}
                                     label={Util.formatMessageId(intl, FM.SETTINGS_FIELDS_MARKDOWNLABEL)}
                                     value={this.state.markdownVal}
                                     multiline={true}
@@ -505,7 +499,7 @@ class Settings extends React.Component<Props, ComponentState> {
                                 />
                                 <OF.TextField
                                     className={OF.FontClassNames.mediumPlus}
-                                    onChanged={(text) => this.onChangedVideo(text)}
+                                    onChange={this.onChangeVideo}
                                     label={Util.formatMessageId(intl, FM.SETTINGS_FIELDS_VIDEOLABEL)}
                                     value={this.state.videoVal}
                                 />

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -353,21 +353,21 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     @OF.autobind
-    onSelectTagsFilter(item: OF.IDropdownOption) {
+    onSelectTagsFilter(event: React.FormEvent<HTMLDivElement>, item: OF.IDropdownOption) {
         this.setState({
             tagsFilter: (item.key !== -1) ? item : null
         })
     }
 
     @OF.autobind
-    onSelectEntityFilter(item: OF.IDropdownOption) {
+    onSelectEntityFilter(event: React.FormEvent<HTMLDivElement>, item: OF.IDropdownOption) {
         this.setState({
             entityFilter: (item.key !== -1) ? item : null
         })
     }
 
     @OF.autobind
-    onSelectActionFilter(item: OF.IDropdownOption) {
+    onSelectActionFilter(event: React.FormEvent<HTMLDivElement>, item: OF.IDropdownOption) {
         this.setState({
             actionFilter: (item.key !== -1) ? item : null
         })
@@ -1637,8 +1637,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                                 ariaLabel={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_TAGS_LABEL)}
                                 label={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_TAGS_LABEL)}
                                 selectedKey={(this.state.tagsFilter ? this.state.tagsFilter.key : -1)}
-                                onChanged={this.onSelectTagsFilter}
-                                placeHolder={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_TAGS_LABEL)}
+                                onChange={this.onSelectTagsFilter}
+                                placeholder={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_TAGS_LABEL)}
                                 options={this.props.allUniqueTags
                                     .map<OF.IDropdownOption>((tag, i) => ({
                                         key: i,
@@ -1653,8 +1653,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                                 ariaLabel={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_ENTITIES_LABEL)}
                                 label={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_ENTITIES_LABEL)}
                                 selectedKey={(this.state.entityFilter ? this.state.entityFilter.key : -1)}
-                                onChanged={this.onSelectEntityFilter}
-                                placeHolder={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_ENTITIES_LABEL)}
+                                onChange={this.onSelectEntityFilter}
+                                placeholder={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_ENTITIES_LABEL)}
                                 options={this.props.entities
                                     // Only show positive versions of negatable entities
                                     .filter(e => e.positiveId == null)
@@ -1668,8 +1668,8 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                                 ariaLabel={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_ACTIONS_LABEL)}
                                 label={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_ACTIONS_LABEL)}
                                 selectedKey={(this.state.actionFilter ? this.state.actionFilter.key : -1)}
-                                onChanged={this.onSelectActionFilter}
-                                placeHolder={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_ACTIONS_LABEL)}
+                                onChange={this.onSelectActionFilter}
+                                placeholder={Util.formatMessageId(this.props.intl, FM.TRAINDIALOGS_FILTERING_ACTIONS_LABEL)}
                                 options={this.props.actions
                                     .map(a => this.toActionFilter(a, this.props.entities))
                                     .filter(Util.notNullOrUndefined)


### PR DESCRIPTION
were getting a bunch of decprecation warnings after the upgrade to 6.x
![image](https://user-images.githubusercontent.com/2856501/60358276-7640b700-998a-11e9-9348-b8f6def131ba.png)
![image](https://user-images.githubusercontent.com/2856501/60358284-82c50f80-998a-11e9-9692-9aa54a1d2c78.png)

mainly using standard `onChange` and `placeholder` properties where possible. There were a few such as `onChangeCardOption` or `onChangeActionType` that couldn't be changed because they were called programmatically outside of user events.

Should clean them up. The diff for `MemorySettings` looks larger then it should be because it wasn't formatted earlier.