### PR TITLE
fix: handle edge cases for OBI .dialog import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13729,7 +13729,7 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -12,7 +12,7 @@ import * as stripJsonComments from 'strip-json-comments'
 enum OBIStepType {
     BEGIN_DIALOG = "Microsoft.BeginDialog",
     END_DIALOG = "Microsoft.EndDialog",
-    END_TURN = "Microsoft.EndTurn",  // TODO(thpar) : Obsolete / delete ?
+    END_TURN = "Microsoft.EndTurn",
     HTTP_REQUEST = "Microsoft.HttpRequest",
     SEND_ACTIVITY = "Microsoft.SendActivity",
     TEXT_INPUT = "Microsoft.TextInput"
@@ -219,7 +219,9 @@ export class ObiDialogParser {
     }
 
     // Recursive helper.
-    private async getTrainDialogsIter(node: ObiDialogNode, currentRounds: CLM.TrainRound[],
+    private async getTrainDialogsIter(
+        node: ObiDialogNode,
+        currentRounds: CLM.TrainRound[],
         intent: string | undefined):
         Promise<CLM.TrainDialog[]> {
         if (!node) {

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -245,8 +245,16 @@ export class ObiDialogParser {
                     }
                     trainRound.extractorStep = extractorStep
                     currentIntent = undefined  // Used the intent in this round, so reset it.
+                    rounds.push(trainRound)
+                } else {
+                    // If we get here, then the current node has steps to execute *without* an intervening intent
+                    // (user utterance).  We therefore must append these scorer steps to the previous round.
+                    if (currentRounds.length === 0) {
+                        throw Error(`Attempting to append scorer steps to a non-existent round in node ${obiDialog.$id}`)
+                    }
+                    let round = currentRounds[currentRounds.length - 1]
+                    round.scorerSteps = [...round.scorerSteps, ...trainRound.scorerSteps]
                 }
-                rounds.push(trainRound)
             }
         }
         // This is a leaf node of the conversational tree; build a dialog containing the visited rounds.

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -11,7 +11,8 @@ import * as stripJsonComments from 'strip-json-comments'
 
 enum OBIStepType {
     BEGIN_DIALOG = "Microsoft.BeginDialog",
-    END_TURN = "Microsoft.EndTurn",
+    END_DIALOG = "Microsoft.EndDialog",
+    END_TURN = "Microsoft.EndTurn",  // TODO(thpar) : Obsolete / delete ?
     HTTP_REQUEST = "Microsoft.HttpRequest",
     SEND_ACTIVITY = "Microsoft.SendActivity",
     TEXT_INPUT = "Microsoft.TextInput"
@@ -325,6 +326,7 @@ export class ObiDialogParser {
                     // Nothing to do here, the child dialogs were already expanded.
                     break
                 }
+                case OBIStepType.END_DIALOG:
                 case OBIStepType.END_TURN:
                     // Noop.
                     break

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -306,10 +306,11 @@ export class ObiDialogParser {
                     // Nothing to do here, the child dialogs were already expanded.
                     break
                 }
+                case OBIStepType.END_TURN:
+                    // Noop.
+                    break
                 default: {
-                    if (step.$type !== OBIStepType.END_TURN) {
-                        this.warnings.push(`Unhandled OBI Type: ${step.$type}`)
-                    }
+                    this.warnings.push(`Unhandled OBI Type: ${step.$type}`)
                 }
             }
         }


### PR DESCRIPTION
In OBI .dialog files, some steps in the tree can carry an "intent", which is a dialog sub-tree classification such as `Product_Key_Service_Integration_main` or `End_of_Conversation_main`.  We use this "intent" as a proxy for user utterances in the generated train dialogs :

![end_of_conv](https://user-images.githubusercontent.com/53840199/66787123-5aa8e000-ee97-11e9-82dc-551ff368375c.png)

This PR fixes 2 edge cases during .dialog import.

1. Nodes that have an incoming intent but no actions other than redirection to other dialog nodes
2. Nodes that have actions but no incoming intents

**For (1)**, the current node's intent was only used if the node also generated actions; this would cause the intent to be dropped if the only action was to redirect to another dialog node.

To fix this, the intent is carried forward through the recursive handling of the dialog tree if it's not used in the generation of a TrainRound.

**For (2)**, we could have a situation where a node generates a valid round -- eg, it has both an incoming intent and one or more actions -- and then the node redirects to another node that has only action steps.  In this situation, we cannot create a new train round for the action-only node, since there is no new user utterance (intent) being introduced.

To fix this, if a node generates only `ScorerStep`s (and no `ExtractorStep`), those `ScorerStep`s will be appended to the previous round.

Tested with import of the Product Key files : 
[Output_Product_Rev5.zip](https://github.com/microsoft/ConversationLearner-UI/files/3726643/Output_Product_Rev5.zip)

