### PR TITLE
fix: prevent list row invocation when viewing card

### DIFF
--- a/src/components/actionPayloadRenderers/CardPayloadRendererWithHighlights.tsx
+++ b/src/components/actionPayloadRenderers/CardPayloadRendererWithHighlights.tsx
@@ -26,6 +26,12 @@ const Component: React.FC<Props> = (props) => {
         setIsOriginalVisivilble(x => !x)
     }
 
+    const onClickViewCard = (event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement | OF.BaseButton | OF.Button, MouseEvent>) => {
+        event.preventDefault()
+        event.stopPropagation()
+        props.onClickViewCard(props.cardAction, isOriginalVisible)
+    }
+
     return (
         <div className="cl-card-payload">
             <div data-testid="action-scorer-card">
@@ -58,7 +64,7 @@ const Component: React.FC<Props> = (props) => {
                 <OF.IconButton
                     disabled={props.isValidationError}
                     className="ms-Button--primary cl-button--viewCard"
-                    onClick={() => props.onClickViewCard(props.cardAction, isOriginalVisible)}
+                    onClick={onClickViewCard}
                     ariaDescription="ViewCard"
                     iconProps={{ iconName: 'RedEye' }}
                 />


### PR DESCRIPTION
Fixes ADO#2220

Click event to view card was going through to list.