### PR TITLE
fix: store newly-created entities and actions in app memory

### DIFF
--- a/src/Utils/dialogEditing.ts
+++ b/src/Utils/dialogEditing.ts
@@ -469,8 +469,10 @@ export async function onEditTeach(
     await editHandler(trainDialog, selectedActivity, args)
 }
 
-// Returns placeholder if it exists, otherwise creates it if given creation action.
-// Will add the new action to `actions` if one is created.
+/**
+ * Returns placeholder if it exists, otherwise creates it if given creation action.
+ * Will add the new action to `actions` if one is created.
+ */
 export async function getOrCreatePlaceholderAPIAction(
     appId: string,
     placeholderName: string | "",
@@ -490,9 +492,9 @@ export async function getOrCreatePlaceholderAPIAction(
         placeholder = actions.filter(a => CLM.ActionBase.isPlaceholderAPI(a))
             .map(aa => new CLM.ApiAction(aa))
             .find(aaa => aaa.name === placeholderName)
-        if (placeholder) {
-            return placeholder
-        }
+    }
+    if (placeholder) {
+        return placeholder
     }
 
     // If create action is available create a new action

--- a/src/Utils/dialogEditing.ts
+++ b/src/Utils/dialogEditing.ts
@@ -469,7 +469,8 @@ export async function onEditTeach(
     await editHandler(trainDialog, selectedActivity, args)
 }
 
-// Returns placeholder if it exists, otherwise creates it if given creation action
+// Returns placeholder if it exists, otherwise creates it if given creation action.
+// Will add the new action to `actions` if one is created.
 export async function getOrCreatePlaceholderAPIAction(
     appId: string,
     placeholderName: string | "",
@@ -489,9 +490,9 @@ export async function getOrCreatePlaceholderAPIAction(
         placeholder = actions.filter(a => CLM.ActionBase.isPlaceholderAPI(a))
             .map(aa => new CLM.ApiAction(aa))
             .find(aaa => aaa.name === placeholderName)
-        if (placeholder) {
-            return placeholder
-        }
+    }
+    if (placeholder) {
+        return placeholder
     }
 
     // If create action is available create a new action

--- a/src/Utils/dialogEditing.ts
+++ b/src/Utils/dialogEditing.ts
@@ -477,7 +477,7 @@ export async function getOrCreatePlaceholderAPIAction(
     actions: CLM.ActionBase[],
     createActionThunkAsync: (appId: string, action: CLM.ActionBase) => Promise<CLM.ActionBase | null> | null
 ): Promise<CLM.ActionBase | undefined> {
-    // Check if it has been attached to real api call
+    // Get the action if it has been attached to real API call.
     const apiHash = Util.hashText(placeholderName)
     let placeholder = actions.find(a => {return a.clientData && a.clientData.importHashes
         ? (a.clientData.importHashes.find(h => h === apiHash) !== undefined)
@@ -489,9 +489,9 @@ export async function getOrCreatePlaceholderAPIAction(
         placeholder = actions.filter(a => CLM.ActionBase.isPlaceholderAPI(a))
             .map(aa => new CLM.ApiAction(aa))
             .find(aaa => aaa.name === placeholderName)
-    }
-    if (placeholder) {
-        return placeholder
+        if (placeholder) {
+            return placeholder
+        }
     }
 
     // If create action is available create a new action
@@ -506,7 +506,7 @@ export async function getOrCreatePlaceholderAPIAction(
         if (!newAction) {
             throw new Error("Failed to create placeholder API")
         }
-
+        actions.push(newAction)
         return newAction
     }
     return undefined

--- a/src/Utils/dialogEditing.ts
+++ b/src/Utils/dialogEditing.ts
@@ -249,7 +249,7 @@ export async function onChangeAction(
                 if (!newAction.clientData || !newAction.clientData.importHashes) {
                     newAction.clientData = { importHashes: []}
                 }
-                newAction.clientData!.importHashes!.push(importHash)
+                newAction.clientData.importHashes!.push(importHash)
                 await editActionThunkAsync(appId, newAction)
 
                 // Test if new lookup can be used on any other imported actions
@@ -470,7 +470,7 @@ export async function onEditTeach(
 }
 
 // Returns placeholder if it exists, otherwise creates it if given creation action
-export async function getPlaceholderAPIAction(
+export async function getOrCreatePlaceholderAPIAction(
     appId: string,
     placeholderName: string | "",
     isTerminal: boolean,
@@ -544,7 +544,8 @@ export async function getAPIPlaceholderScorerStep(
     createActionThunkAsync: (appId: string, action: CLM.ActionBase) => Promise<CLM.ActionBase | null>
 ): Promise<CLM.TrainScorerStep> {
 
-    const placeholderAction = await getPlaceholderAPIAction(appId, placeholderName, isTerminal, actions, createActionThunkAsync)
+    const placeholderAction = await getOrCreatePlaceholderAPIAction(appId, placeholderName, isTerminal,
+        actions, createActionThunkAsync)
 
     if (!placeholderAction) {
         throw new Error("Unable to create API placeholder Action")

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -36,8 +36,8 @@ export class ObiDialogParser {
         createEntityThunkAsync: (appId: string, entity: CLM.EntityBase) => Promise<CLM.EntityBase | null>
     ) {
         this.app = app
-        this.actions = actions
-        this.entities = entities
+        this.actions = [...actions]
+        this.entities = [...entities]
         this.createActionThunkAsync = createActionThunkAsync
         this.createEntityThunkAsync = createEntityThunkAsync
     }
@@ -249,8 +249,8 @@ export class ObiDialogParser {
         const hashText = JSON.stringify(step)
         let action: CLM.ActionBase | undefined | null = OBIUtils.findActionFromHashText(hashText, this.actions)
         if (!action && this.createActionThunkAsync) {
-            action = await DialogEditing.getPlaceholderAPIAction(this.app.appId, step.url, isTerminal,
-                this.actions, this.createActionThunkAsync as any)
+            action = await DialogEditing.getOrCreatePlaceholderAPIAction(this.app.appId, step.url,
+                isTerminal, this.actions, this.createActionThunkAsync as any)
         }
         // Create an entity for each output parameter in the action.
         let actionOutputEntities: OBIUtils.OBIActionOutput[] = []

--- a/src/Utils/obiUtils.tsx
+++ b/src/Utils/obiUtils.tsx
@@ -654,6 +654,9 @@ export async function importActionOutput(
             if (!entityId) {
                 throw new Error("Invalid Entity Definition")
             }
+            // Record the created entity in the input entity list.
+            newEntity.entityId = entityId
+            entities.push(newEntity)
         }
         else {
             entityId = "UNKNOWN ENTITY"

--- a/src/Utils/obiUtils.tsx
+++ b/src/Utils/obiUtils.tsx
@@ -252,7 +252,8 @@ export async function trainDialogFromTranscriptImport(
                     const isTerminal = !nextActivity || nextActivity.from.role === "user"
 
                     if (!action) {
-                        action = await DialogEditing.getPlaceholderAPIAction(app.appId, actionCall.actionName, isTerminal, actions, createActionThunkAsync as any)
+                        action = await DialogEditing.getOrCreatePlaceholderAPIAction(app.appId, actionCall.actionName,
+                            isTerminal, actions, createActionThunkAsync as any)
                     }
                     // Throw error if I was supposed to create actions
                     if (!action && createActionThunkAsync) {

--- a/src/Utils/obiUtils.tsx
+++ b/src/Utils/obiUtils.tsx
@@ -611,7 +611,7 @@ export function areTranscriptsEqual(transcript1: Util.RecursivePartial<BB.Activi
 /**
  * Given the {entityName, entityValue} results from some action being imported, returns
  * an array of FilledEntity instances representing those results.
- * Entities that do not yet exist will be created once.
+ * Entities that do not yet exist will be created and added to `entities`.
  */
 export async function importActionOutput(
     actionResults: OBIActionOutput[],


### PR DESCRIPTION
During .dialog import, we check to see if a given action or entity has already been created by looking them up in app memory (TrainDialog's `actions` or `entities` props).  Invoking the `create...ThunkAsync` does not update props while importing a set of dialogs; accordingly, without this change, the import will try to create the same action/entity multiple times, if the same action/entity is referenced in multiple dialog steps.

Tested via import of the product key intent v4 files.