### PR TITLE
fix: prevent creating duplicate actions

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -935,7 +935,9 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
             actionType: CLM.ActionTypes[this.state.selectedActionTypeOptionKey],
             entityId: this.state.selectedEntityOptionKey,
             enumValueId: this.state.selectedEnumValueOptionKey,
-            clientData: this.props.action ? this.props.action.clientData : undefined
+            clientData: this.props.action
+                ? this.props.action.clientData
+                : { importHashes: [] }
         })
 
         if (this.state.isEditing && this.props.action) {


### PR DESCRIPTION
Seems there was regression when `clientData` was added to actions to allow duplicate actions.

This object needs to match was the server returns.