### PR TITLE
fix: keep DetailsList in DOM to correct log selection when deleting

### DIFF
--- a/src/routes/Apps/App/Index.css
+++ b/src/routes/Apps/App/Index.css
@@ -70,6 +70,10 @@
     text-align: center;
 }
 
+.cl-page-placeholder--none {
+    display: none;
+}
+
 .cl-page-placeholder__description {
     margin-bottom: 1em;
 }

--- a/src/routes/Apps/App/LogDialogs.tsx
+++ b/src/routes/Apps/App/LogDialogs.tsx
@@ -1026,61 +1026,58 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                         iconProps={{ iconName: 'Delete' }}
                     />
                 </div>
-                {
-                    isPlaceholderVisible
-                        ? <div className="cl-page-placeholder">
-                            <div className="cl-page-placeholder__content">
-                                <div className={`cl-page-placeholder__description ${OF.FontClassNames.xxLarge}`}>Create a Log Dialog</div>
-                                <OF.PrimaryButton
-                                    iconProps={{
-                                        iconName: "Add"
-                                    }}
-                                    disabled={isEditingDisabled}
-                                    onClick={this.onClickNewChatSession}
-                                    ariaDescription={Util.formatMessageId(this.props.intl, FM.LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION)}
-                                    text={Util.formatMessageId(this.props.intl, FM.LOGDIALOGS_CREATEBUTTONTITLE)}
-                                />
-                            </div>
-                        </div>
-                        : <>
-                            <div>
-                                <OF.Label htmlFor="logdialogs-input-search" className={OF.FontClassNames.medium}>
-                                    Search:
-                                </OF.Label>
-                                <OF.SearchBox
-                                    id="logdialogs-input-search"
-                                    data-testid="logdialogs-search-box"
-                                    className={OF.FontClassNames.mediumPlus}
-                                    onChange={this.onChangeSearchString}
-                                    onSearch={this.onSearch}
-                                />
-                            </div>
-                            <OF.DetailsList
-                                data-testid="logdialogs-details-list"
-                                key={this.state.dialogKey}
-                                className={OF.FontClassNames.mediumPlus}
-                                items={computedLogDialogs}
-                                selection={this.selection}
-                                getKey={getDialogKey}
-                                setKey="selectionKey"
-                                columns={this.state.columns}
-                                checkboxVisibility={OF.CheckboxVisibility.onHover}
-                                onColumnHeaderClick={this.onClickColumnHeader}
-                                onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
-                                onRenderItemColumn={(logDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(logDialog, this))}
-                                onItemInvoked={logDialog => this.onClickLogDialogItem(logDialog)}
+
+                    <div className={`cl-page-placeholder ${isPlaceholderVisible ? '' : 'cl-page-placeholder--none'}`}>
+                        <div className="cl-page-placeholder__content">
+                            <div className={`cl-page-placeholder__description ${OF.FontClassNames.xxLarge}`}>Create a Log Dialog</div>
+                            <OF.PrimaryButton
+                                iconProps={{
+                                    iconName: "Add"
+                                }}
+                                disabled={isEditingDisabled}
+                                onClick={this.onClickNewChatSession}
+                                ariaDescription={Util.formatMessageId(this.props.intl, FM.LOGDIALOGS_CREATEBUTTONARIALDESCRIPTION)}
+                                text={Util.formatMessageId(this.props.intl, FM.LOGDIALOGS_CREATEBUTTONTITLE)}
                             />
-                        </>
-                }
+                        </div>
+                    </div>
+                    <>
+                        <div className={isPlaceholderVisible ? 'cl-hidden' : ''}>
+                            <OF.Label htmlFor="logdialogs-input-search" className={OF.FontClassNames.medium}>
+                                Search:
+                            </OF.Label>
+                            <OF.SearchBox
+                                id="logdialogs-input-search"
+                                data-testid="logdialogs-search-box"
+                                className={OF.FontClassNames.mediumPlus}
+                                onChange={this.onChangeSearchString}
+                                onSearch={this.onSearch}
+                            />
+                        </div>
+                        <OF.DetailsList
+                            data-testid="logdialogs-details-list"
+                            key={this.state.dialogKey}
+                            className={`${OF.FontClassNames.mediumPlus} ${isPlaceholderVisible ? 'cl-hidden' : ''}`}
+                            items={computedLogDialogs}
+                            selection={this.selection}
+                            getKey={getDialogKey}
+                            setKey="selectionKey"
+                            columns={this.state.columns}
+                            checkboxVisibility={OF.CheckboxVisibility.onHover}
+                            onColumnHeaderClick={this.onClickColumnHeader}
+                            onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
+                            onRenderItemColumn={(logDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(logDialog, this))}
+                            onItemInvoked={logDialog => this.onClickLogDialogItem(logDialog)}
+                        />
+                    </>
 
 
-
-                <ChatSessionModal
-                    app={this.props.app}
-                    editingPackageId={this.props.editingPackageId}
-                    open={this.state.isChatSessionWindowOpen}
-                    onClose={this.onCloseChatSessionWindow}
-                />
+                    <ChatSessionModal
+                        app={this.props.app}
+                        editingPackageId={this.props.editingPackageId}
+                        open={this.state.isChatSessionWindowOpen}
+                        onClose={this.onCloseChatSessionWindow}
+                    />
                 {
                     teachSession && teachSession.teach &&
                     <TeachSessionModal


### PR DESCRIPTION
I'm not sure why the selection object isn't reset when it's source doesn't exist anymore (list is removed from DOM).  I asked on the OF teams channel so we'll see if they have better solution.
This works for now.

Fixes ADO#2307