### PR TITLE
fix: detect api change

### DIFF
--- a/src/components/modals/ActionCreatorEditor.tsx
+++ b/src/components/modals/ActionCreatorEditor.tsx
@@ -540,7 +540,12 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
 
         const isTerminalChanged = initialEditState!.isTerminal !== this.state.isTerminal
         const isRepromptChanged = initialEditState!.reprompt !== this.state.reprompt
+        const isSelectedApiChanged = initialEditState.selectedApiOptionKey !== this.state.selectedApiOptionKey
+        const isSelectedCardChanged = initialEditState.selectedCardOptionKey !== this.state.selectedCardOptionKey
+
         const hasPendingChanges = isAnyPayloadChanged
+            || isSelectedApiChanged
+            || isSelectedCardChanged
             || expectedEntitiesChanged
             || requiredEntitiesChanged
             || disqualifyingEntitiesChanged


### PR DESCRIPTION
Fixes: ADO#2159

I was surprised this wasn't caught earlier, looks like we didn't detect changes in the callback or card selected.

Notice, "Save" button is enabled after changing to "OutOfStock" and then disabled when changing back.
![image](http://g.recordit.co/2j7I1uNS5N.gif)