### PR TITLE
feat: remove prebuilt entity types options

### DIFF
--- a/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
@@ -145,6 +145,7 @@ class Container extends React.Component<Props, ComponentState> {
                     }))
 
             this.resolverOptions = [...this.staticResolverOptions, ...localePreBuiltOptions]
+
             if (nextProps.entity === null) {
                 this.entityOptions = [...this.staticEntityOptions]
 
@@ -159,6 +160,7 @@ class Container extends React.Component<Props, ComponentState> {
                     enumValues: this.initEnumValues(undefined)
                 });
             } else {
+                this.entityOptions = [...this.staticResolverOptions, ...localePreBuiltOptions]
                 const entityType = nextProps.entity.entityType
                 const isPrebuilt = CLM.isPrebuilt(nextProps.entity)
                 const resolverType = nextProps.entity.resolverType === null ? this.NONE_RESOLVER : nextProps.entity.resolverType


### PR DESCRIPTION
Only removes from dropdown for now. Will need to work on server after. There was a lot of complexity with overloading the entity type to be custom string and relying on prebuilt prefix stuff. Perhaps we can remove a lot of logic there.

I assume we'll have to leave it in for a while but the `CLM.isPrebuilt` function is now obsolete since there can't be prebuilts, only entities with resolver.

Before:
![image](https://user-images.githubusercontent.com/2856501/63714838-3b32f680-c808-11e9-91a9-17a75499ee87.png)

After:
![image](https://user-images.githubusercontent.com/2856501/63714859-40904100-c808-11e9-8a2d-117839415a50.png)

Fixes ADO#2232 (Partially)

