### PR TITLE
fix: add toggle to Session renderer

### DIFF
--- a/src/components/actionPayloadRenderers/SessionPayloadRenderer.tsx
+++ b/src/components/actionPayloadRenderers/SessionPayloadRenderer.tsx
@@ -1,40 +1,51 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import * as React from 'react'
-import { TextAction, EntityBase, Memory } from '@conversationlearner/models'
-import * as Util from '../../Utils/util'
 import * as OF from 'office-ui-fabric-react'
+import './TextPayloadRenderer.css'
 
 interface Props {
-    sessionAction: TextAction
-    entities: EntityBase[]
-    // TODO: Find better alternative than null
-    // When memories is null it's assumed parent doesn't have access to it and intends to fallback to the entity names
-    memories: Memory[] | null
+    original: string
+    currentMemory: string | null
 }
 
-export default class Component extends React.Component<Props> {
+interface State {
+    isOriginalVisible: boolean
+}
+
+export default class Component extends React.Component<Props, State> {
+    state: Readonly<State> = {
+        isOriginalVisible: false
+    }
+
+    onChangeVisible = () => {
+        this.setState(prevState => ({
+            isOriginalVisible: !prevState.isOriginalVisible
+        }))
+    }
 
     render() {
-        const { entities, memories, sessionAction } = this.props
-        const defaultEntityMap = Util.getDefaultEntityMap(entities)
-        const renderStringUsingEntityNames = sessionAction.renderValue(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
-        const renderStringUsingCurrentMemory = memories === null
-            ? null
-            : sessionAction.renderValue(Util.createEntityMapFromMemories(entities, memories), { fallbackToOriginal: true })
+        const showToggle = this.props.currentMemory !== null && this.props.currentMemory !== this.props.original
 
         return <div className={`${OF.FontClassNames.mediumPlus}`}>
             <div className="cl-payloadrenderer-session-primary" data-testid="action-scorer-session-response">
                 EndSession
             </div>
             <div data-testid="action-scorer-session-response-user">
-                {(renderStringUsingCurrentMemory != null)
-                    ? `${renderStringUsingCurrentMemory}`
-                    : `${renderStringUsingEntityNames}`
+                {(this.props.currentMemory === null || this.state.isOriginalVisible)
+                    ? this.props.original
+                    : this.props.currentMemory
                 }
             </div>
+            {showToggle && <div>
+                <OF.Toggle
+                    checked={this.state.isOriginalVisible}
+                    onChange={this.onChangeVisible}
+                />
+            </div>}
         </div>
     }
 }
+

--- a/src/components/actionPayloadRenderers/SessionPayloadRendererContainer.tsx
+++ b/src/components/actionPayloadRenderers/SessionPayloadRendererContainer.tsx
@@ -1,23 +1,32 @@
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 import * as React from 'react'
 import { TextAction, EntityBase, Memory } from '@conversationlearner/models'
 import SessionPayloadRenderer from './SessionPayloadRenderer'
+import * as Util from '../../Utils/util'
 
 interface Props {
     sessionAction: TextAction
     entities: EntityBase[]
+    // TODO: Find better alternative than null
+    // When memories is null it's assumed parent doesn't have access to it and intends to fallback to the entity names
     memories: Memory[] | null
 }
 
 export default class Component extends React.Component<Props> {
     render() {
+        const { entities, memories, sessionAction } = this.props
+        const defaultEntityMap = Util.getDefaultEntityMap(entities)
+        const renderStringUsingEntityNames = sessionAction.renderValue(defaultEntityMap, { preserveOptionalNodeWrappingCharacters: true })
+        const renderStringUsingCurrentMemory = memories === null
+            ? null
+            : sessionAction.renderValue(Util.createEntityMapFromMemories(entities, memories), { fallbackToOriginal: true })
+
         return <SessionPayloadRenderer
-            sessionAction={this.props.sessionAction}
-            entities={this.props.entities}
-            memories={this.props.memories}
+            original={renderStringUsingEntityNames}
+            currentMemory={renderStringUsingCurrentMemory}
         />
     }
 }


### PR DESCRIPTION
Can't remember exactly, but think in process of trying to make EndSession actions more easitly distinguished from Text actions we created it's own renderer with the italic prefix, but forgot to include the toggle switch.  Adds the toggle switch 

![image](http://g.recordit.co/C1Mu5H4uPn.gif)