### PR TITLE
fix: check name in use when editing

### DIFF
--- a/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
@@ -467,16 +467,20 @@ class Container extends React.Component<Props, ComponentState> {
         }
 
         // Check that name isn't in use
-        if (!this.state.isEditing) {
-            const foundEntity = this.props.entities.find(e => e.entityName === this.state.entityNameVal);
-            if (foundEntity) {
-                if (CLM.isPrebuilt(foundEntity)
-                    && typeof foundEntity.doNotMemorize !== 'undefined'
-                    && foundEntity.doNotMemorize) {
-                    return ''
-                }
-                return Util.formatMessageId(intl, FM.FIELDERROR_DISTINCT)
+        const entity = this.props.entity
+        const otherEntities = entity
+            ? this.props.entities
+                .filter(e => e.entityId !== entity.entityId)
+            : this.props.entities
+
+        const foundEntity = otherEntities.find(e => e.entityName === this.state.entityNameVal)
+        if (foundEntity) {
+            if (CLM.isPrebuilt(foundEntity)
+                && typeof foundEntity.doNotMemorize !== 'undefined'
+                && foundEntity.doNotMemorize) {
+                return ''
             }
+            return Util.formatMessageId(intl, FM.FIELDERROR_DISTINCT)
         }
 
         if (!this.state.isPrebuilt && (value.toLowerCase().substring(0, prebuiltPrefix.length) === prebuiltPrefix)) {


### PR DESCRIPTION
Noticed this while working on other bug. This error check wasn't run when editing, I assume because we didn't allow entity rename before. Now that we do it should be run in both cases.