### PR TITLE
 fix: use DetailsList getKey and setKey to use render computed dialogs

### DIFF
--- a/src/components/ActionDetailsList.tsx
+++ b/src/components/ActionDetailsList.tsx
@@ -114,17 +114,20 @@ class ActionDetailsList extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
-        const { columns } = this.state;
-        const sortColumn = columns.find(c => clickedColumn.key === c.key)!
-        const isSortedDescending = !clickedColumn.isSortedDescending;
+        const sortColumn = this.state.columns.find(c => c.key === clickedColumn.key)!
+        const columns = this.state.columns.map(column => {
+            column.isSorted = false
+            column.isSortedDescending = false
+            if (column === sortColumn) {
+                column.isSorted = true
+                column.isSortedDescending = !clickedColumn.isSortedDescending
+            }
+            return column
+        })
 
         // Reset the items and columns to match the state.
         this.setState({
-            columns: columns.map(column => {
-                column.isSorted = (column.key === clickedColumn.key);
-                column.isSortedDescending = isSortedDescending;
-                return column;
-            }),
+            columns,
             sortColumn
         });
     }

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -149,18 +149,26 @@ class App extends React.Component<Props, ComponentState> {
               render={props =>
                 <React.Fragment>
                   {this.state.loadingState === LoadingState.LOADING &&
-                    <p>Loading...</p>
+                    <div className="cl-o-app-columns">
+                      <div className="cl-app_content">
+                        <p>Loading...</p>
+                      </div>
+                    </div>
                   }
                   {this.state.loadingState === LoadingState.FAILED &&
-                    <div>
-                      <p>Loading Failed.</p>
-                      <div>
-                        <OF.PrimaryButton
-                          onClick={this.loadBotInfo}
-                          iconProps={{ iconName: 'Refresh' }}
-                        >
-                          Retry
+                    <div className="cl-o-app-columns">
+                      <div className="cl-app_content">
+                        <div>
+                          <p>Loading Failed.</p>
+                          <div>
+                            <OF.PrimaryButton
+                              onClick={this.loadBotInfo}
+                              iconProps={{ iconName: 'Refresh' }}
+                            >
+                              Retry
                           </OF.PrimaryButton>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   }

--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -219,19 +219,22 @@ class Entities extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     onClickColumnHeader(event: any, clickedColumn: IRenderableColumn) {
-        const { columns } = this.state;
-        const sortColumn = columns.find(c => c.key === clickedColumn.key)!
-        const isSortedDescending = !clickedColumn.isSortedDescending;
+        const sortColumn = this.state.columns.find(c => c.key === clickedColumn.key)!
+        const columns = this.state.columns.map(column => {
+            column.isSorted = false
+            column.isSortedDescending = false
+            if (column === sortColumn) {
+                column.isSorted = true
+                column.isSortedDescending = !clickedColumn.isSortedDescending
+            }
+            return column
+        })
 
         // Reset the items and columns to match the state.
         this.setState({
-            columns: columns.map(col => {
-                col.isSorted = (col.key === sortColumn.key);
-                col.isSortedDescending = isSortedDescending;
-                return col;
-            }),
+            columns,
             sortColumn
-        });
+        })
     }
 
     @OF.autobind

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -141,9 +141,9 @@ function getColumns(intl: InjectedIntl): IRenderableColumn[] {
 const defaultEntityFilter = (intl: InjectedIntl) => ({ key: -1, text: Util.formatMessageId(intl, FM.TRAINDIALOGS_FILTERING_ENTITIES), data: null })
 const defaultActionFilter = (intl: InjectedIntl) => ({ key: -1, text: Util.formatMessageId(intl, FM.TRAINDIALOGS_FILTERING_ACTIONS) })
 const defaultTagFilter = (intl: InjectedIntl) => ({ key: -1, text: Util.formatMessageId(intl, FM.TRAINDIALOGS_FILTERING_TAGS) })
+const getDialogKey = (trainDialog: OF.IObjectWithKey) => (trainDialog as CLM.TrainDialog).trainDialogId
 
 interface ComponentState {
-    trainDialogs: CLM.TrainDialog[]
     columns: IRenderableColumn[]
     sortColumn: IRenderableColumn
     activityHistory: Activity[]
@@ -198,7 +198,6 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         })
 
         this.state = {
-            trainDialogs: props.trainDialogs,
             columns: columns,
             sortColumn: lastModifiedColumn,
             activityHistory: [],
@@ -269,36 +268,9 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         if (this.props.trainDialogs !== newProps.trainDialogs) {
             this.focusNewTeachSessionButton();
         }
-
-        /**
-         * Recompute state dialogs. This not a good practice to save state on every prop change, but 
-         * the internals of the dialog can change such as validity or rounds and we need those updates.
-         * Previously, it was computed on every render() so this isn't much worse.
-         */
-        // if (this.props.trainDialogs.length !== newProps.trainDialogs.length) {
-        if (true) {
-            let trainDialogs = this.getFilteredDialogs(newProps.trainDialogs)
-            trainDialogs = this.sortTrainDialogs(trainDialogs, this.state.columns, this.state.sortColumn)
-
-            this.setState({
-                trainDialogs
-            })
-        }
     }
 
     async componentDidUpdate(prevProps: Props, prevState: ComponentState) {
-        // If any of the filters changed, recompute filtered dialogs based on updated filers
-        if (prevState.searchValue !== this.state.searchValue
-            || prevState.tagsFilter !== this.state.tagsFilter
-            || prevState.entityFilter !== this.state.entityFilter
-            || prevState.actionFilter !== this.state.actionFilter) {
-            let trainDialogs = this.getFilteredDialogs(this.props.trainDialogs)
-
-            this.setState({
-                trainDialogs
-            })
-        }
-
         this.handleQueryParameters(this.props.location.search, prevProps.location.search)
     }
 
