### PR TITLE
 fix: use query parameter for selected entity and action

### DIFF
--- a/src/routes/Apps/App/Entities.tsx
+++ b/src/routes/Apps/App/Entities.tsx
@@ -152,8 +152,7 @@ interface ComponentState {
 }
 
 class Entities extends React.Component<Props, ComponentState> {
-    newEntityButtonRef = React.createRef<OF.IButton>()
-    state: ComponentState
+    private newEntityButtonRef = React.createRef<OF.IButton>()
 
     constructor(props: Props) {
         super(props)
@@ -229,12 +228,8 @@ class Entities extends React.Component<Props, ComponentState> {
 
     @OF.autobind
     handleDelete(entity: EntityBase) {
-        this.setState({
-            createEditModalOpen: false,
-            entitySelected: null
-        })
+        this.handleCloseCreateModal()
         this.props.deleteEntityThunkAsync(this.props.app.appId, entity)
-        setTimeout(() => this.focusNewEntityButton(), 1000)
     }
 
     @OF.autobind
@@ -264,7 +259,8 @@ class Entities extends React.Component<Props, ComponentState> {
     }
 
     onSelectEntity(entity: EntityBase) {
-        if (this.props.editingPackageId !== this.props.app.devPackageId) {
+        const isEditingDevPackage = this.props.editingPackageId === this.props.app.devPackageId
+        if (!isEditingDevPackage) {
             return
         }
 


### PR DESCRIPTION
Tried to apply the pattern used on TrainDialogs and LogDialogs here, but it doesn't work.

Something is resetting the location search and I'm not sure how. I tried putting breakpoints on all the `history` operations and can't isolate it.

You can see below the component refreshes with the selectedId set then some time durring the prop updates (sometimes 2th time sometimes 4th) it gets reset.

![image](https://user-images.githubusercontent.com/2856501/61983676-2ddede00-afb6-11e9-8516-15067f0de092.png)

I thought the whole point if the previous task was to allow refresh and deep linking. It doesn't seem to work even for basic refresh.

Seems there is not much value in committing this at the moment.