### PR TITLE
fix: save tags and description on replayed dialog

### DIFF
--- a/src/components/modals/EditDialogModal.tsx
+++ b/src/components/modals/EditDialogModal.tsx
@@ -978,6 +978,17 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
         return null
     }
 
+    @autobind
+    private onClickReplayDialog() {
+        const dialog: CLM.TrainDialog = {
+            ...this.props.trainDialog,
+            tags: this.state.tags,
+            description: this.state.description,
+        }
+
+        this.props.onReplayDialog(dialog)
+    }
+
     render() {
         const { intl } = this.props
         // Put mask of webchat if waiting for extraction labelling
@@ -1075,7 +1086,7 @@ class EditDialogModal extends React.Component<Props, ComponentState> {
                                 <OF.PrimaryButton
                                     data-testid="edit-dialog-modal-replay-button"
                                     disabled={this.state.pendingExtractionChanges || this.props.editState !== EditState.CAN_EDIT}
-                                    onClick={() => this.props.onReplayDialog(this.props.trainDialog)}
+                                    onClick={this.onClickReplayDialog}
                                     ariaDescription={formatMessageId(intl, FM.BUTTON_REPLAY)}
                                     text={formatMessageId(intl, FM.BUTTON_REPLAY)}
                                     iconProps={{ iconName: 'Refresh' }}

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -1670,7 +1670,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                         onChangeExtraction={(trainDialog, activity, editHandlerArgs) => this.onChangeExtraction(trainDialog, activity, editHandlerArgs.extractResponse, editHandlerArgs.textVariations)}
                         onChangeAction={(trainDialog, activity, editHandlerArgs) => this.onChangeAction(trainDialog, activity, editHandlerArgs.trainScorerStep)}
                         onEndSessionActivity={this.onEndSessionActivity}
-                        onReplayDialog={(trainDialog) => this.onReplayTrainDialog(trainDialog)}
+                        onReplayDialog={this.onReplayTrainDialog}
                         onSetInitialEntities={this.onSetInitialEntities}
                         initialHistory={this.state.activityHistory}
                         editType={this.state.editType}
@@ -1711,7 +1711,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                     onDeleteDialog={() => this.onDeleteTrainDialog()}
                     onContinueDialog={(editedTrainDialog, initialUserInput) => this.onContinueTrainDialog(editedTrainDialog, initialUserInput)}
                     onSaveDialog={(editedTrainDialog) => this.onReplaceTrainDialog(editedTrainDialog)}
-                    onReplayDialog={(editedTrainDialog) => this.onReplayTrainDialog(editedTrainDialog)}
+                    onReplayDialog={this.onReplayTrainDialog}
                     onCreateDialog={(newTrainDialog) => this.onCreateTrainDialog(newTrainDialog)}
                     allUniqueTags={this.props.allUniqueTags}
                     importIndex={this.state.importIndex}


### PR DESCRIPTION
Fixes ADO#2054

Latest updates to tags and description were getting lost because it was using them from the state of traindialog instead of updated state which may have edits.