### PR TITLE
fix: update TipType for CARD actions to ACTION_CARD

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -1530,7 +1530,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                                             .map(cardTemplateVariable => {
                                                 return (
                                                     <React.Fragment key={cardTemplateVariable.key}>
-                                                        <OF.Label className="cl-label">{cardTemplateVariable.key} <HelpIcon tipType={ToolTip.TipType.ACTION_ARGUMENTS} /></OF.Label>
+                                                        <OF.Label className="cl-label">{cardTemplateVariable.key} <HelpIcon tipType={ToolTip.TipType.ACTION_CARD} /></OF.Label>
                                                         <ActionPayloadEditor.Editor
                                                             options={optionsAvailableForPayload}
                                                             value={this.state.slateValuesMap[cardTemplateVariable.key]}


### PR DESCRIPTION
Help tooltips for the AdaptiveCard parameters were incorrectly referencing API terminology; fixed enum to pull the Card help tooltips.