### PR TITLE
test: add smoke test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 
+# https://circleci.com/docs/2.0/reusing-config/#the-commands-key
 commands:
   run-bot-and-ui:
     description: "Runs the sample bot and the UI to allow E2E test to be run."
@@ -48,6 +49,20 @@ commands:
       # For some reason this times out as failure even though the bot is running and request should succeed
       # - run: npx wait-on -- http://localhost:3978
       - run: npx wait-on -- http://localhost:3000
+  save-test-results:
+    description: "Save artifacts and test results"
+    steps:
+      - store_artifacts:
+          path: results
+
+      - store_artifacts:
+          path: cypress/videos
+
+      - store_artifacts:
+          path: cypress/screenshots
+
+      - store_test_results:
+          path: results
 
 jobs:
   build:
@@ -93,17 +108,7 @@ jobs:
       # Need to add in --parallel once we have a license for it from Cypress
       - run: npm run cypress -- run --record false --spec  "cypress/integration/smoke/**/*.spec.*"
 
-      - store_artifacts:
-          path: results
-
-      - store_artifacts:
-          path: cypress/videos
-
-      - store_artifacts:
-          path: cypress/screenshots
-
-      - store_test_results:
-          path: results
+      - save-test-results
 
   test-regression:
     docker:
@@ -120,46 +125,17 @@ jobs:
       # Need to add in --parallel once we have a license for it from Cypress
       - run: npm run cypress -- run --record false --spec  "cypress/integration/Regression/**/*.spec.js"
 
-      - store_artifacts:
-          path: results
-
-      - store_artifacts:
-          path: cypress/videos
-
-      - store_artifacts:
-          path: cypress/screenshots
-
-      - store_test_results:
-          path: results
+      - save-test-results
 
       - run:
           command: npm run cypress -- run --record false --spec  "cypress/integration/regressionTs/**/*.spec.*"
           when: always
 
-      - store_artifacts:
-          path: results
-
-      - store_artifacts:
-          path: cypress/videos
-
-      - store_artifacts:
-          path: cypress/screenshots
-
-      - store_test_results:
-          path: results
+      - save-test-results
 
       - run:
           command: npm run cypress -- run --record false --spec "cypress/integration/Tools/DeleteAllTestGeneratedModels.spec.js"
           when: always
-
-      - store_artifacts:
-          path: results
-
-      - store_artifacts:
-          path: cypress/videos
-
-      - store_artifacts:
-          path: cypress/screenshots
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
 
       # Run UI e2e tests
       # Need to add in --parallel once we have a license for it from Cypress
-      - run: npm run cypress -- run --record false --spec  "cypress/integration/smoke/**/*.spec.*"
+      - run: npm run cypress -- run --record false --spec  "cypress/integration/smoke/required/**/*.spec.*"
 
       - save-test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm run test
       - run: npm run cibuild
 
-  test:
+  test-smoke:
     docker:
       - image: cypress/browsers:chrome65-ff57
         environment:
@@ -61,18 +61,18 @@ jobs:
 
       # Clone the Samples BOT
       - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop ../cl-samples
-      
+
       # Install and build sample Bot application
       - run: cd ../cl-samples && npm ci
       - run: cd ../cl-samples && npm run build
 
       # Run sample
-      - run: 
+      - run:
           command: cd ../cl-samples && npm run test-apicallbacks
           background: true
 
       # Run UI
-      - run: 
+      - run:
           command: npm start
           background: true
 
@@ -81,10 +81,79 @@ jobs:
       # For some reason this times out as failure even though the bot is running and request should succeed
       # - run: npx wait-on -- http://localhost:3978
       - run: npx wait-on -- http://localhost:3000
-      
+
       # Run UI e2e tests
       # Need to add in --parallel once we have a license for it from Cypress
