### PR TITLE
 fix: show sort arrow by default and sort on first click

### DIFF
--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -29,12 +29,26 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
     constructor(p: any) {
         super(p);
         const columns = getColumns(this.props.intl)
+        const defaultSortColumnName = "actionResponse"
+        const defaultSortColumn = columns.find(c => c.key === defaultSortColumnName)
+        if (!defaultSortColumn) {
+            throw new Error(`Could not find column by name: ${defaultSortColumnName}`)
+        }
+
+        columns.forEach(col => {
+            col.isSorted = false
+            col.isSortedDescending = false
+
+            if (col === defaultSortColumn) {
+                col.isSorted = true
+            }
+        })
+
         this.state = {
-            columns: columns,
-            sortColumn: columns[0],
+            columns,
+            sortColumn: defaultSortColumn,
             cardViewerAction: null
         }
-        this.onClickColumnHeader = this.onClickColumnHeader.bind(this);
     }
 
     validationError(action: CLM.ActionBase): boolean {
@@ -98,8 +112,10 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
         return actions;
     }
 
+    @OF.autobind
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
         const { columns } = this.state;
+        const sortColumn = columns.find(c => clickedColumn.key === c.key)!
         const isSortedDescending = !clickedColumn.isSortedDescending;
 
         // Reset the items and columns to match the state.
@@ -109,7 +125,7 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
                 column.isSortedDescending = isSortedDescending;
                 return column;
             }),
-            sortColumn: clickedColumn
+            sortColumn
         });
     }
 

--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -150,13 +150,28 @@ class Entities extends React.Component<Props, ComponentState> {
 
     constructor(props: Props) {
         super(props)
-        const columns = getColumns(this.props.intl);
+        const columns = getColumns(this.props.intl)
+        const defaultSortColumnName = "entityName"
+        const defaultSortColumn = columns.find(c => c.key === defaultSortColumnName)
+        if (!defaultSortColumn) {
+            throw new Error(`Could not find column by name: ${defaultSortColumnName}`)
+        }
+
+        columns.forEach(col => {
+            col.isSorted = false
+            col.isSortedDescending = false
+
+            if (col === defaultSortColumn) {
+                col.isSorted = true
+            }
+        })
+
         this.state = {
             searchValue: '',
             createEditModalOpen: false,
             entitySelected: null,
             columns: columns,
-            sortColumn: columns[0]
+            sortColumn: defaultSortColumn,
         }
     }
 
@@ -211,16 +226,17 @@ class Entities extends React.Component<Props, ComponentState> {
     @OF.autobind
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
         const { columns } = this.state;
+        const sortColumn = columns.find(c => c.key === clickedColumn.key)!
         const isSortedDescending = !clickedColumn.isSortedDescending;
 
         // Reset the items and columns to match the state.
         this.setState({
             columns: columns.map(col => {
-                col.isSorted = (col.key === clickedColumn.key);
+                col.isSorted = (col.key === sortColumn.key);
                 col.isSortedDescending = isSortedDescending;
                 return col;
             }),
-            sortColumn: clickedColumn
+            sortColumn
         });
     }
 
@@ -246,8 +262,8 @@ class Entities extends React.Component<Props, ComponentState> {
                 const secondValue = this.state.sortColumn.getSortValue(b, this)
                 const compareValue = firstValue.localeCompare(secondValue)
                 return this.state.sortColumn.isSortedDescending
-                    ? compareValue
-                    : compareValue * -1
+                    ? compareValue * -1
+                    : compareValue
             })
 
         return filteredEntities;

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -157,7 +157,7 @@ const defaultActionFilter = (intl: InjectedIntl) => ({ key: -1, text: Util.forma
 const defaultTagFilter = (intl: InjectedIntl) => ({ key: -1, text: Util.formatMessageId(intl, FM.TRAINDIALOGS_FILTERING_TAGS) })
 
 interface ComponentState {
-    columns: OF.IColumn[]
+    columns: IRenderableColumn[]
     sortColumn: IRenderableColumn
     history: Activity[]
     lastAction: CLM.ActionBase | null
@@ -200,6 +200,15 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         super(props)
         const columns = getColumns(this.props.intl)
         const lastModifiedColumn = columns.find(c => c.key === 'lastModifiedDateTime')!
+        columns.forEach(col => {
+            col.isSorted = false
+            col.isSortedDescending = false
+
+            if (col === lastModifiedColumn) {
+                col.isSorted = true
+            }
+        })
+
         this.state = {
             columns: columns,
             sortColumn: lastModifiedColumn,
@@ -317,6 +326,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     @OF.autobind
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
         const { columns } = this.state;
+        const sortColumn = columns.find(c => c.key === clickedColumn.key)!
         const isSortedDescending = !clickedColumn.isSortedDescending;
 
         // Reset the items and columns to match the state.
@@ -326,7 +336,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 column.isSortedDescending = isSortedDescending;
                 return column;
             }),
-            sortColumn: clickedColumn
+            sortColumn,
         });
     }
 

