### PR TITLE
fix: use onItemInvoked instead of onActiveItemChanged

### DIFF
--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -135,7 +135,7 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
         })
     }
 
-    onClickRow(item: any, index: number | undefined, event: React.FocusEvent<HTMLElement> | undefined) {
+    onClickRow(item: any, index: number | undefined, event: Event | undefined) {
         // Don't response to row click if it's button that was clicked
         if (event && (event.target as any).type !== 'button') {
             const action = item as CLM.ActionBase
@@ -170,8 +170,9 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
                     items={sortedActions}
                     columns={this.state.columns}
                     checkboxVisibility={OF.CheckboxVisibility.hidden}
+                    onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
                     onRenderItemColumn={(action: CLM.ActionBase, i, column: IRenderableColumn) => column.render(action, this)}
-                    onActiveItemChanged={(item, index, ev) => this.onClickRow(item, index, ev)}
+                    onItemInvoked={(item, index, ev) => this.onClickRow(item, index, ev)}
                     onColumnHeaderClick={this.onClickColumnHeader}
                     onRenderDetailsHeader={(detailsHeaderProps: OF.IDetailsHeaderProps,
                         defaultRender: OF.IRenderFunction<OF.IDetailsHeaderProps>) =>

--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -342,13 +342,14 @@ class Entities extends React.Component<Props, ComponentState> {
                             items={computedEntities}
                             columns={this.state.columns}
                             checkboxVisibility={OF.CheckboxVisibility.hidden}
+                            onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
                             onRenderItemColumn={(entity: EntityBase, i, column: IRenderableColumn) =>
                                 column.render(entity, this)}
                             onRenderDetailsHeader={(detailsHeaderProps: OF.IDetailsHeaderProps,
                                 defaultRender: OF.IRenderFunction<OF.IDetailsHeaderProps>) =>
                                 onRenderDetailsHeader(detailsHeaderProps, defaultRender)}
                             onColumnHeaderClick={this.onClickColumnHeader}
-                            onActiveItemChanged={entity => this.onSelectEntity(entity)}
+                            onItemInvoked={entity => this.onSelectEntity(entity)}
                         />
                     </React.Fragment>}
                 <EntityCreatorEditor

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -1560,8 +1560,9 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                                 columns={this.state.columns}
                                 checkboxVisibility={OF.CheckboxVisibility.hidden}
                                 onColumnHeaderClick={this.onClickColumnHeader}
+                                onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
                                 onRenderItemColumn={(trainDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(trainDialog, this))}
-                                onActiveItemChanged={trainDialog => this.onClickTrainDialogItem(trainDialog)}
+                                onItemInvoked={trainDialog => this.onClickTrainDialogItem(trainDialog)}
                             />}
                     </React.Fragment>}
                 {teachSession && teachSession.teach &&

--- a/src/routes/Apps/AppsListComponent.tsx
+++ b/src/routes/Apps/AppsListComponent.tsx
@@ -261,9 +261,10 @@ export class Component extends React.Component<Props, ComponentState> {
                     items={apps}
                     columns={this.state.columns}
                     checkboxVisibility={OF.CheckboxVisibility.hidden}
+                    onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
                     onRenderItemColumn={(app, i, column: ISortableRenderableColumn) => column.render(app, props)}
                     onColumnHeaderClick={this.onClickColumnHeader}
-                    onActiveItemChanged={app => this.props.onClickApp(app)}
+                    onItemInvoked={app => this.props.onClickApp(app)}
                 />}
             <AppCreatorModal
                 open={props.isAppCreateModalOpen}


### PR DESCRIPTION
Since I did the work for selection on LogDialogs list we learned the trick to enable single click invocation on items.

We can now use the proper `onItemInvoked` instead of `onActiveItemChanged`. The allows right click and many accessibility improvements such as keyboard navigation and 'Enter' for selection.

Fixes: ADO#1519