-      # - run: npm run cypress -- run --record false --spec  "cypress/integration/smoke/**/*.spec.*"
+      - run: npm run cypress -- run --record false --spec  "cypress/integration/smoke/**/*.spec.*"
+
+      - store_artifacts:
+          path: results
+
+      - store_artifacts:
+          path: cypress/videos
+
+      - store_artifacts:
+          path: cypress/screenshots
+
+      - store_test_results:
+          path: results
+
+  test-regression:
+    docker:
+      - image: cypress/browsers:chrome65-ff57
+        environment:
+          ## this enables colors in the output
+          TERM: xterm
+          ipc: host ## https://github.com/cypress-io/cypress/issues/350
+    parallelism: 1
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1-deps-{{ .Branch }}
+            - v1-deps
+
+      - run: node --version
+      - run: npm --version
+      - run: npm ci
+
+      - save_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - ~/.npm
+            - ~/.cache
+
+      # Randomly pick 1 out of 5 LUIS Authoring Keys and set the BASH_ENV with it.
+      - run: node .circleci/SetLuisAuthoringKey.js >> $BASH_ENV
+
+      # Clone the Samples BOT
+      - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop ../cl-samples
+
+      # Install and build sample Bot application
+      - run: cd ../cl-samples && npm ci
+      - run: cd ../cl-samples && npm run build
+
+      # Run sample
+      - run:
+          command: cd ../cl-samples && npm run test-apicallbacks
+          background: true
+
+      # Run UI
+      - run:
+          command: npm start
+          background: true
+
+      # Ensure bot and ui are running
+      # TODO: Find out why this fails.
+      # For some reason this times out as failure even though the bot is running and request should succeed
+      # - run: npx wait-on -- http://localhost:3978
+      - run: npx wait-on -- http://localhost:3000
+
+      # Run UI e2e tests
+      # Need to add in --parallel once we have a license for it from Cypress
       - run: npm run cypress -- run --record false --spec  "cypress/integration/Regression/**/*.spec.js"
 
       - store_artifacts:
@@ -95,7 +164,7 @@ jobs:
 
       - store_artifacts:
           path: cypress/screenshots
-          
+
       - store_test_results:
           path: results
 
@@ -111,11 +180,11 @@ jobs:
 
       - store_artifacts:
           path: cypress/screenshots
-          
+
       - store_test_results:
           path: results
 
-      - run: 
+      - run:
           command: npm run cypress -- run --record false --spec "cypress/integration/Tools/DeleteAllTestGeneratedModels.spec.js"
           when: always
 
@@ -127,12 +196,14 @@ jobs:
 
       - store_artifacts:
           path: cypress/screenshots
-          
-          
+
 workflows:
   build-test:
     jobs:
       - build
-      - test:
+      - test-smoke:
           requires:
-              - build
+            - build
+      - test-regression:
+          requires:
+            - test-smoke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,54 @@
 version: 2.1
+
+commands:
+  run-bot-and-ui:
+    description: "Runs the sample bot and the UI to allow E2E test to be run."
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1-deps-{{ .Branch }}
+            - v1-deps
+
+      - run: node --version
+      - run: npm --version
+      - run: npm ci
+
+      - save_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - ~/.npm
+            - ~/.cache
+
+      # Randomly pick 1 out of 5 LUIS Authoring Keys and set the BASH_ENV with it.
+      - run: node .circleci/SetLuisAuthoringKey.js >> $BASH_ENV
+
+      # Clone the Samples BOT
+      - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop ../cl-samples
+
+      # Install and build sample Bot application
+      - run: cd ../cl-samples && npm ci
+      - run: cd ../cl-samples && npm run build
+
+      # Run sample
+      - run:
+          command: cd ../cl-samples && npm run test-apicallbacks
+          background: true
+
+      # Run UI
+      - run:
+          command: npm start
+          background: true
+
+      # Ensure bot and ui are running
+      # TODO: Find out why this fails.
+      # For some reason this times out as failure even though the bot is running and request should succeed
+      # - run: npx wait-on -- http://localhost:3978
+      - run: npx wait-on -- http://localhost:3000
+
 jobs:
   build:
     docker:
@@ -37,50 +87,7 @@ jobs:
           ipc: host ## https://github.com/cypress-io/cypress/issues/350
     parallelism: 1
     steps:
