### PR TITLE
 feat: enable dispatch algorithm selection

### DIFF
--- a/src/Utils/dispatchUtils.ts
+++ b/src/Utils/dispatchUtils.ts
@@ -2,14 +2,27 @@ import * as CLM from '@conversationlearner/models'
 import { SourceAndModelPair } from "src/types/models"
 import * as uuid from 'uuid/v4'
 import * as Util from './util'
+import { DispatcherAlgorithmType } from 'src/components/modals/DispatcherCreator';
 
 export function generateDispatcherSource(
+    sourceModelPairs: SourceAndModelPair[],
+    algorithmType: DispatcherAlgorithmType,
+) {
+    switch (algorithmType) {
+        case DispatcherAlgorithmType.DeterministicSingleTransfer:
+            return generageDeterministicDispatcherSource(sourceModelPairs)
+    }
+
+    throw new Error(`Could not associate Dispatcher Algorithm Type with algorithm. You passed: ${algorithmType}`)
+}
+
+function generageDeterministicDispatcherSource(
     sourceModelPairs: SourceAndModelPair[],
     transitionRoundLimit: number = 3,
 ): CLM.AppDefinition {
     /**
      * Generate 1 Dispatch Action per model and associate with source + model pair
-     * 
+     *
      * Store:
      * - modelId for dispatching
      * - modelName for display
@@ -48,7 +61,7 @@ export function generateDispatcherSource(
     /**
      * For each dialog in model A set each rounds to use that models Dispatch Action
      * This means, when this input (extraction) is seen, dispatch to this model.
-     * 
+     *
      * Clear all entities, and ensure single scorer step
      */
     const modelTrainDialogs = sourceModelPairs.map((sm, mIndex) => {
@@ -89,17 +102,17 @@ export function generateDispatcherSource(
 
     /**
      * Intermix rounds from different dialogs to implicitly demonstrate dispatching/context switching to other model
-     * 
+     *
      * Example
      * Dialogs:
-     *  ModelA: 
+     *  ModelA:
      *   [A,B,C]
      *  ModelB:
      *   [D,E,F]
      *  ModelC:
      *   [G,H,I]
      * ...
-     * 
+     *
      * Output:
      * [
      *  [A,D,E,F],

--- a/src/Utils/dispatchUtils.ts
+++ b/src/Utils/dispatchUtils.ts
@@ -4,6 +4,11 @@ import * as uuid from 'uuid/v4'
 import * as Util from './util'
 import { DispatcherAlgorithmType } from 'src/components/modals/DispatcherCreator';
 
+/**
+ * Generations new source based on child sources and given algorithm
+ * @param sourceModelPairs Model Sources and Model Definitions Paired with each other.
+ * @param algorithmType Type of generation Algorithm
+ */
 export function generateDispatcherSource(
     sourceModelPairs: SourceAndModelPair[],
     algorithmType: DispatcherAlgorithmType,
@@ -16,17 +21,37 @@ export function generateDispatcherSource(
     throw new Error(`Could not associate Dispatcher Algorithm Type with algorithm. You passed: ${algorithmType}`)
 }
 
+/**
+ * Attempt to transition at first N number of rounds for each dialog in model, to a dialog in another model.
+ * @param transitionRoundLimit Limit on number of places to transfer between models. Defaults to 3
+ */
 function generageDeterministicDispatcherSource(
     sourceModelPairs: SourceAndModelPair[],
     transitionRoundLimit: number = 3,
 ): CLM.AppDefinition {
-    /**
-     * Generate 1 Dispatch Action per model and associate with source + model pair
-     *
-     * Store:
-     * - modelId for dispatching
-     * - modelName for display
-     */
+    generateDispatchActions(sourceModelPairs);
+
+    const modelsTrainDialogs = associateModelDialogsWithDispatchActionsAndClean(sourceModelPairs)
+
+    const trainDialogs = determisticSingleTransfer(modelsTrainDialogs, transitionRoundLimit);
+
+    const source: CLM.AppDefinition = {
+        trainDialogs,
+        actions: sourceModelPairs.map(sm => sm.action),
+        entities: [],
+    }
+
+    return source
+}
+
+/**
+ * Generate 1 Dispatch Action per model and associate with source + model pair
+ *
+ * Store:
+ * - modelId for dispatching
+ * - modelName for display
+ */
+function generateDispatchActions(sourceModelPairs: SourceAndModelPair[]) {
     sourceModelPairs.forEach(smp => {
         // If object already has action associated, don't create new one
         if (smp.action) {
@@ -57,16 +82,18 @@ function generageDeterministicDispatcherSource(
 
         smp.action = dispatchAction
     })
+}
 
-    /**
-     * For each dialog in model A set each rounds to use that models Dispatch Action
-     * This means, when this input (extraction) is seen, dispatch to this model.
-     *
-     * Clear all entities, and ensure single scorer step
-     */
-    const modelTrainDialogs = sourceModelPairs.map((sm, mIndex) => {
+/**
+ * For each dialog in model A set each rounds to use that models Dispatch Action
+ * This means, when this input (extraction) is seen, dispatch to this model.
+ *
+ * Clear all entities, and ensure single scorer step
+ */
+function associateModelDialogsWithDispatchActionsAndClean(sourceModelPairs: SourceAndModelPair[]): CLM.TrainDialog[][] {
+    return sourceModelPairs.map((sm, mIndex) => {
         if (!sm.action) {
-            throw new Error(`(Source + Model) pair must have dispatch action assigned at this point`)
+            throw new Error(`(Source + Model) pair must have dispatch action assigned at this point`);
         }
 
         return sm.source.trainDialogs.map((t, tIndex) => {
@@ -93,48 +120,50 @@ function generageDeterministicDispatcherSource(
                 ]
             })
 
-            t.tags = [`model-${mIndex + 1}`, `dialog-${tIndex + 1}`]
-            // t.description = `Model: ${sm.model.appName} - Dialog ${tIndex + 1}`
+            t.tags = [`model-${mIndex + 1}`, `dialog-${tIndex + 1}`];
+            // t.description = `Model: ${sm.model.appName} - Dialog ${tIndex + 1}
 
-            return t
-        })
-    })
+            return t;
+        });
+    });
+}
 
-    /**
-     * Intermix rounds from different dialogs to implicitly demonstrate dispatching/context switching to other model
-     *
-     * Example
-     * Dialogs:
-     *  ModelA:
-     *   [A,B,C]
-     *  ModelB:
-     *   [D,E,F]
-     *  ModelC:
-     *   [G,H,I]
-     * ...
-     *
-     * Output:
-     * [
-     *  [A,D,E,F],
-     *  [A,B,D,E,F],
-     *  [A,B,C,D,E,F],
-     *  [A,G,H,I],
-     *  [A,B,G,H,I],
-     *  [A,B,C,G,H,I],
-     *  [D,A,B,C],
-     *  [D,E,A,B,C],
-     *  [D,E,F,A,B,C],
-     *  [D,G,H,I],
-     *  [D,E,G,H,I],
-     *  [D,E,F,G,H,I],
-     *  ...
-     * ]
-     */
+/**
+ * Intermix rounds from different dialogs to implicitly demonstrate dispatching/context switching to other model
+ *
+ * Example
+ * Dialogs:
+ *  ModelA:
+ *   [A,B,C]
+ *  ModelB:
+ *   [D,E,F]
+ *  ModelC:
+ *   [G,H,I]
+ * ...
+ *
+ * Output:
+ * [
+ *  [A,D,E,F],
+ *  [A,B,D,E,F],
+ *  [A,B,C,D,E,F],
+ *  [A,G,H,I],
+ *  [A,B,G,H,I],
+ *  [A,B,C,G,H,I],
+ *  [D,A,B,C],
+ *  [D,E,A,B,C],
+ *  [D,E,F,A,B,C],
+ *  [D,G,H,I],
+ *  [D,E,G,H,I],
+ *  [D,E,F,G,H,I],
+ *  ...
+ * ]
+ */
 
-    // Flatten dialogs from models
-    // TODO: This could cause dispatch model to train on dispatching to dialogs within itself.
-    // This could be good, but also could be extra noise.
-    const allTrainDialogs = modelTrainDialogs
+function determisticSingleTransfer(
+    modelsTrainDialogs: CLM.TrainDialog[][],
+    transitionRoundLimit: number
+): CLM.TrainDialog[] {
+    const allTrainDialogs = modelsTrainDialogs
         .reduce((a, b) => [...a, ...b])
 
     const dialogsWithoutModelTransition = Util.deepCopy(allTrainDialogs)
@@ -145,54 +174,67 @@ function generageDeterministicDispatcherSource(
      * Could try re-entry patterns: A B A
      * Could try multi model switch: A B C
      */
-    const mixRounds = allTrainDialogs.map(t => t.rounds)
-        .map((rs, i, allDialogsRounds) => {
-            // Get rounds from dialogs other than the one being dispatched
-            const otherDialogsRounds = allDialogsRounds.filter((_, j) => j !== i)
+    const mixRounds = modelsTrainDialogs
+        .map((modelDialogs, mIndex) => {
 
-            // TODO: Adapt to be able to transition at multiple points in dialog
-            // Beginning (First 4) and End (Last 4) ?
-            const possibleTransitionRounds = rs
-                // Only attempt to transition within first 4 rounds
-                // After 4, assume user will stay on task
-                .filter((_, j) => j <= transitionRoundLimit)
+            /**
+             * Original implementation attempted transitions within same model and preserved action
+             * This could be good or introduce noise. Consider it as option
+             */
+            const trainDialogsFromOtherModels = modelsTrainDialogs.filter((_, k) => k !== mIndex);
+            return modelDialogs
+                .map(t => t.rounds)
+                .map((rs, i, allDialogsRounds) => {
+                    // Get rounds from dialogs other than the one being dispatched
+                    const otherDialogsRounds = trainDialogsFromOtherModels
+                        .reduce((a, b) => [...a, ...b])
+                        .map(t => t.rounds)
 
-            // For each round, try to transition to one of the other dialogs
-            return otherDialogsRounds
-                .map((dialogRounds) => {
-                    return possibleTransitionRounds
-                        .map((_, k) => {
-                            // Get rounds until index
-                            const firstRounds = rs.slice(0, k + 1)
-                            // Note: always concatenates entire dialog from start
-                            const secondRounds = dialogRounds
-                            return [...firstRounds, ...secondRounds]
+                    // TODO: Adapt to be able to transition at multiple points in dialog
+                    // Beginning (First 4) and End (Last 4) ?
+                    const possibleTransitionRounds = rs
+                        // Only attempt to transition within first 4 rounds
+                        // After 4, assume user will stay on task
+                        .filter((_, j) => j <= transitionRoundLimit);
+
+                    // For each round, try to transition to one of the other dialogs
+                    return otherDialogsRounds
+                        .map((dialogRounds) => {
+                            return possibleTransitionRounds
+                                .map((_, k) => {
+                                    // Get rounds until index
+                                    const firstRounds = rs.slice(0, k + 1)
+                                    // Note: always concatenates entire dialog from start
+                                    const secondRounds = dialogRounds
+                                    return [...firstRounds, ...secondRounds]
+                                });
                         })
+                        .reduce((a, b) => [...a, ...b])
                 })
                 .reduce((a, b) => [...a, ...b])
         })
         .reduce((a, b) => [...a, ...b])
 
-    const mixedDialogs = mixRounds.map(rs => ({
-        tags: [`generated`],
-        description: "",
-        trainDialogId: uuid(),
-        rounds: rs,
-        clientData: {
-            importHashes: []
-        },
-        initialFilledEntities: [],
-    }))
+    const mixedDialogs = mixRounds.map<CLM.TrainDialog>(rs => {
+        return {
+            tags: [`generated`],
+            description: "",
+            trainDialogId: uuid(),
+            rounds: rs,
 
-    const source = {
-        trainDialogs: [
-            ...dialogsWithoutModelTransition,
-            ...mixedDialogs
-        ],
-        actions: sourceModelPairs.map(sm => sm.action),
-        entities: [],
-        packageId: uuid()
-    }
+            // Ignored fields
+            clientData: {
+                importHashes: []
+            },
+            initialFilledEntities: [],
+            createdDateTime: new Date().toJSON(),
+            lastModifiedDateTime: new Date().toJSON(),
+        } as unknown as CLM.TrainDialog
+    })
 
-    return source as CLM.AppDefinition
+    return [
+        ...dialogsWithoutModelTransition,
+        ...mixedDialogs
+    ]
 }
+

--- a/src/actions/trainActions.ts
+++ b/src/actions/trainActions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import * as CLM from '@conversationlearner/models'
@@ -16,6 +16,7 @@ import { AxiosError } from 'axios'
 import { setErrorDisplay } from './displayActions'
 import { EntityLabelConflictError } from '../types/errors'
 import { ActionTypes } from '@conversationlearner/models';
+import { DispatcherAlgorithmType } from 'src/components/modals/DispatcherCreator';
 
 // --------------------------
 // CreateTrainDialog
@@ -288,7 +289,7 @@ const regenerateDispatchDialogsFulfilled = (trainDialogs: CLM.TrainDialog[]): Ac
     }
 }
 
-export const regenerateDispatchTrainDialogsAsync = (dispatchModelId: string, actions: CLM.ActionBase[], existingTrainDialogs: CLM.TrainDialog[]) => {
+export const regenerateDispatchTrainDialogsAsync = (dispatchModelId: string, algorithmType: DispatcherAlgorithmType, actions: CLM.ActionBase[], existingTrainDialogs: CLM.TrainDialog[]) => {
     return async (dispatch: Dispatch<any>) => {
         const clClient = ClientFactory.getInstance(AT.REGENERATE_DISPATCH_DIALOGS_ASYNC)
         dispatch(regenerateDispatchDialogsAsync())
@@ -314,7 +315,7 @@ export const regenerateDispatchTrainDialogsAsync = (dispatchModelId: string, act
                     }
                 }))
 
-            const dispatcherSource = DispatchUtils.generateDispatcherSource(sourceModelPairs)
+            const dispatcherSource = DispatchUtils.generateDispatcherSource(sourceModelPairs, algorithmType)
 
             // Delete all existing dialogs
             await Promise.all(existingTrainDialogs.map(td => clClient.trainDialogsDelete(dispatchModelId, td.trainDialogId)))

--- a/src/components/ToolTips/ToolTips.tsx
+++ b/src/components/ToolTips/ToolTips.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import * as React from 'react'
@@ -34,6 +34,8 @@ export enum TipType {
     ACTION_WAIT = 'isTerminal',
     ACTION_DELETE_INUSE = 'actionDeleteInUse',
 
+    DISPATCHER_CREATOR_ALGORITHM_TYPE = 'dispatcherCreatorAlgorithmType',
+
     EDITDIALOGMODAL_UNKNOWN_NEED_REPLAY = "EDITDIALOGMODAL_UNKNOWN_NEED_REPLAY",
     EDITDIALOGMODAL_WARNING_NEED_REPLAY = "EDITDIALOGMODAL_WARNING_NEED_REPLAY",
 
@@ -60,7 +62,7 @@ export enum TipType {
 
     MEMORY_CONVERTER = 'memoryConverter',
     MEMORY_MANAGER = 'memoryManager',
- 
+
     MODEL_VERSION_EDITING = 'modelVersionEditing',
     MODEL_VERSION_LIVE = 'modelVersionLIve',
 
@@ -147,8 +149,8 @@ const memoryConverterSample =
     `
     AS_VALUE_LIST       returns MemoryValue[]
     AS_STRING           returns string
-    AS_STRING_LIST      returns string[] 
-    AS_NUMBER           returns number 
+    AS_STRING_LIST      returns string[]
+    AS_NUMBER           returns number
     AS_NUMBER_LIST      returns  number[]
     AS_BOOLEAN          returns boolean
     AS_BOOLEAN_LIST     returns boolean[]`
@@ -166,7 +168,7 @@ const memoryManagerSample =
     // SET
     memoryManager.Set(entityName: string, true)
     i.e. memoryManager.Set("toppings", ["cheese", "peppers"])
-   
+
     // DELETE
     memoryManager.Delete(entityName: string, value?: string): void
     memoryManager.DeleteAll(saveEntityNames: string[]): void
@@ -402,7 +404,12 @@ export function getTip(tipType: string) {
                     />
                 </div>
             )
-
+        case TipType.DISPATCHER_CREATOR_ALGORITHM_TYPE:
+            return (
+                <div>
+                    <h2>Dispatcher Algorithm Type</h2>
+                </div>
+            )
         case TipType.EDITDIALOGMODAL_UNKNOWN_NEED_REPLAY:
             return (
                 <div>

--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import * as React from 'react'
@@ -149,7 +149,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                 autoActionCreate: this.state.autoActionMatch
             }
             this.props.onSubmitOBI(appInput, obiImportData)
-        }   
+        }
     }
 
     // TODO: Refactor to use default form submission instead of manually listening for keys
@@ -251,9 +251,6 @@ class AppCreator extends React.Component<Props, ComponentState> {
             case AppCreatorType.OBI:
                 return (
                     <FormattedMessageId id={FM.APPCREATOR_OBI_TITLE} />)
-            case AppCreatorType.DISPATCHER:
-                return (
-                    <FormattedMessageId id={FM.APPCREATOR_DISPATCHER_TITLE} />)
             default:
                 throw new Error(`Could not get title for unknown app creator type: ${this.props.creatorType}`)
         }
@@ -305,8 +302,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                         onKeyDown={key => this.onKeyDown(key)}
                         value={this.state.appNameVal}
                     />
-                    {(this.props.creatorType === AppCreatorType.NEW 
-                    || this.props.creatorType === AppCreatorType.DISPATCHER) &&
+                    {this.props.creatorType === AppCreatorType.NEW &&
                         <OF.Dropdown
                             ariaLabel={Util.formatMessageId(intl, FM.APPCREATOR_FIELDS_LOCALE_LABEL)}
                             label={Util.formatMessageId(intl, FM.APPCREATOR_FIELDS_LOCALE_LABEL)}
@@ -358,17 +354,17 @@ class AppCreator extends React.Component<Props, ComponentState> {
                                 <OF.PrimaryButton
                                     data-testid="transcript-locate-file-button"
                                     className="cl-file-picker-button"
-                                    ariaDescription={Util.formatMessageId(this.props.intl, FM.BUTTON_SELECT_FILES)} 
-                                    text={Util.formatMessageId(this.props.intl, FM.BUTTON_SELECT_FILES)} 
+                                    ariaDescription={Util.formatMessageId(this.props.intl, FM.BUTTON_SELECT_FILES)}
+                                    text={Util.formatMessageId(this.props.intl, FM.BUTTON_SELECT_FILES)}
                                     iconProps={{ iconName: 'DocumentSearch' }}
                                     onClick={() => this.fileInput.click()}
                                 />
                                 <OF.TextField
                                     disabled={true}
-                                    value={!this.state.obiFiles 
+                                    value={!this.state.obiFiles
                                         ? undefined
                                         : this.state.obiFiles.length === 1
-                                        ? this.state.obiFiles[0].name 
+                                        ? this.state.obiFiles[0].name
                                         : `${this.state.obiFiles.length} files selected`
                                     }
                                 />
@@ -415,8 +411,7 @@ class AppCreator extends React.Component<Props, ComponentState> {
                                     iconProps={{ iconName: 'Accept' }}
                                 />
                             }
-                            {(this.props.creatorType === AppCreatorType.NEW ||
-                            this.props.creatorType === AppCreatorType.DISPATCHER) &&
+                            {this.props.creatorType === AppCreatorType.NEW &&
                                 <OF.PrimaryButton
                                     disabled={this.isSubmitDisabled()}
                                     data-testid="model-creator-submit-button"

--- a/src/components/modals/DispatcherCreator.tsx
+++ b/src/components/modals/DispatcherCreator.tsx
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import * as React from 'react'
+import * as OF from 'office-ui-fabric-react'
+import * as Util from '../../Utils/util'
+import * as CLM from '@conversationlearner/models'
+import actions from '../../actions'
+import FormattedMessageId from '../FormattedMessageId'
+import { returntypeof } from 'react-redux-typescript'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import { State } from '../../types'
+import { FM } from '../../react-intl-messages'
+import { injectIntl, InjectedIntlProps } from 'react-intl'
+import { autobind } from 'core-decorators'
+import HelpIcon from '../HelpIcon';
+import { TipType } from '../ToolTips/ToolTips'
+
+export enum DispatcherAlgorithmType {
+    DeterministicSingleTransfer = "Deterministic Single Transfer",
+    RandomSingleTransfer = 'Random Single Transfer',
+    RandomMultiTransfer = 'Random Multi Transfer'
+}
+
+interface ComponentState {
+    modelName: string
+    dispatcherAlgorithmType: DispatcherAlgorithmType
+}
+
+const initialState: ComponentState = {
+    modelName: '',
+    dispatcherAlgorithmType: DispatcherAlgorithmType.DeterministicSingleTransfer,
+}
+
+class Component extends React.Component<Props, ComponentState> {
+    state: ComponentState = { ...initialState }
+
+    componentDidUpdate(prevProps: Props) {
+        // Reset when opening modal
+        if (this.props.open === false && prevProps.open === true) {
+            this.setState(initialState)
+        }
+    }
+
+    @autobind
+    onChangeName(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, modelName: string) {
+        this.setState({
+            modelName
+        })
+    }
+
+    @autobind
+    onClickCancel() {
+        this.props.onCancel()
+    }
+
+    private getModelFromState(): Partial<CLM.AppBase> {
+        return {
+            appName: this.state.modelName.trim(),
+            locale: 'en-us',
+            metadata: {
+                botFrameworkApps: [],
+                markdown: undefined,
+                video: undefined,
+                isLoggingOn: true,
+            }
+        }
+    }
+
+    @autobind
+    onClickCreate() {
+        const isSubmitDisabled = this.isSubmitDisabled()
+        if (isSubmitDisabled === false) {
+            const model = this.getModelFromState()
+            this.props.onSubmit(model, this.state.dispatcherAlgorithmType)
+        }
+    }
+
+    onGetNameErrorMessage(value: string): string {
+        const { intl } = this.props
+        const MAX_NAME_LENGTH = 30
+
+        if (value.length === 0) {
+            return Util.formatMessageId(intl, FM.FIELDERROR_REQUIREDVALUE)
+        }
+
+        if (value.length > MAX_NAME_LENGTH) {
+            return Util.formatMessageId(intl, FM.FIELDERROR_MAX_30)
+        }
+
+        if (!/^[a-zA-Z0-9- ]+$/.test(value)) {
+            return Util.formatMessageId(intl, FM.APPCREATOR_FIELDERROR_ALPHANUMERIC)
+        }
+
+        if (!value.trim().length) {
+            return Util.formatMessageId(intl, FM.APPCREATOR_FIELDERROR_ALPHANUMERIC)
+        }
+
+        // Check that name isn't in use
+        if (this.props.apps.find(a => a.appName === value)) {
+            return Util.formatMessageId(intl, FM.FIELDERROR_DISTINCT)
+        }
+
+        return ""
+    }
+
+    isSubmitDisabled(): boolean {
+        return this.onGetNameErrorMessage(this.state.modelName) !== ""
+    }
+
+    @autobind
+    onChoiceChange(ev: React.FormEvent<HTMLInputElement>, option?: OF.IChoiceGroupOption) {
+        if (!option) {
+            return
+        }
+
+        this.setState({ dispatcherAlgorithmType: option.key as DispatcherAlgorithmType })
+    }
+
+    render() {
+        const { intl } = this.props
+        return (
+            <OF.Modal
+                isOpen={this.props.open}
+                onDismiss={this.onClickCancel}
+                isBlocking={false}
+                containerClassName='cl-modal cl-modal--small'
+            >
+                <div className='cl-modal_header'>
+                    <span className={OF.FontClassNames.xxLarge}>
+                        <FormattedMessageId id={FM.APPCREATOR_DISPATCHER_TITLE} />
+                    </span>
+                </div>
+                <div className="cl-action-creator-fieldset">
+                    <OF.TextField
+                        data-testid="dispatcher-creator-input-name"
+                        onGetErrorMessage={value => this.onGetNameErrorMessage(value)}
+                        onChange={this.onChangeName}
+                        label={Util.formatMessageId(intl, FM.APPCREATOR_FIELDS_NAME_LABEL)}
+                        placeholder={Util.formatMessageId(intl, FM.APPCREATOR_FIELDS_NAME_PLACEHOLDER)}
+                        value={this.state.modelName}
+                    />
+
+                    <div>
+                        <div className={OF.FontClassNames.medium}>
+                            <FormattedMessageId id={FM.DISPATCHCREATOR_ALGORITHM_TYPE_LABEL} />
+                            <HelpIcon tipType={TipType.DISPATCHER_CREATOR_ALGORITHM_TYPE} />
+                        </div>
+                        <OF.ChoiceGroup
+                            className="defaultChoiceGroup"
+                            defaultSelectedKey={DispatcherAlgorithmType.DeterministicSingleTransfer}
+                            options={[
+                                {
+                                    key: DispatcherAlgorithmType.DeterministicSingleTransfer,
+                                    text: DispatcherAlgorithmType.DeterministicSingleTransfer
+                                },
+                                {
+                                    key: DispatcherAlgorithmType.RandomSingleTransfer,
+                                    text: DispatcherAlgorithmType.RandomSingleTransfer
+                                },
+                                {
+                                    key: DispatcherAlgorithmType.RandomMultiTransfer,
+                                    text: DispatcherAlgorithmType.RandomMultiTransfer
+                                },
+                            ]}
+                            selectedKey={this.state.dispatcherAlgorithmType}
+                            onChange={this.onChoiceChange}
+                            required={false}
+                        />
+                    </div>
+
+
+                </div>
+                <div className='cl-modal_footer'>
+                    <div className="cl-modal-buttons">
+                        <div className="cl-modal-buttons_secondary" />
+                        <div className="cl-modal-buttons_primary">
+                            <OF.PrimaryButton
+                                disabled={this.isSubmitDisabled()}
+                                data-testid="dispatcher-creator-submit-button"
+                                onClick={this.onClickCreate}
+                                ariaDescription={Util.formatMessageId(intl, FM.BUTTON_CREATE)}
+                                text={Util.formatMessageId(intl, FM.BUTTON_CREATE)}
+                                iconProps={{ iconName: 'Accept' }}
+                            />
+
+                            <OF.DefaultButton
+                                data-testid="dispatcher-creator-cancel-button"
+                                onClick={this.onClickCancel}
+                                ariaDescription={Util.formatMessageId(intl, FM.APPCREATOR_CANCELBUTTON_ARIADESCRIPTION)}
+                                text={Util.formatMessageId(intl, FM.APPCREATOR_CANCELBUTTON_TEXT)}
+                                iconProps={{ iconName: 'Cancel' }}
+                            />
+                        </div>
+                    </div>
+                </div>
+            </OF.Modal>
+        )
+    }
+}
+
+const mapDispatchToProps = (dispatch: any) => {
+    return bindActionCreators({
+        setErrorDisplay: actions.display.setErrorDisplay,
+    }, dispatch);
+}
+const mapStateToProps = (state: State) => {
+    return {
+        apps: state.apps.all
+    }
+}
+
+export interface ReceivedProps {
+    open: boolean
+    onSubmit: (model: Partial<CLM.AppBase>, algorithmType: DispatcherAlgorithmType) => void
+    onCancel: () => void
+}
+
+// Props types inferred from mapStateToProps & dispatchToProps
+const stateProps = returntypeof(mapStateToProps);
+const dispatchProps = returntypeof(mapDispatchToProps);
+type Props = typeof stateProps & typeof dispatchProps & ReceivedProps & InjectedIntlProps
+
+export default connect<typeof stateProps, typeof dispatchProps, ReceivedProps>(mapStateToProps, mapDispatchToProps)(injectIntl(Component))

--- a/src/react-intl-messages.ts
+++ b/src/react-intl-messages.ts
@@ -1,7 +1,7 @@
 import { AT } from "./types";
 
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 export enum FM {
@@ -56,7 +56,7 @@ export enum FM {
     // ActionDeleteModal
     ACTION_DELETE_INUSE_TITLE = 'ActionDelete.inUse.title',
     ACTION_DELETE_INUSE_PLACEHOLDER_PRESERVE = 'ActionDelete.inUse.placeholderPreserve',
-    ACTION_DELETE_INUSE_PLACEHOLDER_REMOVE = 'ActionDelete.inUse.placeholderRemove', 
+    ACTION_DELETE_INUSE_PLACEHOLDER_REMOVE = 'ActionDelete.inUse.placeholderRemove',
 
     // ActionDetails
     ACTIONDETAILSLIST_COLUMNS_RESPONSE = 'ActionDetailsList.columns.response',
@@ -107,6 +107,7 @@ export enum FM {
     APPCREATOR_FIELDS_IMPORT_NAME_LABEL = 'AppCreator.fields.importname.label',
     APPCREATOR_FIELDS_NAME_PLACEHOLDER = 'AppCreator.fields.name.placeholder',
     APPCREATOR_FIELDS_LOCALE_LABEL = 'AppCreator.fields.locale.label',
+    APPCREATOR_FIELDS_DISPATCHER_ALGORITHM_LABEL = 'AppCreator.fields.dispatcherAlgorithm.label',
     APPCREATOR_COPYBUTTON_ARIADESCRIPTION = 'AppCreator.copyButton.ariaDescription',
     APPCREATOR_COPYBUTTON_TEXT = 'AppCreator.copyButton.text',
     APPCREATOR_IMPORT_BUTTON_ARIADESCRIPTION = 'AppCreator.importButton.ariaDescription',
@@ -115,6 +116,9 @@ export enum FM {
     APPCREATOR_CHOOSE_FILE_BUTTON_TEXT = 'AppCreator.chooseFileButton.text',
     APPCREATOR_CANCELBUTTON_ARIADESCRIPTION = 'AppCreator.cancelButton.ariaDescription',
     APPCREATOR_CANCELBUTTON_TEXT = 'AppCreator.cancelButton.text',
+
+    // Dispatcher Creator
+    DISPATCHCREATOR_ALGORITHM_TYPE_LABEL = 'DispatcherCreator.algorithmType.label',
 
     // Apps List
     APPSLIST_SUBTITLE = 'AppsList.subtitle',
@@ -185,7 +189,7 @@ export enum FM {
 
     // CompareDialogs
     COMPAREDIALOGS_EDIT = 'CompareDialogs.button.edit',
-    
+
     // ConfirmCancelModal
     CONFIRMCANCELMODAL_PRIMARYBUTTON_TEXT = 'ConfirmCancelModal.primaryButton.text',
     CONFIRMCANCELMODAL_DEFAULTBUTTON_TEXT = 'ConfirmCancelModal.defaultButton.text',
@@ -304,7 +308,7 @@ export enum FM {
     ERROR_PRIMARYBUTTON_TEXT = 'Error.text',
     ERROR_TOOMANYCHARACTERS = 'Error.tooManyChars',
 
-    // ExportChoice 
+    // ExportChoice
     EXPORT_CHOICE_TITLE = 'ExportChoice.title',
     EXPORT_CHOICE_DESCRIPTION = 'ExportChoice.description',
     EXPORT_CHOICE_LABEL = 'ExportChoice.label',
@@ -324,7 +328,7 @@ export enum FM {
     FIELDERROR_DISTINCT = 'FieldError.distinct',
     FIELDERROR_MAX_30 = 'fieldError.max30',
     FIELDERROR_REQUIREDVALUE = 'fieldError.requiredValue',
-    
+
     // Import
     IMPORT_AUTOIMPORT = 'Importer.autoimport',
     IMPORT_AUTOMERGE = 'Importer.automerge',
@@ -575,17 +579,17 @@ export enum FM {
     TRAINDIALOGS_FILTERING_RESET = 'TrainDialogs.Filters.reset',
     TRAINDIALOGS_LISTVIEW_BUTTON = 'TrainDialogs.ListView.Button',
     TRAINDIALOGS_TREEVIEW_BUTTON = 'TrainDialogs.TreeView.Button',
-    
+
     // Trainscript Import Cancel
     TRANSCRIPT_IMPORT_CANCEL_TITLE = 'TranscriptImportCancel.title',
     TRANSCRIPT_IMPORT_CANCEL_CHECKBOX_LABEL = 'TranscriptImportCancel.Checkbox.label',
-    
+
     // Transcript Importer
     TRANSCRIPT_IMPORTER_TITLE = 'TranscriptImporter.title',
     TRANSCRIPT_IMPORTER_DESCRIPTION = 'TranscriptImporter.description',
     TRANSCRIPT_IMPORTER_TRANSCRIPT_BUTTON = 'TranscriptImporter.transcriptbutton',
     TRANSCRIPT_IMPORTER_LG_BUTTON = 'TranscriptImporter.lgbutton',
-    
+
     // Transcript Validator
     TRANSCRIPT_VALIDATOR_TITLE = 'TranscriptValidator.title',
     TRANSCRIPT_VALIDATOR_SUBTITLE = 'TranscriptValidator.subtitle',
@@ -667,7 +671,7 @@ export default {
         [FM.ACTIONSCORER_COLUMNS_ENTITIES]: 'Entities',
         [FM.ACTIONSCORER_COLUMNS_ISTERMINAL]: 'Wait',
         [FM.ACTIONSCORER_COLUMNS_TYPE]: 'Type',
-        
+
         [FM.ACTION_DELETE_INUSE_TITLE]: 'Deleting actions used by train dialogs',
         [FM.ACTION_DELETE_INUSE_PLACEHOLDER_PRESERVE]: 'This operation will preserves the reference to the action leaving a placeholder. All the dialogs using the action will become invalid.  This option can be useful to see where and how the action was used as you correct the dialogs or replace the action.',
         [FM.ACTION_DELETE_INUSE_PLACEHOLDER_REMOVE]: 'This operation will remove the reference to the action. The dialog may become invalid if removal of the action affected memory or left a round unterminated. This option can be useful to if you think most of the dialogs will remain valid and you do not want to have to correct each dialog.',
@@ -699,6 +703,7 @@ export default {
         [FM.APPCREATOR_FIELDS_IMPORT_NAME_LABEL]: 'New Model Name',
         [FM.APPCREATOR_FIELDS_NAME_PLACEHOLDER]: 'Model name...',
         [FM.APPCREATOR_FIELDS_LOCALE_LABEL]: 'Locale',
+        [FM.APPCREATOR_FIELDS_DISPATCHER_ALGORITHM_LABEL]: 'Algorithm Type',
         [FM.APPCREATOR_COPYBUTTON_ARIADESCRIPTION]: 'Copy',
         [FM.APPCREATOR_COPYBUTTON_TEXT]: 'Copy',
         [FM.APPCREATOR_IMPORT_BUTTON_ARIADESCRIPTION]: 'Import application',
@@ -707,6 +712,9 @@ export default {
         [FM.APPCREATOR_CHOOSE_FILE_BUTTON_TEXT]: 'Select File',
         [FM.APPCREATOR_CANCELBUTTON_ARIADESCRIPTION]: 'Cancel',
         [FM.APPCREATOR_CANCELBUTTON_TEXT]: 'Cancel',
+
+        // Dispatch Creator
+        [FM.DISPATCHCREATOR_ALGORITHM_TYPE_LABEL]: 'Algorithm Type',
 
         // App
         [FM.APP_HEADER_MODELS]: 'My Models',
@@ -1043,7 +1051,7 @@ export default {
         // ConfirmCancelModal
         [FM.CONFIRMCANCELMODAL_PRIMARYBUTTON_TEXT]: 'Confirm',
         [FM.CONFIRMCANCELMODAL_DEFAULTBUTTON_TEXT]: 'Cancel',
-        
+
         // DialogMetadata
         [FM.DIALOGMETADATA_TAGS_LABEL]: 'Tags',
         [FM.DIALOGMETADATA_DESCRIPTION_LABEL]: 'Description',
@@ -1080,7 +1088,7 @@ export default {
         [FM.EDITDIALOGMODAL_WARNING_INVALID_PACKAGE]: 'Editing only permitted on the Master tag',
         [FM.EDITDIALOGMODAL_UNKNOWN_NEED_REPLAY]: 'Entity or Action changes require replay of the TrainDialog',
         [FM.EDITDIALOGMODAL_WARNING_NEED_REPLAY]: 'Entity or Action changes require replay of the TrainDialog',
-        
+
         // EntityCreatorEditor
         [FM.ENTITYCREATOREDITOR_FIELDERROR_NOBLANK]: 'May not be blank',
         [FM.ENTITYCREATOREDITOR_FIELDERROR_RESERVED]: 'Name is reserved.',
@@ -1234,9 +1242,9 @@ export default {
         [FM.USERINPUT_BRANCH_TITLE]: 'Add Different User Input',
         [FM.USERINPUT_PLACEHOLDER]: 'User Input...',
 
-        /** 
+        /**
          * This is kind of hack which re-uses redux action types as unit strings for localized error messages
-         * 
+         *
          * It should probably be `errors.application.create` but we're using something like: `CREATE_APPLICATION_ASYNC`
          */
         [AT.CREATE_APPLICATION_ASYNC]: 'Creating Application',

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import * as React from 'react'
@@ -34,6 +34,7 @@ import { TeachSessionState } from '../../../types/StateTypes'
 import './TrainDialogs.css'
 import { autobind } from 'core-decorators';
 import { ActionTypes } from '@conversationlearner/models';
+import { DispatcherAlgorithmType } from 'src/components/modals/DispatcherCreator';
 
 export interface EditHandlerArgs {
     userInput?: string,
@@ -530,7 +531,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             activityHistory: [],
             lastAction: null,
             currentTrainDialog: null,
-            // originalTrainDialogId - do not clear. Need for later 
+            // originalTrainDialogId - do not clear. Need for later
             dialogKey: this.state.dialogKey + 1
         })
 
@@ -764,7 +765,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             activityHistory: [],
             lastAction: null,
             currentTrainDialog: null,
-            // originalTrainDialogId - do not clear. Need for later 
+            // originalTrainDialogId - do not clear. Need for later
             dialogKey: this.state.dialogKey + 1
         })
 
@@ -799,7 +800,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 activityHistory: [],
                 lastAction: null,
                 currentTrainDialog: null,
-                // originalTrainDialogId - do not clear. Need for later 
+                // originalTrainDialogId - do not clear. Need for later
                 dialogKey: this.state.dialogKey + 1
             })
 
@@ -953,7 +954,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
 
             const originalTrainDialogId = this.state.originalTrainDialog ? this.state.originalTrainDialog.trainDialogId : null
 
-            // Remove any data added for rendering 
+            // Remove any data added for rendering
             DialogUtils.cleanTrainDialog(newTrainDialog)
 
             newTrainDialog.validity = validity
@@ -977,7 +978,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         }
     }
 
-    // Create a new trainDialog 
+    // Create a new trainDialog
     async onCreateTrainDialog(newTrainDialog: CLM.TrainDialog) {
 
         this.setState({
@@ -1065,7 +1066,14 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             isRegenActive: true,
         })
 
-        await this.props.regenerateDispatchTrainDialogsAsync(this.props.app.appId, this.props.actions, this.props.trainDialogs)
+        let algorithmType = DispatcherAlgorithmType.DeterministicSingleTransfer
+        const match = (this.props.app.metadata.markdown || '').match(/Type: ([\w ]+)/)
+        if (match && match[1]) {
+            console.log(`Dispatch Algorithm Type: `, { match })
+            // TODO: Find way to extract algorithm type
+        }
+
+        await this.props.regenerateDispatchTrainDialogsAsync(this.props.app.appId, algorithmType, this.props.actions, this.props.trainDialogs)
 
         this.setState({
             isRegenActive: false,
@@ -1085,14 +1093,14 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 importAutoMerge: obiImportData.autoMerge,
                 importAutoActionCreate: obiImportData.autoActionCreate
             })
-    
+
             await this.onImportNextTrainDialog()
         }
         catch (error) {
             await Util.setStateAsync(this, {
                 importedTrainDialogs: undefined
             })
-            this.props.setErrorDisplay(ErrorType.Error, "Import Failed", error.message, null)       
+            this.props.setErrorDisplay(ErrorType.Error, "Import Failed", error.message, null)
         }
     }
 
@@ -1134,7 +1142,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             this.props.createActionThunkAsync as any,
             this.props.createEntityThunkAsync as any
             )
-        
+
         try {
             const importedTrainDialogs = await obiTranscriptParser.getTrainDialogs(transcriptFiles, lgFiles)
             await Util.setStateAsync(this, {
@@ -1144,7 +1152,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 importAutoCreate,
                 importAutoMerge
             })
-    
+
             await this.onImportNextTrainDialog()
         }
         catch (e) {
@@ -1166,11 +1174,11 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         const importIndex = this.state.importIndex === undefined ? 0 : this.state.importIndex + 1
         await Util.setStateAsync(this, { importIndex })
 
-        // Check if I'm done importing 
+        // Check if I'm done importing
         if (this.state.importIndex === undefined || this.state.importIndex >= this.state.importedTrainDialogs.length) {
-            this.setState({ 
+            this.setState({
                 importedTrainDialogs: undefined,
-                isImportWaitModalOpen: false 
+                isImportWaitModalOpen: false
             })
             return
         }
@@ -1202,7 +1210,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
         if (this.state.importAutoActionCreate) {
             await OBIUtils.createImportedActions(
                 this.props.app.appId,
-                newTrainDialog, 
+                newTrainDialog,
                 this.props.botInfo.templates,
                 this.props.createActionThunkAsync as any)
 
@@ -1278,7 +1286,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             isEditDialogModalOpen: false,
             selectedActivityIndex: null,
             currentTrainDialog: null,
-            // originalTrainDialog: Do not clear.  Save for later 
+            // originalTrainDialog: Do not clear.  Save for later
             activityHistory: [],
             lastAction: null,
             dialogKey: this.state.dialogKey + 1

--- a/src/routes/Apps/AppsIndex.tsx
+++ b/src/routes/Apps/AppsIndex.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import * as React from 'react'
@@ -17,6 +17,7 @@ import { CL_IMPORT_TUTORIALS_USER_ID } from '../../types/const'
 import { OBIImportData } from '../../Utils/obiUtils'
 import * as DispatchUtils from '../../Utils/dispatchUtils'
 import { SourceAndModelPair } from '../../types/models'
+import { DispatcherAlgorithmType } from 'src/components/modals/DispatcherCreator';
 
 class AppsIndex extends React.Component<Props> {
     updateAppsAndBot() {
@@ -59,19 +60,15 @@ class AppsIndex extends React.Component<Props> {
         history.push(`${match.url}/${app.appId}${obiImportData ? "/trainDialogs" : ""}`, { app })
     }
 
-    onCreateDispatchModel = async (appToCreate: CLM.AppBase, childrenModels: CLM.AppBase[]) => {
-        if (childrenModels.length > 5) {
-            throw new Error(`Must only select 5 or less models when creating a Dispatcher Model`)
-        }
-
-        appToCreate.metadata.markdown = 'Dispatcher'
+    onCreateDispatchModel = async (appToCreate: CLM.AppBase, childrenModels: CLM.AppBase[], algorithmType: DispatcherAlgorithmType) => {
+        appToCreate.metadata.markdown = `Dispatcher - Type: ${algorithmType}`
 
         /**
          * Fetch source and associate with each model
          */
         const childrenSourceModelPairs = await Promise.all(childrenModels.map<Promise<SourceAndModelPair>>(async model => {
             const source = await (this.props.fetchAppSourceThunkAsync(model.appId, model.devPackageId) as any) as CLM.AppDefinition
-            
+
             return {
                 source,
                 model,
@@ -79,7 +76,7 @@ class AppsIndex extends React.Component<Props> {
             }
         }))
 
-        const source = DispatchUtils.generateDispatcherSource(childrenSourceModelPairs)
+        const source = DispatchUtils.generateDispatcherSource(childrenSourceModelPairs, algorithmType)
         const app = await (this.props.createApplicationThunkAsync(this.props.user.id, appToCreate, source) as any as Promise<CLM.AppBase>)
         const { match, history } = this.props
         history.push(`${match.url}/${app.appId}`, { app })

--- a/src/routes/Apps/AppsList.tsx
+++ b/src/routes/Apps/AppsList.tsx
@@ -16,8 +16,10 @@ import { fetchTutorialsThunkAsync } from '../../actions/appActions'
 import { CL_IMPORT_TUTORIALS_USER_ID, State, AppCreatorType } from '../../types'
 import { injectIntl, InjectedIntlProps } from 'react-intl'
 import { autobind } from 'core-decorators'
+import { DispatcherAlgorithmType } from 'src/components/modals/DispatcherCreator';
 
 interface ComponentState {
+    isDispatcherCreateModalOpen: boolean
     isAppCreateModalOpen: boolean
     appCreatorType: AppCreatorType
     isImportTutorialsOpen: boolean
@@ -29,6 +31,7 @@ interface ComponentState {
 class AppsList extends React.Component<Props, ComponentState> {
 
     state: Readonly<ComponentState> = {
+        isDispatcherCreateModalOpen: false,
         isAppCreateModalOpen: false,
         appCreatorType: AppCreatorType.NEW,
         isImportTutorialsOpen: false,
@@ -94,13 +97,7 @@ class AppsList extends React.Component<Props, ComponentState> {
         this.setState({
             isAppCreateModalOpen: false
         }, () => {
-            if (this.state.appCreatorType === AppCreatorType.DISPATCHER) {
-                const selectedModels = this.selection.getSelection() as CLM.AppBase[]
-                this.props.onCreateDispatchModel(app, selectedModels)
-            }
-            else {
-                this.props.onCreateApp(app, source)
-            }
+            this.props.onCreateApp(app, source)
         })
     }
 
@@ -108,6 +105,23 @@ class AppsList extends React.Component<Props, ComponentState> {
     onCancelAppCreateModal() {
         this.setState({
             isAppCreateModalOpen: false
+        })
+    }
+
+    @autobind
+    onSubmitDispatcherCreateModal(app: Partial<CLM.AppBase>, algorithmType: DispatcherAlgorithmType) {
+        this.setState({
+            isDispatcherCreateModalOpen: false
+        }, () => {
+            const selectedModels = this.selection.getSelection() as CLM.AppBase[]
+            this.props.onCreateDispatchModel(app, selectedModels, algorithmType)
+        })
+    }
+
+    @autobind
+    onCancelDispatcherCreateModal() {
+        this.setState({
+            isDispatcherCreateModalOpen: false
         })
     }
 
@@ -132,8 +146,7 @@ class AppsList extends React.Component<Props, ComponentState> {
     @autobind
     onClickCreateNewDispatcherModel() {
         this.setState({
-            isAppCreateModalOpen: true,
-            appCreatorType: AppCreatorType.DISPATCHER
+            isDispatcherCreateModalOpen: true,
         })
     }
 
@@ -162,6 +175,10 @@ class AppsList extends React.Component<Props, ComponentState> {
             onSubmitAppCreateModal={this.onSubmitAppCreateModal}
             onCancelAppCreateModal={this.onCancelAppCreateModal}
             appCreatorType={this.state.appCreatorType}
+
+            isDispatcherCreateModalOpen={this.state.isDispatcherCreateModalOpen}
+            onSubmitDispatcherCreateModal={this.onSubmitDispatcherCreateModal}
+            onCancelDispatcherCreateModal={this.onCancelDispatcherCreateModal}
 
             onClickCreateNewApp={this.onClickCreateNewApp}
             onClickImportApp={this.onClickImportApp}
@@ -201,7 +218,7 @@ export interface ReceivedProps {
     onCreateApp: (app: Partial<CLM.AppBase>, source: CLM.AppDefinition | null, obiImportData?: OBIImportData) => void
     onClickDeleteApp: (app: CLM.AppBase) => void
     onImportTutorial: (tutorial: CLM.AppBase) => void
-    onCreateDispatchModel: (model: Partial<CLM.AppBase>, models: CLM.AppBase[]) => void
+    onCreateDispatchModel: (model: Partial<CLM.AppBase>, models: CLM.AppBase[], algorithmType: DispatcherAlgorithmType) => void
 }
 
 // Props types inferred from mapStateToProps & dispatchToProps

--- a/src/routes/Apps/AppsListComponent.tsx
+++ b/src/routes/Apps/AppsListComponent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import * as React from 'react'
@@ -13,7 +13,8 @@ import { InjectedIntl, InjectedIntlProps } from 'react-intl'
 import { FM } from '../../react-intl-messages'
 import { User, AppCreatorType, FeatureStrings } from '../../types'
 import { autobind } from 'core-decorators';
-import { OBIImportData } from '../../Utils/obiUtils';
+import { OBIImportData } from '../../Utils/obiUtils'
+import DispatcherCreator, { DispatcherAlgorithmType } from 'src/components/modals/DispatcherCreator'
 
 export interface ISortableRenderableColumn extends OF.IColumn {
     render: (app: CLM.AppBase, props: Props) => JSX.Element
@@ -123,6 +124,7 @@ interface Props extends InjectedIntlProps {
     featuresString: string
     selectionCount: number
 
+    isDispatcherCreateModalOpen: boolean
     isAppCreateModalOpen: boolean
     onSubmitAppCreateModal: (app: CLM.AppBase, source: CLM.AppDefinition | undefined) => void
     onCancelAppCreateModal: () => void
@@ -132,6 +134,9 @@ interface Props extends InjectedIntlProps {
     onClickImportApp: () => void
     onClickImportDemoApps: () => void
     onClickCreateNewDispatcherModel: () => void
+
+    onSubmitDispatcherCreateModal: (model: CLM.AppBase, algorithmType: DispatcherAlgorithmType) => void
+    onCancelDispatcherCreateModal: () => void
 
     onClickImportOBI: () => void
     onSubmitImportOBI: (app: CLM.AppBase, obiImportData: OBIImportData) => void
@@ -296,6 +301,11 @@ export class Component extends React.Component<Props, ComponentState> {
                         onSubmitOBI={props.onSubmitImportOBI}
                         onCancel={props.onCancelAppCreateModal}
                         creatorType={props.appCreatorType}
+                    />
+                    <DispatcherCreator
+                        open={props.isDispatcherCreateModalOpen}
+                        onSubmit={props.onSubmitDispatcherCreateModal}
+                        onCancel={props.onCancelDispatcherCreateModal}
                     />
                     <TutorialImporterModal
                         open={props.isImportTutorialsOpen}

--- a/src/types/const.ts
+++ b/src/types/const.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 export enum ErrorType {
@@ -12,7 +12,6 @@ export enum AppCreatorType {
     IMPORT = "IMPORT",
     COPY = "COPY",
     OBI = "OBI",
-    DISPATCHER = "DISPATCHER",
 }
 
 // After an edit takes place which activity should I select in webchat


### PR DESCRIPTION
## Enable algorithm selection on Dispatcher Creator modal

![image](https://user-images.githubusercontent.com/2856501/63977864-85231300-ca7a-11e9-96f8-c775476aea8e.png)

- Move to dedicated modal since the other is very overloaded with unrelated concerns.
- Re-organized / re factored algorithm code (`dispatchUtil`) to be more readable and have better facades points.
- Renamed existing to DeterministicSingleTransfer
- Added RandomSingleTransfer
- Note: RandomMultiTransfer is not implemented. Need to go over it with Lars as it's very different from the first two. (Think it was select N rounds subset from random dialogs and concat to larger dialog. Will likely be hard to tell if it's written correctly)

Interesting idea during algo design that I realized the number of transition points within a dialog could be dependent on the dialog and instead of be fixed value like (Attempt up to 5 transition points).

E.g. A small dialog of 7 might try to transition in 4 places
but a dialog of 100 rounds would need to transition on probably 20 places.
 
I still think it's eventually going to need text analysis to do this well. In other words transitioning is much more likely and relevant at certain points in the conversation than others and lends to ML problem.