### PR TITLE
fix: preserve isResolutionRequired when editing and add tests

### DIFF
--- a/cypress/fixtures/isResolutionRequired.cl
+++ b/cypress/fixtures/isResolutionRequired.cl
@@ -1,0 +1,261 @@
+{
+    "trainDialogs": [
+        {
+            "tags": [],
+            "description": "",
+            "trainDialogId": "19c82187-2e53-48f6-b940-1feb286d5834",
+            "rounds": [
+                {
+                    "extractorStep": {
+                        "textVariations": [
+                            {
+                                "text": "I have 3 fruits and 4 vegetables",
+                                "labelEntities": [
+                                    {
+                                        "entityId": "f9d18809-e7ca-42c1-8f93-eb5f86584e2d",
+                                        "startCharIndex": 7,
+                                        "endCharIndex": 7,
+                                        "entityText": "3",
+                                        "resolution": {
+                                            "subtype": "integer",
+                                            "value": "3"
+                                        },
+                                        "builtinType": "builtin.number"
+                                    },
+                                    {
+                                        "entityId": "f9d18809-e7ca-42c1-8f93-eb5f86584e2d",
+                                        "startCharIndex": 20,
+                                        "endCharIndex": 20,
+                                        "entityText": "4",
+                                        "resolution": {
+                                            "subtype": "integer",
+                                            "value": "4"
+                                        },
+                                        "builtinType": "builtin.number"
+                                    },
+                                    {
+                                        "entityId": "542a99de-fee3-4b6a-83c7-2bd60f852e30",
+                                        "startCharIndex": 7,
+                                        "endCharIndex": 7,
+                                        "entityText": "3",
+                                        "resolution": {},
+                                        "builtinType": "LUIS"
+                                    },
+                                    {
+                                        "entityId": "17b7d7ce-3136-490c-a427-03f8f694de22",
+                                        "startCharIndex": 20,
+                                        "endCharIndex": 20,
+                                        "entityText": "4",
+                                        "resolution": {},
+                                        "builtinType": "LUIS"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "scorerSteps": [
+                        {
+                            "input": {
+                                "filledEntities": [
+                                    {
+                                        "entityId": "542a99de-fee3-4b6a-83c7-2bd60f852e30",
+                                        "values": [
+                                            {
+                                                "userText": "3",
+                                                "displayText": "3",
+                                                "builtinType": "builtin.number",
+                                                "resolution": {
+                                                    "subtype": "integer",
+                                                    "value": "3"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "entityId": "17b7d7ce-3136-490c-a427-03f8f694de22",
+                                        "values": [
+                                            {
+                                                "userText": "4",
+                                                "displayText": "4",
+                                                "builtinType": "builtin.number",
+                                                "resolution": {
+                                                    "subtype": "integer",
+                                                    "value": "4"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "context": {},
+                                "maskedActions": []
+                            },
+                            "labelAction": "f2b1e5f2-08c7-4fad-974d-e00f3c100546",
+                            "metrics": {
+                                "predictMetrics": {
+                                    "blisTime": 0.012084007263183594,
+                                    "contextDialogBlisTime": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extractorStep": {
+                        "textVariations": [
+                            {
+                                "text": "I have 7 fruits and 8 vegetables",
+                                "labelEntities": [
+                                    {
+                                        "entityId": "f9d18809-e7ca-42c1-8f93-eb5f86584e2d",
+                                        "startCharIndex": 7,
+                                        "endCharIndex": 7,
+                                        "entityText": "7",
+                                        "resolution": {
+                                            "subtype": "integer",
+                                            "value": "7"
+                                        },
+                                        "builtinType": "builtin.number"
+                                    },
+                                    {
+                                        "entityId": "f9d18809-e7ca-42c1-8f93-eb5f86584e2d",
+                                        "startCharIndex": 20,
+                                        "endCharIndex": 20,
+                                        "entityText": "8",
+                                        "resolution": {
+                                            "subtype": "integer",
+                                            "value": "8"
+                                        },
+                                        "builtinType": "builtin.number"
+                                    },
+                                    {
+                                        "entityId": "542a99de-fee3-4b6a-83c7-2bd60f852e30",
+                                        "startCharIndex": 7,
+                                        "endCharIndex": 7,
+                                        "entityText": "7",
+                                        "resolution": {},
+                                        "builtinType": "LUIS"
+                                    },
+                                    {
+                                        "entityId": "17b7d7ce-3136-490c-a427-03f8f694de22",
+                                        "startCharIndex": 20,
+                                        "endCharIndex": 20,
+                                        "entityText": "8",
+                                        "resolution": {},
+                                        "builtinType": "LUIS"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "scorerSteps": [
+                        {
+                            "input": {
+                                "filledEntities": [
+                                    {
+                                        "entityId": "542a99de-fee3-4b6a-83c7-2bd60f852e30",
+                                        "values": [
+                                            {
+                                                "userText": "7",
+                                                "displayText": "7",
+                                                "builtinType": "builtin.number",
+                                                "resolution": {
+                                                    "subtype": "integer",
+                                                    "value": "7"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "entityId": "17b7d7ce-3136-490c-a427-03f8f694de22",
+                                        "values": [
+                                            {
+                                                "userText": "8",
+                                                "displayText": "8",
+                                                "builtinType": "builtin.number",
+                                                "resolution": {
+                                                    "subtype": "integer",
+                                                    "value": "8"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "context": {},
+                                "maskedActions": []
+                            },
+                            "labelAction": "f2b1e5f2-08c7-4fad-974d-e00f3c100546",
+                            "metrics": {
+                                "predictMetrics": {
+                                    "blisTime": 0.013524770736694336,
+                                    "contextDialogBlisTime": 0
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "clientData": {
+                "importHashes": []
+            },
+            "initialFilledEntities": [],
+            "createdDateTime": "2019-09-23T21:19:36.770002+00:00",
+            "lastModifiedDateTime": "2019-09-23T21:21:15+00:00"
+        }
+    ],
+    "actions": [
+        {
+            "actionId": "f2b1e5f2-08c7-4fad-974d-e00f3c100546",
+            "createdDateTime": "2019-09-23T21:20:18.4648565+00:00",
+            "actionType": "TEXT",
+            "payload": "{\"json\":{\"kind\":\"value\",\"document\":{\"kind\":\"document\",\"data\":{},\"nodes\":[{\"kind\":\"block\",\"type\":\"line\",\"isVoid\":false,\"data\":{},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"You have \",\"marks\":[]}]},{\"kind\":\"inline\",\"type\":\"mention-inline-node\",\"isVoid\":false,\"data\":{\"completed\":true,\"option\":{\"id\":\"542a99de-fee3-4b6a-83c7-2bd60f852e30\",\"name\":\"fruits\"}},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"$fruits\",\"marks\":[]}]}]},{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\" fruits and \",\"marks\":[]}]},{\"kind\":\"inline\",\"type\":\"mention-inline-node\",\"isVoid\":false,\"data\":{\"completed\":true,\"option\":{\"id\":\"17b7d7ce-3136-490c-a427-03f8f694de22\",\"name\":\"vegetables\"}},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"$vegetables\",\"marks\":[]}]}]},{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\" vegetables\",\"marks\":[]}]}]}]}}}",
+            "isTerminal": true,
+            "requiredEntitiesFromPayload": [
+                "542a99de-fee3-4b6a-83c7-2bd60f852e30",
+                "17b7d7ce-3136-490c-a427-03f8f694de22"
+            ],
+            "requiredEntities": [
+                "542a99de-fee3-4b6a-83c7-2bd60f852e30",
+                "17b7d7ce-3136-490c-a427-03f8f694de22"
+            ],
+            "negativeEntities": [],
+            "requiredConditions": [],
+            "negativeConditions": [],
+            "clientData": {
+                "importHashes": []
+            }
+        }
+    ],
+    "entities": [
+        {
+            "doNotMemorize": true,
+            "entityId": "f9d18809-e7ca-42c1-8f93-eb5f86584e2d",
+            "createdDateTime": "2019-09-23T21:19:19.1875064+00:00",
+            "entityName": "builtin-number",
+            "entityType": "number",
+            "isMultivalue": false,
+            "isNegatible": false,
+            "isResolutionRequired": false
+        },
+        {
+            "entityId": "542a99de-fee3-4b6a-83c7-2bd60f852e30",
+            "createdDateTime": "2019-09-23T21:19:18.4842925+00:00",
+            "entityName": "fruits",
+            "entityType": "LUIS",
+            "isMultivalue": false,
+            "isNegatible": false,
+            "resolverType": "number",
+            "isResolutionRequired": false
+        },
+        {
+            "entityId": "17b7d7ce-3136-490c-a427-03f8f694de22",
+            "createdDateTime": "2019-09-23T21:19:31.5000127+00:00",
+            "entityName": "vegetables",
+            "entityType": "LUIS",
+            "isMultivalue": false,
+            "isNegatible": false,
+            "resolverType": "number",
+            "isResolutionRequired": true
+        }
+    ],
+    "packageId": "cf3a8450-362f-49ae-8eda-a122076ada28"
+}

--- a/cypress/integration/regressionTs/isResolutionRequired.spec.ts
+++ b/cypress/integration/regressionTs/isResolutionRequired.spec.ts
@@ -6,11 +6,15 @@ describe('Resolution Required', () => {
     const testData = {
         modelName: `IsResRequired`,
         modelFile: 'isResolutionRequired.cl',
+        entityName01: 'fruits',
+        entityName02: 'vegetables',
     }
 
     before(() => {
         cy.visit('/')
         util.importModel(testData.modelName, testData.modelFile)
+        cy.get(s.trainingStatus.running, { timeout: constants.training.timeout })
+        cy.get(s.trainingStatus.completed, { timeout: constants.training.timeout })
     })
 
     describe('Entity Option Behavior', () => {
@@ -57,8 +61,31 @@ describe('Resolution Required', () => {
     })
 
     describe('Entity Label Behavior', () => {
-        it('given no resolution, entity label with option False should be allowed and label with option True should be removed', () => {
+        before(() => {
+            cy.reload()
 
+            cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
+                .should('not.exist')
+
+            cy.get(s.model.buttonNavTrainDialogs)
+                .click()
+
+            cy.get(s.trainDialogs.buttonNew)
+                .click()
+        })
+
+        it('given no resolution, entity label with option False should be allowed and label with option True should be removed', () => {
+            // We know imported model has learned to label words preceeding fruits and vegetables
+            // Fruits has resolution required False which means label will not be affected (exist)
+            // Vegetables has resolution required True which means label will be removed (not exist)
+            util.inputText('I have many fruits and many vegetables')
+
+            cy.get(s.extractionEditor.customButton)
+                .contains(testData.entityName01)
+
+            cy.get(s.extractionEditor.customButton)
+                .contains(testData.entityName02)
+                .should('not.exist')
         })
     })
 })

--- a/cypress/integration/regressionTs/isResolutionRequired.spec.ts
+++ b/cypress/integration/regressionTs/isResolutionRequired.spec.ts
@@ -20,6 +20,11 @@ describe('Resolution Required', () => {
     describe('Entity Option Behavior', () => {
         describe('New Entity', () => {
             before(() => {
+                cy.reload()
+
+                cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
+                    .should('not.exist')
+
                 cy.get(s.model.buttonNavEntities)
                     .click()
 
@@ -54,8 +59,20 @@ describe('Resolution Required', () => {
         })
 
         describe('Editing', () => {
-            it('should be disabled when editing', () => {
+            before(() => {
+                cy.reload()
 
+                cy.get(s.common.spinner, { timeout: constants.spinner.timeout })
+                    .should('not.exist')
+
+                cy.get(s.entities.name)
+                    .contains(testData.entityName01)
+                    .click()
+            })
+
+            it('should be disabled when editing', () => {
+                cy.get(s.entity.checkboxResolutionRequired)
+                    .should('have.class', 'is-disabled')
             })
         })
     })

--- a/cypress/integration/regressionTs/isResolutionRequired.spec.ts
+++ b/cypress/integration/regressionTs/isResolutionRequired.spec.ts
@@ -1,0 +1,64 @@
+import * as util from '../../support/utilities'
+import constants from '../../support/constants'
+import s from '../../support/selectors'
+
+describe('Resolution Required', () => {
+    const testData = {
+        modelName: `IsResRequired`,
+        modelFile: 'isResolutionRequired.cl',
+    }
+
+    before(() => {
+        cy.visit('/')
+        util.importModel(testData.modelName, testData.modelFile)
+    })
+
+    describe('Entity Option Behavior', () => {
+        describe('New Entity', () => {
+            before(() => {
+                cy.get(s.model.buttonNavEntities)
+                    .click()
+
+                cy.get(s.entities.buttonCreate)
+                    .click()
+            })
+
+            it('given NONE resolver type should be disabled and unchecked', () => {
+                cy.get(s.entity.dropDownResolverType)
+                    .should('contain.text', 'none')
+
+                cy.get(s.entity.checkboxResolutionRequired)
+                    .should('have.class', 'is-disabled')
+                    .should('not.have.class', 'is-checked')
+            })
+
+            it('when resolver type change from NONE to other, checkbox should be enabled and checked', () => {
+                util.selectDropDownOption(s.entity.dropDownResolverType, 'number')
+
+                cy.get(s.entity.checkboxResolutionRequired)
+                    .should('not.have.class', 'is-disabled')
+                    .should('have.class', 'is-checked')
+            })
+
+            it('when resolver type changes from other to NONE, checkbox should be disabled and unchecked', () => {
+                util.selectDropDownOption(s.entity.dropDownResolverType, 'none')
+
+                cy.get(s.entity.checkboxResolutionRequired)
+                    .should('have.class', 'is-disabled')
+                    .should('not.have.class', 'is-checked')
+            })
+        })
+
+        describe('Editing', () => {
+            it('should be disabled when editing', () => {
+
+            })
+        })
+    })
+
+    describe('Entity Label Behavior', () => {
+        it('given no resolution, entity label with option False should be allowed and label with option True should be removed', () => {
+
+        })
+    })
+})

--- a/cypress/support/selectors.ts
+++ b/cypress/support/selectors.ts
@@ -40,6 +40,8 @@ const selectors = {
         name: '[data-testid="entities-name"]',
     },
     entity: {
+        checkboxResolutionRequired: '[data-testid="entity-creator-resolution-required"] .ms-Checkbox',
+        dropDownResolverType: '[data-testid="entity-creator-resolver-type-dropdown"]',
         dropDownType: '[data-testid="entity-creator-entity-type-dropdown"]',
         modal: '[data-testid="entity-creator-modal"]',
         name: '[data-testid="entity-creator-entity-name-text"]',

--- a/src/components/modals/EntityCreatorEditor/EntityCreatorComponent.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorComponent.tsx
@@ -177,7 +177,7 @@ const EditComponent: React.FC<Props> = (props) => {
         <div className="cl-entity-creator-checkboxes cl-entity-creator-form">
             {props.entityTypeKey == CLM.EntityType.LUIS &&
                 <TC.Checkbox
-                    data-testid="entity-creator-resolver-strict"
+                    data-testid="entity-creator-resolution-required"
                     label={Util.formatMessageId(props.intl, FM.ENTITYCREATOREDITOR_FIELDS_RESOLVER_RESOLUTION_REQUIRED_LABEL)}
                     checked={props.isResolutionRequired}
                     onChange={props.onChangeResolverResolutionRequired}

--- a/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
@@ -789,7 +789,7 @@ class Container extends React.Component<Props, ComponentState> {
                 }
             })
 
-        const isEditing = typeof this.props.entity === 'object'
+        const isEditing = this.props.entity != null
 
         return <Component
             open={this.props.open}

--- a/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
+++ b/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
@@ -32,7 +32,6 @@ const initState: ComponentState = {
     isMultivalueVal: false,
     isNegatableVal: false,
     isResolutionRequired: false,
-    isEditing: false,
     enumValues: [],
     title: '',
     hasPendingChanges: false,
@@ -53,7 +52,6 @@ interface ComponentState {
     isMultivalueVal: boolean
     isNegatableVal: boolean
     isResolutionRequired: boolean
-    isEditing: boolean
     enumValues: (CLM.EnumValue | null)[]
     title: string
     hasPendingChanges: boolean
@@ -181,7 +179,6 @@ class Container extends React.Component<Props, ComponentState> {
                     isMultivalueVal: nextProps.entity.isMultivalue,
                     isNegatableVal: nextProps.entity.isNegatible,
                     isResolutionRequired: nextProps.entity.isResolutionRequired,
-                    isEditing: true,
                     title: nextProps.intl.formatMessage({
                         id: FM.ENTITYCREATOREDITOR_TITLE_EDIT,
                         defaultMessage: 'Edit Entity'
@@ -202,18 +199,22 @@ class Container extends React.Component<Props, ComponentState> {
     }
 
     componentDidUpdate(prevProps: Props, prevState: ComponentState) {
+        // If editing resolution option is disabled so preserve value
+        // Otherwise,
         // Force changes to isResolutionRequired when resolutionType changes
         // If NONE to other, enabled and true
         // If oter to NONE, disabled and false
-        if (this.state.entityResolverVal !== NONE_RESOLVER_KEY && prevState.entityResolverVal === NONE_RESOLVER_KEY) {
-            this.setState({
-                isResolutionRequired: true
-            })
-        }
-        else if (this.state.entityResolverVal === NONE_RESOLVER_KEY && prevState.entityResolverVal !== NONE_RESOLVER_KEY) {
-            this.setState({
-                isResolutionRequired: false
-            })
+        if (this.props.entity == null) {
+            if (this.state.entityResolverVal !== NONE_RESOLVER_KEY && prevState.entityResolverVal === NONE_RESOLVER_KEY) {
+                this.setState({
+                    isResolutionRequired: true
+                })
+            }
+            else if (this.state.entityResolverVal === NONE_RESOLVER_KEY && prevState.entityResolverVal !== NONE_RESOLVER_KEY) {
+                this.setState({
+                    isResolutionRequired: false
+                })
+            }
         }
 
         const entity = this.props.entity
@@ -296,7 +297,7 @@ class Container extends React.Component<Props, ComponentState> {
             newOrEditedEntity.enumValues = this.state.enumValues.filter(v => v) as CLM.EnumValue[]
         }
         // Set entity id if we're editing existing id.
-        if (this.state.isEditing && this.props.entity) {
+        if (this.props.entity) {
             newOrEditedEntity.entityId = this.props.entity.entityId
 
             if (newOrEditedEntity.isNegatible) {
@@ -316,7 +317,7 @@ class Container extends React.Component<Props, ComponentState> {
         let needValidationWarning = false
 
         // If editing check for validation errors
-        if (this.state.isEditing) {
+        if (this.props.entity) {
             const appId = this.props.app.appId
             const isMultiValueChanged = this.props.entity ? newOrEditedEntity.isMultivalue !== this.props.entity.isMultivalue : false
             const isNegatableChanged = this.props.entity ? newOrEditedEntity.isNegatible !== this.props.entity.isNegatible : false
@@ -352,16 +353,15 @@ class Container extends React.Component<Props, ComponentState> {
     saveAndClose(newOrEditedEntity: CLM.EntityBase) {
         const appId = this.props.app.appId
 
-        if (!this.state.isEditing) {
-            this.props.createEntityThunkAsync(appId, newOrEditedEntity)
-            this.props.handleClose()
-            return
+        const originalEntity = this.props.entity
+        if (originalEntity) {
+            this.props.editEntityThunkAsync(appId, newOrEditedEntity, originalEntity)
         }
         else {
-            // We know props.entity is valid because we're not editing
-            this.props.editEntityThunkAsync(appId, newOrEditedEntity, this.props.entity!)
-            this.props.handleClose()
+            this.props.createEntityThunkAsync(appId, newOrEditedEntity)
         }
+
+        this.props.handleClose()
     }
 
     onClickCancel = () => {
@@ -467,7 +467,7 @@ class Container extends React.Component<Props, ComponentState> {
         }
 
         // Check that name isn't in use
-        if (!this.state.isEditing) {
+        if (!this.props.entity) {
             const foundEntity = this.props.entities.find(e => e.entityName === this.state.entityNameVal);
             if (foundEntity) {
                 if (CLM.isPrebuilt(foundEntity)
@@ -785,6 +785,8 @@ class Container extends React.Component<Props, ComponentState> {
                 }
             })
 
+        const isEditing = typeof this.props.entity === 'object'
+
         return <Component
             open={this.props.open}
             title={title}
@@ -792,7 +794,7 @@ class Container extends React.Component<Props, ComponentState> {
             entityOptions={this.entityOptions}
 
             entityTypeKey={this.state.entityTypeVal}
-            isTypeDisabled={this.state.isEditing || this.props.entityTypeFilter != null}
+            isTypeDisabled={isEditing || this.props.entityTypeFilter != null}
             onChangeType={this.onChangeType}
 
             name={name}
@@ -808,7 +810,7 @@ class Container extends React.Component<Props, ComponentState> {
             isNegatable={this.state.isNegatableVal}
             onChangeNegatable={this.onChangeReversible}
 
-            isEditing={this.state.isEditing}
+            isEditing={isEditing}
             requiredActions={this.getRequiredActions()}
             disqualifiedActions={this.getDisqualifiedActions()}
 
@@ -821,7 +823,7 @@ class Container extends React.Component<Props, ComponentState> {
 
             isConfirmDeleteModalOpen={this.state.isConfirmDeleteModalOpen}
             isDeleteErrorModalOpen={this.state.isDeleteErrorModalOpen}
-            showDelete={this.state.isEditing && !!this.props.handleDelete}
+            showDelete={isEditing && !!this.props.handleDelete}
             onClickDelete={this.onClickDelete}
             onCancelDelete={this.onCancelDelete}
             onConfirmDelete={this.onConfirmDelete}


### PR DESCRIPTION
There was bug where option should show true regardless of actual entity value due to the force check / uncheck logic. Since the property is non-editable, it is now disabled when editing.

- Also adds e2e tests for checkbox behavior and actual extraction logic.
- Removed extra `isEditing` boolean

```
  Resolution Required
    Entity Option Behavior
      New Entity
        √ given NONE resolver type should be disabled and unchecked (54033ms)
        √ when resolver type change from NONE to other, checkbox should be enabled and checked (286ms)
        √ when resolver type changes from other to NONE, checkbox should be disabled and unchecked (272ms)
      Editing
        √ should be disabled when editing (3615ms)
    Entity Label Behavior
      √ given no resolution, entity label with option False should be allowed and label with option True should be removed (10134ms)
```