-      - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-            - v1-deps-{{ .Branch }}
-            - v1-deps
-
-      - run: node --version
-      - run: npm --version
-      - run: npm ci
-
-      - save_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-          paths:
-            - ~/.npm
-            - ~/.cache
-
-      # Randomly pick 1 out of 5 LUIS Authoring Keys and set the BASH_ENV with it.
-      - run: node .circleci/SetLuisAuthoringKey.js >> $BASH_ENV
-
-      # Clone the Samples BOT
-      - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop ../cl-samples
-
-      # Install and build sample Bot application
-      - run: cd ../cl-samples && npm ci
-      - run: cd ../cl-samples && npm run build
-
-      # Run sample
-      - run:
-          command: cd ../cl-samples && npm run test-apicallbacks
-          background: true
-
-      # Run UI
-      - run:
-          command: npm start
-          background: true
-
-      # Ensure bot and ui are running
-      # TODO: Find out why this fails.
-      # For some reason this times out as failure even though the bot is running and request should succeed
-      # - run: npx wait-on -- http://localhost:3978
-      - run: npx wait-on -- http://localhost:3000
+      - run-bot-and-ui
 
       # Run UI e2e tests
       # Need to add in --parallel once we have a license for it from Cypress
@@ -107,50 +114,7 @@ jobs:
           ipc: host ## https://github.com/cypress-io/cypress/issues/350
     parallelism: 1
     steps:
-      - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-            - v1-deps-{{ .Branch }}
-            - v1-deps
-
-      - run: node --version
-      - run: npm --version
-      - run: npm ci
-
-      - save_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-          paths:
-            - ~/.npm
-            - ~/.cache
-
-      # Randomly pick 1 out of 5 LUIS Authoring Keys and set the BASH_ENV with it.
-      - run: node .circleci/SetLuisAuthoringKey.js >> $BASH_ENV
-
-      # Clone the Samples BOT
-      - run: git clone https://github.com/Microsoft/ConversationLearner-Samples -b develop ../cl-samples
-
-      # Install and build sample Bot application
-      - run: cd ../cl-samples && npm ci
-      - run: cd ../cl-samples && npm run build
-
-      # Run sample
-      - run:
-          command: cd ../cl-samples && npm run test-apicallbacks
-          background: true
-
-      # Run UI
-      - run:
-          command: npm start
-          background: true
-
-      # Ensure bot and ui are running
-      # TODO: Find out why this fails.
-      # For some reason this times out as failure even though the bot is running and request should succeed
-      # - run: npx wait-on -- http://localhost:3978
-      - run: npx wait-on -- http://localhost:3000
+      - run-bot-and-ui
 
       # Run UI e2e tests
       # Need to add in --parallel once we have a license for it from Cypress

--- a/cypress/integration/smoke/required/placeholder.spec.ts
+++ b/cypress/integration/smoke/required/placeholder.spec.ts
@@ -1,5 +1,5 @@
 describe('Placeholder smoke test', () => {
-    test('Replace with actual tests', () => {
+    it('should pass - replace with actual tests', () => {
         cy.visit(`/`)
     })
 })

--- a/cypress/integration/smoke/required/placeholder.spec.ts
+++ b/cypress/integration/smoke/required/placeholder.spec.ts
@@ -1,0 +1,5 @@
+describe('Placeholder smoke test', () => {
+    test('Replace with actual tests', () => {
+        cy.visit(`/`)
+    })
+})


### PR DESCRIPTION
Adds separate smoke job in order to have separate github check which can pass or fail independently of the others.

We had a smoke folder but it was only used by the sample repo. Eventually you should be able to put which ever tests you want in this folder and to have them run.

Would need to preserve the existing smoke test for samples. ~If there needs to be change to avoid executing `apiCoverage` test then you would need to add more folders and change paths in cypress commands and update samples to refer to this new path.~ Created a new "required" folder for tests you would like to run.

~Likely won't pass in first couple of runs as trying to see if we can re-use sections of the YAML instead of duplicating job definition.~
Added `commands` https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21
`run-bot-and-ui` and `save-test-results` to reduce a lot of the duplicated steps.

Now the job is mostly focused on the actual `cypress` command 