### PR TITLE
fix: remove query param on teach abandon

### DIFF
--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -543,6 +543,13 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
                 await this.onImportNextTrainDialog()
             }
         }
+
+        // Remove active dialog from query parameter if present
+        const searchParams = new URLSearchParams(this.props.location.search)
+        const selectedDialogId = searchParams.get(DialogUtils.DialogQueryParams.id)
+        if (selectedDialogId) {
+            this.props.history.replace(this.props.match.url, { app: this.props.app })
+        }
     }
 
     async handlePotentialMerge(newTrainDialog: CLM.TrainDialog, matchedTrainDialog: CLM.TrainDialog) {


### PR DESCRIPTION
Fixes ADO#2255

There was code to remove the param when closing the EditDialogModal `onCloseEditDialogModal` but there was not when closing the Teach Session `onCloseTeachSession`

When you continued a dialog and abandoned the edits you could not open that dialog anymore because the ID was still present and when clicking to push id on the history it looked the same as previous history and was skipped. Probably a few more cases where this might occur and don't like the feeling of adding removal code on all the potential close paths.

Seems like the query param should synced with the state so it can't be wrong. E.g. when dialog is active, query param is added, when dialog is not active param is removed. However this already goes against our working code because we activate a dialog by manually modifying the history.

I added removal code in the other place for now. Could be extracted to function but wanted to wait on that. 