### PR TITLE
fix: test results that were being discarded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,18 @@ jobs:
       # - run: npm run cypress -- run --record false --spec  "cypress/integration/smoke/**/*.spec.*"
       - run: npm run cypress -- run --record false --spec  "cypress/integration/Regression/**/*.spec.js"
 
+      - store_artifacts:
+          path: results
+
+      - store_artifacts:
+          path: cypress/videos
+
+      - store_artifacts:
+          path: cypress/screenshots
+          
+      - store_test_results:
+          path: results
+
       - run:
           command: npm run cypress -- run --record false --spec  "cypress/integration/regressionTs/**/*.spec.*"
           when: always
@@ -102,7 +114,6 @@ jobs:
           
       - store_test_results:
           path: results
-
 
       - run: 
           command: npm run cypress -- run --record false --spec "cypress/integration/Tools/DeleteAllTestGeneratedModels.spec.js"


### PR DESCRIPTION
This should fix a recent change that caused regression (.js) test results to be lost.

Once I verify this is working I will be checking it in.