@@ -375,7 +347,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     private selection: OF.ISelection = new OF.Selection({
-        getKey: (trainDialog) => (trainDialog as CLM.TrainDialog).trainDialogId,
+        getKey: getDialogKey,
         onSelectionChanged: this.onSelectionChanged
     })
 
@@ -398,13 +370,9 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             return column;
         })
 
-        const trainDialogs = this.sortTrainDialogs(this.state.trainDialogs, columns, sortColumn)
-
-        // Reset the items and columns to match the state.
         this.setState({
             columns,
             sortColumn,
-            trainDialogs,
         });
     }
 
@@ -1377,6 +1345,9 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
     render() {
         const { intl } = this.props
+        let trainDialogs = this.getFilteredDialogs(this.props.trainDialogs)
+        trainDialogs = this.sortTrainDialogs(trainDialogs, this.state.columns, this.state.sortColumn)
+
         const isNoDialogs = this.props.trainDialogs.length === 0
         const editState = (this.props.editingPackageId !== this.props.app.devPackageId)
             ? EditState.INVALID_PACKAGE
@@ -1554,7 +1525,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                                 }
                             />
                         </div>
-                        {this.state.trainDialogs.length === 0
+                        {trainDialogs.length === 0
                             && <div><OF.Icon iconName="Warning" className="cl-icon" /> No dialogs match the search criteria</div>}
                     </React.Fragment>}
 
@@ -1562,9 +1533,11 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                     data-testid="detail-list"
                     key={this.state.dialogKey}
                     className={`${OF.FontClassNames.mediumPlus} ${(this.state.isTreeViewModalOpen || isNoDialogs) ? 'cl-hidden' : ''}`}
-                    items={this.state.trainDialogs}
+                    items={trainDialogs}
                     selection={this.selection}
                     layoutMode={OF.DetailsListLayoutMode.justified}
+                    getKey={getDialogKey}
+                    setKey="selectionKey"
                     columns={this.state.columns}
                     checkboxVisibility={OF.CheckboxVisibility.onHover}
                     onColumnHeaderClick={this.onClickColumnHeader}

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -367,7 +367,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 column.isSorted = true
                 column.isSortedDescending = !clickedColumn.isSortedDescending
             }
-            return column;
+            return column
         })
 
         this.setState({
@@ -1343,11 +1343,15 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         })
     }
 
