### PR TITLE
fix: remove entity overlay when switching extraction

### DIFF
--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -144,7 +144,8 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
             this.setState({
                 value: convertEntitiesAndTextToTokenizedEditorValue(nextProps.text, nextProps.customEntities, NodeType.CustomEntityNodeType),
                 preBuiltEditorValues: nextProps.preBuiltEntities.map<any[]>(preBuiltEntity => convertEntitiesAndTextToEditorValue(nextProps.text, [preBuiltEntity], NodeType.PreBuiltEntityNodeType)),
-                isSelectionOverlappingOtherEntities: false
+                isSelectionOverlappingOtherEntities: false,
+                isDeleteButtonVisible: false,
             })
             this.props.onClosePicker()
         }


### PR DESCRIPTION
Fixes: ADO#2264

**Why was the entity overlay added?**

We used to allow users to freely select text. This was a established behavior they would expect from other program like notepad or Word and some time ago this overlay was put in and diverged from that behavior. Likely to protect against some error but what was it? In other words, previously there was no concept or requirement to UNselect something, the new selection would over write the old one. Now the users have to click again.

There is also duplicated state in the extractor editor and the custom entity node. From my testing it was because the node is not re-rendered and needs this, but it's going against standard react patterns of lifting state to parents, This is example of thing that would be better to capture comments.