### PR TITLE
fix: use same case on feature string matching

### DIFF
--- a/src/Utils/util.ts
+++ b/src/Utils/util.ts
@@ -237,13 +237,13 @@ export const getSetEntityActionsFromEnumEntity = (entity: CLM.EntityBase): CLM.A
 export function readFileAsync(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
         const reader = new FileReader();
-    
+
         reader.onload = (e: Event) => {
             resolve(reader.result as any);
         };
-    
+
         reader.onerror = reject;
-    
+
         reader.readAsText(file);
     })
 }
@@ -257,7 +257,7 @@ export function isTemplateTitleGeneric(template: CLM.Template): boolean {
 // Calculate a 32 bit FNV-1a hash
 // Ref.: http://isthe.com/chongo/tech/comp/fnv/
 export function hashText(text: string) {
-    // tslint:disable:no-bitwise 
+    // tslint:disable:no-bitwise
     let l = text.length
     let hval = 0x811C9DC5  // seed
 
@@ -271,7 +271,7 @@ export function hashText(text: string) {
 }
 
 export function isFeatureEnabled(featureString: string | undefined, feature: Const.FeatureStrings) {
-    if (featureString && featureString.toUpperCase().includes(feature)) {
+    if (featureString && featureString.toUpperCase().includes(feature.toUpperCase())) {
         return true
     }
     return false


### PR DESCRIPTION
There was utility added that used `toUpperCase()` on one side but not the other.
Purpose is to eliminate casing from matching for both the features and feature string. User shouldn't have to remember if it's "cci" "Cci", or "CCI", they all should work and easier to explain to people. 