-    render() {
-        const { intl } = this.props
+    getFilteredAndSortedDialogs() {
         let trainDialogs = this.getFilteredDialogs(this.props.trainDialogs)
         trainDialogs = this.sortTrainDialogs(trainDialogs, this.state.columns, this.state.sortColumn)
+        return trainDialogs
+    }
 
+    render() {
+        const { intl } = this.props
+        const computedTrainDialogs = this.getFilteredAndSortedDialogs()
         const isNoDialogs = this.props.trainDialogs.length === 0
         const editState = (this.props.editingPackageId !== this.props.app.devPackageId)
             ? EditState.INVALID_PACKAGE
@@ -1525,26 +1529,27 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                                 }
                             />
                         </div>
-                        {trainDialogs.length === 0
-                            && <div><OF.Icon iconName="Warning" className="cl-icon" /> No dialogs match the search criteria</div>}
+                        {computedTrainDialogs.length === 0
+                            ? <div><OF.Icon iconName="Warning" className="cl-icon" /> No dialogs match the search criteria</div>
+                            : <OF.DetailsList
+                                data-testid="detail-list"
+                                key={this.state.dialogKey}
+                                className={OF.FontClassNames.mediumPlus}
+                                items={computedTrainDialogs}
+                                selection={this.selection}
+                                layoutMode={OF.DetailsListLayoutMode.justified}
+                                getKey={getDialogKey}
+                                setKey="selectionKey"
+                                columns={this.state.columns}
+                                checkboxVisibility={OF.CheckboxVisibility.onHover}
+                                onColumnHeaderClick={this.onClickColumnHeader}
+                                onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
+                                onRenderItemColumn={(trainDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(trainDialog, this))}
+                                onItemInvoked={trainDialog => this.onClickTrainDialogItem(trainDialog)}
+                            />}
                     </React.Fragment>}
 
-                <OF.DetailsList
-                    data-testid="detail-list"
-                    key={this.state.dialogKey}
-                    className={`${OF.FontClassNames.mediumPlus} ${(this.state.isTreeViewModalOpen || isNoDialogs) ? 'cl-hidden' : ''}`}
-                    items={trainDialogs}
-                    selection={this.selection}
-                    layoutMode={OF.DetailsListLayoutMode.justified}
-                    getKey={getDialogKey}
-                    setKey="selectionKey"
-                    columns={this.state.columns}
-                    checkboxVisibility={OF.CheckboxVisibility.onHover}
-                    onColumnHeaderClick={this.onClickColumnHeader}
-                    onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
-                    onRenderItemColumn={(trainDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(trainDialog, this))}
-                    onItemInvoked={trainDialog => this.onClickTrainDialogItem(trainDialog)}
-                />
+
 
                 {teachSession && teachSession.teach &&
                     <TeachSessionModal

--- a/src/routes/Apps/AppsListComponent.tsx
+++ b/src/routes/Apps/AppsListComponent.tsx
@@ -186,19 +186,21 @@ export class Component extends React.Component<Props, ComponentState> {
         return sortedApps;
     }
 
-    onClickColumnHeader = (event: React.MouseEvent<HTMLElement>, column: ISortableRenderableColumn) => {
-        const { columns } = this.state;
-        const sortColumn = columns.find(c => column.key === c.key)!
+    @OF.autobind
+    onClickColumnHeader(event: React.MouseEvent<HTMLElement, MouseEvent>, clickedColumn: ISortableRenderableColumn) {
+        const sortColumn = this.state.columns.find(c => c.key === clickedColumn.key)!
+        const columns = this.state.columns.map(column => {
+            column.isSorted = false
+            column.isSortedDescending = false
+            if (column === sortColumn) {
+                column.isSorted = true
+                column.isSortedDescending = !clickedColumn.isSortedDescending
+            }
+            return column
+        })
 
         this.setState({
-            columns: columns.map(col => {
-                col.isSorted = false;
-                if (col.key === column.key) {
-                    col.isSorted = true;
-                    col.isSortedDescending = !col.isSortedDescending;
-                }
-                return col;
-            }),
+            columns,
             sortColumn,
         });
     }


### PR DESCRIPTION
After enough experimenting/process of elimination with my own recreation and their demo it seems the `getKey` and `setKey` were needed instead of only the `getKey` on the selection.  Still am not sure why the selection is preserved on train dialogs bug seemingly reset on log dialogs when the filter exludes the selected items. Also noticed they released office 7.x so will be looking into that.

Also, try to normalize sorting pattern on various lists, and fix the spacing of loading indicators for the app