--- a/src/routes/Apps/AppsListComponent.tsx
+++ b/src/routes/Apps/AppsListComponent.tsx
@@ -133,7 +133,6 @@ interface Props extends InjectedIntlProps {
 }
 
 interface ComponentState {
-    sortedApps: AppBase[]
     columns: ISortableRenderableColumn[]
     sortColumn: ISortableRenderableColumn
 }
@@ -163,7 +162,6 @@ export class Component extends React.Component<Props, ComponentState> {
         })
 
         this.state = {
-            sortedApps: props.apps,
             columns,
             sortColumn: defaultSortColumn
         }
@@ -188,38 +186,26 @@ export class Component extends React.Component<Props, ComponentState> {
         return sortedApps;
     }
 
-    onClickColumnHeader = (event: React.MouseEvent<HTMLElement>, clickedColumn: ISortableRenderableColumn) => {
-        const { columns, sortedApps } = this.state;
-        const sortColumn = columns.find(c => clickedColumn.key === c.key)!
-        const newColumns = columns.map(col => {
-            col.isSorted = false
-            if (col.key === clickedColumn.key) {
-                col.isSorted = true
-                col.isSortedDescending = !col.isSortedDescending
-            }
-            return col
-        })
-
-        const newSortedApps = this.getSortedApplications(sortColumn, sortedApps)
+    onClickColumnHeader = (event: React.MouseEvent<HTMLElement>, column: ISortableRenderableColumn) => {
+        const { columns } = this.state;
+        const sortColumn = columns.find(c => column.key === c.key)!
 
         this.setState({
-            columns: newColumns,
+            columns: columns.map(col => {
+                col.isSorted = false;
+                if (col.key === column.key) {
+                    col.isSorted = true;
+                    col.isSortedDescending = !col.isSortedDescending;
+                }
+                return col;
+            }),
             sortColumn,
-            sortedApps: newSortedApps,
-        })
-    }
-
-    componentDidUpdate(prevProps: Props) {
-        if (prevProps.apps.length !== this.props.apps.length) {
-            const sortedApps = this.getSortedApplications(this.state.sortColumn, this.props.apps)
-            this.setState({
-                sortedApps
-            })
-        }
+        });
     }
 
     render() {
         const props = this.props
+        const apps = this.getSortedApplications(this.state.sortColumn, props.apps);
 
         return <div className="cl-page">
             <span className={OF.FontClassNames.mediumPlus} data-testid="model-list-title">
@@ -250,7 +236,7 @@ export class Component extends React.Component<Props, ComponentState> {
                     />
                 }
             </div>
-            {this.state.sortedApps.length === 0
+            {apps.length === 0
                 ? <div className="cl-page-placeholder">
                     <div className="cl-page-placeholder__content">
                         <div className={`cl-page-placeholder__description ${OF.FontClassNames.xxLarge}`}>{Util.formatMessageId(props.intl, FM.APPSLIST_EMPTY_TEXT)}</div>
@@ -272,7 +258,7 @@ export class Component extends React.Component<Props, ComponentState> {
                 </div>
                 : <OF.DetailsList
                     className={OF.FontClassNames.mediumPlus}
-                    items={this.state.sortedApps}
+                    items={apps}
                     columns={this.state.columns}
                     checkboxVisibility={OF.CheckboxVisibility.hidden}
                     onRenderItemColumn={(app, i, column: ISortableRenderableColumn) => column.render(app, props)}


### PR DESCRIPTION
Previously we didn't show an arrow indicating the sorted column. This could mislead users into thinking the list is not sortable.  Also if you clicked the column it would be not sort the first time.
This fixes both of those issues.  I need to create a code pen for Office fabric as this seems like a bug, but basically the `column` object received in the `onClickColumnHeader` function is not the same as one of the columns even though it has the same shape.

We have to manually find the matching column by `key` and I'm not sure why that matters.