### PR TITLE
fix: restore blue coloring or noneditable entities

### DIFF
--- a/src/components/ExtractorResponseEditor/PreBuiltEntity.tsx
+++ b/src/components/ExtractorResponseEditor/PreBuiltEntity.tsx
@@ -12,14 +12,13 @@ interface EntityComponentProps {
 
 interface Props extends EntityComponentProps {
     name: string
-    showSelect: boolean
 }
 
 export const PreBuiltEntity = (props: Props) => {
-    const { name, showSelect } = props
-    const className = showSelect ? "cl-entity-node cl-entity-node--prebuilt" : "cl-entity-node cl-entity-node--custom"
+    const { name } = props
+
     return (
-        <span className={className}>
+        <span className="cl-entity-node cl-entity-node--prebuilt">
             <div className="cl-entity-node-indicator noselect">
                 <div className="cl-entity-node-indicator__mincontent">
                     <div className="cl-entity-node-indicator__name">

--- a/src/components/ExtractorResponseEditor/PreBuiltEntityNode.tsx
+++ b/src/components/ExtractorResponseEditor/PreBuiltEntityNode.tsx
@@ -22,7 +22,6 @@ export const PreBuiltEntityNode = (props: Props) => {
     return (
         <PreBuiltEntity
             name={nodeData.displayName}
-            showSelect={nodeData.showSelect}
             {...props.attributes}
         >
             {...props.children}

--- a/src/components/ExtractorResponseEditor/models.ts
+++ b/src/components/ExtractorResponseEditor/models.ts
@@ -47,7 +47,6 @@ export interface IGenericEntityData<T> {
     text: string
     displayName: string
     original: T
-    showSelect?: boolean
 }
 
 export enum NodeType {

--- a/src/components/ExtractorResponseEditor/utilities.ts
+++ b/src/components/ExtractorResponseEditor/utilities.ts
@@ -511,7 +511,7 @@ export const getPreBuiltEntityDisplayName = (entity: CLM.EntityBase, pe: CLM.Pre
     return names[names.length - 1]
 }
 
-export const convertPredictedEntityToGenericEntity = (pe: CLM.PredictedEntity, showSelect: boolean, entityName: string, displayName: string): models.IGenericEntity<models.IGenericEntityData<CLM.PredictedEntity>> =>
+export const convertPredictedEntityToGenericEntity = (pe: CLM.PredictedEntity, entityName: string, displayName: string): models.IGenericEntity<models.IGenericEntityData<CLM.PredictedEntity>> =>
     ({
         startIndex: pe.startCharIndex,
         // The predicted entities returned by the service treat indices as characters instead of before or after the character so add 1 to endIndex for slicing using JavaScript
@@ -528,7 +528,6 @@ export const convertPredictedEntityToGenericEntity = (pe: CLM.PredictedEntity, s
             text: pe.entityText,
             displayName,
             original: pe,
-            showSelect
         }
     })
 
@@ -596,11 +595,11 @@ export const convertExtractorResponseToEditorModels = (extractResponse: CLM.Extr
 
     const customEntities = internalPredictedEntities
         .filter(({ entity }) => entity && entity.entityType === CLM.EntityType.LUIS)
-        .map(({ entity, predictedEntity }) => convertPredictedEntityToGenericEntity(predictedEntity, entity!.doNotMemorize ? true : false, entity!.entityName, util.entityDisplayName(entity!)))
+        .map(({ entity, predictedEntity }) => convertPredictedEntityToGenericEntity(predictedEntity, entity!.entityName, util.entityDisplayName(entity!)))
 
     const preBuiltEntities = internalPredictedEntities
         .filter(({ entity }) => entity && CLM.isPrebuilt(entity))
-        .map(({ entity, predictedEntity }) => convertPredictedEntityToGenericEntity(predictedEntity, entity!.doNotMemorize ? true : false, entity!.entityName, getPreBuiltEntityDisplayName(entity!, predictedEntity)))
+        .map(({ entity, predictedEntity }) => convertPredictedEntityToGenericEntity(predictedEntity, entity!.entityName, getPreBuiltEntityDisplayName(entity!, predictedEntity)))
 
     return {
         options,


### PR DESCRIPTION
Remove old code when resolvers were added

![image](https://user-images.githubusercontent.com/2856501/60918620-a0c32780-a248-11e9-8b07-ca8acc8efe60.png)


Related PRs for tracking:
https://github.com/microsoft/ConversationLearner-UI/pull/792/files#diff-0516be742b5d150780ab0a12838b8d1dR599
https://github.com/microsoft/ConversationLearner-UI/pull/791/files#diff-ecfa596a555464dcfc9af80d0fc3be98R268

Fixes ADO#2200