### PR TITLE
feat: Handle SwitchCondition nodes in .dialog import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13729,7 +13729,7 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -391,7 +391,6 @@ export class ObiDialogParser {
 
     /**
      * Creates enum entities and values for elements used in SwitchCondition comparisons, if they do not already exist.
-     * Noop for values that have already been created.
      * 
      * @param conditionalEntities dictionary key is the name of the value used in comparison (entity name);
      *     dictionary values are the distinct string values used across all comparisons of that entity.

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -245,8 +245,16 @@ export class ObiDialogParser {
                     }
                     trainRound.extractorStep = extractorStep
                     currentIntent = undefined  // Used the intent in this round, so reset it.
+                    rounds.push(trainRound)
+                } else {
+                    // If we get here, then the current node has steps to execute *without* an intervening intent
+                    // (user utterance).  We therefore must append these scorer steps to the previous round.
+                    if (currentRounds.length === 0) {
+                        throw Error(`Attempting to append scorer steps to a non-existent round in node ${obiDialog.$id}`)
+                    }
+                    let round = currentRounds[currentRounds.length - 1]
+                    round.scorerSteps = [...round.scorerSteps, ...trainRound.scorerSteps]
                 }
-                rounds.push(trainRound)
             }
         }
         // This is a leaf node of the conversational tree; build a dialog containing the visited rounds.

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -11,7 +11,8 @@ import * as stripJsonComments from 'strip-json-comments'
 
 enum OBIStepType {
     BEGIN_DIALOG = "Microsoft.BeginDialog",
-    END_TURN = "Microsoft.EndTurn",
+    END_DIALOG = "Microsoft.EndDialog",
+    END_TURN = "Microsoft.EndTurn",  // TODO(thpar) : Obsolete / delete ?
     HTTP_REQUEST = "Microsoft.HttpRequest",
     SEND_ACTIVITY = "Microsoft.SendActivity",
     TEXT_INPUT = "Microsoft.TextInput"
@@ -325,6 +326,7 @@ export class ObiDialogParser {
                     // Nothing to do here, the child dialogs were already expanded.
                     break
                 }
+                case OBIStepType.END_DIALOG:
                 case OBIStepType.END_TURN:
                     // Noop.
                     break

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -136,6 +136,7 @@ export class ObiDialogParser {
     private async collectDialogNodes(obiDialog: OBITypes.OBIDialog, conditionalEntities: { [key: string]: Set<string> }):
         Promise<ObiDialogNode> {
         let node: ObiDialogNode = new ObiDialogNode(obiDialog)
+        // TODO(thpar) : add steps for capturing API input and output.
         if (obiDialog.rules) {
             await this.collectDialogRuleChildren(node, obiDialog.rules, conditionalEntities)
         }

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -15,6 +15,7 @@ enum OBIStepType {
     END_TURN = "Microsoft.EndTurn",  // TODO(thpar) : Obsolete / delete ?
     HTTP_REQUEST = "Microsoft.HttpRequest",
     SEND_ACTIVITY = "Microsoft.SendActivity",
+    SWITCH_CONDITION = "Microsoft.SwitchCondition",
     TEXT_INPUT = "Microsoft.TextInput"
 }
 

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -80,7 +80,7 @@ export class ObiDialogParser {
         if (!mainDialog) {
             this.warnings.push(`Missing entry point. Expecting a .dialog file called "Entry.main"`)
         } else {
-            let conditionalEntities: { [key: string]: Set<string> } = {}
+            const conditionalEntities: { [key: string]: Set<string> } = {}
             const rootNode = await this.collectDialogNodes(mainDialog, conditionalEntities)
             await this.createOrUpdateConditionalEntities(conditionalEntities)
             trainDialogs = await this.getTrainDialogs(rootNode)
@@ -189,8 +189,10 @@ export class ObiDialogParser {
     /**
      * Collects dialog nodes from dialog-redirecting elements in the dialog `steps` section.
      */
-    private async collectDialogStepChildren(node: ObiDialogNode, steps: (string | OBITypes.OBIDialog)[],
-        conditionalEntities: { [key: string]: Set<string> }) {
+    private async collectDialogStepChildren(
+        node: ObiDialogNode,
+        steps: (string | OBITypes.OBIDialog)[],
+        conditionalEntities: { [key: string]: Set<string> }): Promise<void> {
         for (const step of steps) {
             if (typeof step === "string") {
                 this.warnings.push(`Unexpected string step in ${node.dialog.$id}`)
@@ -304,7 +306,7 @@ export class ObiDialogParser {
 
     private async getScorerStepsFromOBIDialogSteps(steps: (string | OBITypes.OBIDialog)[]):
         Promise<CLM.TrainScorerStep[]> {
-        let scorerSteps: CLM.TrainScorerStep[] = []
+        const scorerSteps: CLM.TrainScorerStep[] = []
         for (const [i, step] of steps.entries()) {
             const nextStep = (i + 1 < steps.length) ? steps[i + 1] : undefined
             if (typeof step === "string" || typeof nextStep === "string") {

--- a/src/Utils/obiDialogParser.ts
+++ b/src/Utils/obiDialogParser.ts
@@ -306,10 +306,11 @@ export class ObiDialogParser {
                     // Nothing to do here, the child dialogs were already expanded.
                     break
                 }
+                case OBIStepType.END_TURN:
+                    // Noop.
+                    break
                 default: {
-                    if (step.$type !== OBIStepType.END_TURN) {
-                        this.warnings.push(`Unhandled OBI Type: ${step.$type}`)
-                    }
+                    this.warnings.push(`Unhandled OBI Type: ${step.$type}`)
                 }
             }
         }

--- a/src/Utils/obiUtils.test.ts
+++ b/src/Utils/obiUtils.test.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import * as ObiUtils from './obiUtils'
 import * as BB from 'botbuilder'
+import * as ObiTypes from '../types/obiTypes'
+import * as ObiUtils from './obiUtils'
 import { deepCopy, RecursivePartial } from './util'
 
 describe('obiUtils', () => {
@@ -151,6 +152,56 @@ describe('obiUtils', () => {
             }
 
             expect(() => ObiUtils.areTranscriptsEqual(t1 , t2)).toThrow()
+        })
+    })
+    // Test cases for parsing conditions from Microsoft.SwitchCondition statements.
+    describe('ConditionParsing', () => {
+        test('Test single condition', () => {
+            let entityConditions: Map<string, Set<string>> = new Map()
+            let testData: ObiTypes.Case = {
+                value: "$foo == bar"
+            }
+            ObiUtils.parseEntityConditionFromDialogCase(testData, entityConditions)
+            expect(entityConditions.has("$foo")).toBe(true)
+            expect(entityConditions.get("$foo")).toEqual(new Set(["bar"]))
+        })
+        test('Test multiple conditions', () => {
+            let entityConditions: Map<string, Set<string>> = new Map()
+            // Set up an existing condition.
+            let valueSet: Set<string> = new Set(["one"])
+            entityConditions.set("$foo", valueSet)
+            let testData: ObiTypes.Case = {
+                value: "$foo == two"
+            }
+            ObiUtils.parseEntityConditionFromDialogCase(testData, entityConditions)
+            expect(entityConditions.has("$foo")).toBe(true)
+            expect(entityConditions.get("$foo")).toEqual(new Set(["one", "two"]))
+        })
+        test('Missing condition token', () => {
+            let entityConditions: Map<string, Set<string>> = new Map()
+            for (const value of ["$foo ==", "== bar", "=="]) {
+                let testData: ObiTypes.Case = { value }
+                try {
+                    ObiUtils.parseEntityConditionFromDialogCase(testData, entityConditions)
+                    fail("Did not get expected exception")
+                }
+                catch (err) {
+                    expect(err instanceof Error).toBe(true)
+                    expect(Error(err).message).toBe("Error: SwitchCondition entity and value must be non-empty")
+                }
+            }
+        })
+        test('Missing ==', () => {
+            let entityConditions: Map<string, Set<string>> = new Map()
+            let testData: ObiTypes.Case = { value: "foo" }
+            try {
+                ObiUtils.parseEntityConditionFromDialogCase(testData, entityConditions)
+                fail("Did not get expected exception")
+            }
+            catch (err) {
+                expect(err instanceof Error).toBe(true)
+                expect(Error(err).message).toBe("Error: SwitchCondition case is expected to have format 'x == y'")
+            }
         })
     })
 })

--- a/src/Utils/obiUtils.test.ts
+++ b/src/Utils/obiUtils.test.ts
@@ -156,29 +156,24 @@ describe('obiUtils', () => {
     })
     // Test cases for parsing conditions from Microsoft.SwitchCondition statements.
     describe('ConditionParsing', () => {
+        let entityConditions: { [key: string]: Set<string> } = {}
         test('Test single condition', () => {
-            let entityConditions: Map<string, Set<string>> = new Map()
             let testData: ObiTypes.Case = {
                 value: "$foo == bar"
             }
             ObiUtils.parseEntityConditionFromDialogCase(testData, entityConditions)
-            expect(entityConditions.has("$foo")).toBe(true)
-            expect(entityConditions.get("$foo")).toEqual(new Set(["bar"]))
+            expect(entityConditions.$foo).toEqual(new Set(["bar"]))
         })
         test('Test multiple conditions', () => {
-            let entityConditions: Map<string, Set<string>> = new Map()
             // Set up an existing condition.
-            let valueSet: Set<string> = new Set(["one"])
-            entityConditions.set("$foo", valueSet)
+            entityConditions.$foo = new Set(["one"])
             let testData: ObiTypes.Case = {
                 value: "$foo == two"
             }
             ObiUtils.parseEntityConditionFromDialogCase(testData, entityConditions)
-            expect(entityConditions.has("$foo")).toBe(true)
-            expect(entityConditions.get("$foo")).toEqual(new Set(["one", "two"]))
+            expect(entityConditions.$foo).toEqual(new Set(["one", "two"]))
         })
         test('Missing condition token', () => {
-            let entityConditions: Map<string, Set<string>> = new Map()
             for (const value of ["$foo ==", "== bar", "=="]) {
                 let testData: ObiTypes.Case = { value }
                 try {
@@ -192,7 +187,6 @@ describe('obiUtils', () => {
             }
         })
         test('Missing ==', () => {
-            let entityConditions: Map<string, Set<string>> = new Map()
             let testData: ObiTypes.Case = { value: "foo" }
             try {
                 ObiUtils.parseEntityConditionFromDialogCase(testData, entityConditions)

--- a/src/Utils/obiUtils.tsx
+++ b/src/Utils/obiUtils.tsx
@@ -39,16 +39,16 @@ export interface OBIImportData {
 
 // Return activities for the given logDialogId
 export async function getLogDialogActivities(
-    appId: string, 
-    logDialogId: string, 
-    user: User, 
+    appId: string,
+    logDialogId: string,
+    user: User,
     actions: CLM.ActionBase[],
     entities: CLM.EntityBase[],
     conversationId: string | undefined,
     channelId: string | undefined,
     fetchLogDialogThunkAsync: (appId: string, logDialogId: string, replaceLocal: boolean, nullOnNotFound: boolean) => Promise<CLM.LogDialog>,
     fetchActivitiesAsync: (appId: string, trainDialog: CLM.TrainDialog, userName: string, userId: string, useMarkdown: boolean) => Promise<CLM.TeachWithActivities>
-    ): Promise<Util.RecursivePartial<BB.Activity>[]> {
+): Promise<Util.RecursivePartial<BB.Activity>[]> {
 
     // Fetch the LogDialog
     const logDialog = await fetchLogDialogThunkAsync(appId, logDialogId, true, true)
@@ -82,7 +82,7 @@ function addActivityReferences(activities: Util.RecursivePartial<BB.Activity>[],
 
 async function getActivities(appId: string, trainDialog: CLM.TrainDialog, user: User, definitions: CLM.AppDefinition,
     fetchActivitiesAsync: (appId: string, trainDialog: CLM.TrainDialog, userName: string, userId: string, useMarkdown: boolean) => Promise<CLM.TeachWithActivities>
-    ): Promise<BB.Transcript> {
+): Promise<BB.Transcript> {
     const newTrainDialog = Util.deepCopy(trainDialog)
     newTrainDialog.definitions = definitions
 
@@ -375,6 +375,8 @@ export function generateEntityMapForAction(action: CLM.ActionBase, filledEntityM
     return map
 }
 
+// NOTA BENE : We currently assume that switch nodes will only be acting on values returned by
+// API calls, and that values will be compared using strict string equality.
 export function parseEntityConditionFromDialogCase(branch: Case, entityConditions: { [key: string]: Set<string> }) {
     if (!branch.value) {
         throw new Error("SwitchCondition cases must have value")
@@ -459,13 +461,13 @@ export function replaceImportActions(trainDialog: CLM.TrainDialog, actions: CLM.
 export function expandLGItems(trainDialog: CLM.TrainDialog, lgItems: CLM.LGItem[]): void {
     for (const round of trainDialog.rounds) {
         for (const scorerStep of round.scorerSteps) {
-                const lgName = scorerStep.importText ? lgNameFromImportText(scorerStep.importText) : null
-                if (lgName) {
-                    let lgItem = lgItems.find(lg => lg.lgName === lgName)
-                    if (lgItem) {
-                        scorerStep.importText = lgItem.text
-                    }
+            const lgName = scorerStep.importText ? lgNameFromImportText(scorerStep.importText) : null
+            if (lgName) {
+                let lgItem = lgItems.find(lg => lg.lgName === lgName)
+                if (lgItem) {
+                    scorerStep.importText = lgItem.text
                 }
+            }
         }
     }
 }
@@ -537,10 +539,10 @@ export async function createImportedActions(
                         if (lgName) {
                             let lgItem = lgItems.find(lg => lg.lgName === lgName)
                             if (lgItem) {
-                                importedAction = { 
-                                    text: lgItem.text, 
-                                    buttons: lgItem.suggestions, 
-                                    isTerminal, 
+                                importedAction = {
+                                    text: lgItem.text,
+                                    buttons: lgItem.suggestions,
+                                    isTerminal,
                                     reprompt: lgItem.suggestions.length > 0,
                                     lgName
                                 }
@@ -553,12 +555,13 @@ export async function createImportedActions(
                         }
                     }
                     if (!importedAction) {
-                        importedAction = { 
-                            text: scorerStep.importText, 
-                            buttons: [], 
-                            isTerminal, 
+                        importedAction = {
+                            text: scorerStep.importText,
+                            buttons: [],
+                            isTerminal,
                             reprompt: false,
-                            actionHash: CLM.hashText(scorerStep.importText)}
+                            actionHash: CLM.hashText(scorerStep.importText)
+                        }
                     }
 
                     action = await createActionFromImport(appId, importedAction, templates, createActionThunkAsync)
@@ -639,9 +642,10 @@ async function createActionFromImport(
         actionType,
         entityId: undefined,
         enumValueId: undefined,
-        clientData: { 
-            actionHashes: importedAction.actionHash ? [importedAction.actionHash] : [], 
-            lgName: importedAction.lgName }
+        clientData: {
+            actionHashes: importedAction.actionHash ? [importedAction.actionHash] : [],
+            lgName: importedAction.lgName
+        }
     })
 
     const newAction = await createActionThunkAsync(appId, action)
@@ -698,7 +702,7 @@ export function areTranscriptsEqual(transcript1: Util.RecursivePartial<BB.Activi
         throw new Error("Not a valid comparison.  ConversationIds do not match.")
     }
     if (transcript1[0].channelId === transcript2[0].channelId) {
-        throw new Error("Not a valid comparison.  Same channel.") 
+        throw new Error("Not a valid comparison.  Same channel.")
     }
     for (let i = 0; i < Math.min(transcript1.length, transcript2.length); i = i + 1) {
         const activity1 = transcript1[i]

--- a/src/Utils/obiUtils.tsx
+++ b/src/Utils/obiUtils.tsx
@@ -375,7 +375,7 @@ export function generateEntityMapForAction(action: CLM.ActionBase, filledEntityM
     return map
 }
 
-export function parseEntityConditionFromDialogCase(branch: Case, entityConditions: Map<string, Set<string>>) {
+export function parseEntityConditionFromDialogCase(branch: Case, entityConditions: { [key: string]: Set<string> }) {
     if (!branch.value) {
         throw new Error("SwitchCondition cases must have value")
     }
@@ -393,10 +393,10 @@ export function parseEntityConditionFromDialogCase(branch: Case, entityCondition
         throw new Error("SwitchCondition case is expected to have format 'x == y'")
     }
     const [entity, value] = tokens
-    let conditionValues = entityConditions.get(entity)
+    let conditionValues = entityConditions[entity]
     if (!conditionValues) {
         conditionValues = new Set<string>()
-        entityConditions.set(entity, conditionValues)
+        entityConditions[entity] = conditionValues
     }
     conditionValues.add(value)
 }

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -1112,8 +1112,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             this.props.actions,
             this.props.entities,
             this.props.createActionThunkAsync as any,
-            this.props.createEntityThunkAsync as any,
-            this.props.editEntityThunkAsync as any)
+            this.props.createEntityThunkAsync as any)
         try {
             const obiParseResult = await obiDialogParser.parse(obiImportData.files)
 
@@ -1934,7 +1933,6 @@ const mapDispatchToProps = (dispatch: any) => {
         deleteTeachSessionThunkAsync: actions.teach.deleteTeachSessionThunkAsync,
         deleteMemoryThunkAsync: actions.teach.deleteMemoryThunkAsync,
         editActionThunkAsync: actions.action.editActionThunkAsync,
-        editEntityThunkAsync: actions.entity.editEntityThunkAsync,
         editTrainDialogThunkAsync: actions.train.editTrainDialogThunkAsync,
         extractFromTrainDialogThunkAsync: actions.train.extractFromTrainDialogThunkAsync,
         fetchActivitiesThunkAsync: actions.train.fetchActivitiesThunkAsync,

--- a/src/routes/Apps/App/TrainDialogs.tsx
+++ b/src/routes/Apps/App/TrainDialogs.tsx
@@ -1099,7 +1099,7 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
             // TODO: Find way to extract algorithm type
         }
 
-        await this.props.regenerateDispatchTrainDialogsAsync(this.props.app.appId, algorithmType, this.props.actions, this.props.trainDialogs)
+        this.props.regenerateDispatchTrainDialogsAsync(this.props.app.appId, algorithmType, this.props.actions, this.props.trainDialogs)
 
         this.setState({
             isRegenActive: false,
@@ -1107,8 +1107,13 @@ class TrainDialogs extends React.Component<Props, ComponentState> {
     }
 
     async importOBIFiles(obiImportData: OBIUtils.OBIImportData): Promise<void> {
-        const obiDialogParser = new OBIDialogParser.ObiDialogParser(this.props.app, this.props.actions, this.props.entities,
-            this.props.createActionThunkAsync as any, this.props.createEntityThunkAsync as any)
+        const obiDialogParser = new OBIDialogParser.ObiDialogParser(
+            this.props.app,
+            this.props.actions,
+            this.props.entities,
+            this.props.createActionThunkAsync as any,
+            this.props.createEntityThunkAsync as any,
+            this.props.editEntityThunkAsync as any)
         try {
             const obiParseResult = await obiDialogParser.parse(obiImportData.files)
 
@@ -1929,6 +1934,7 @@ const mapDispatchToProps = (dispatch: any) => {
         deleteTeachSessionThunkAsync: actions.teach.deleteTeachSessionThunkAsync,
         deleteMemoryThunkAsync: actions.teach.deleteMemoryThunkAsync,
         editActionThunkAsync: actions.action.editActionThunkAsync,
+        editEntityThunkAsync: actions.entity.editEntityThunkAsync,
         editTrainDialogThunkAsync: actions.train.editTrainDialogThunkAsync,
         extractFromTrainDialogThunkAsync: actions.train.extractFromTrainDialogThunkAsync,
         fetchActivitiesThunkAsync: actions.train.fetchActivitiesThunkAsync,

--- a/src/types/obiTypes.ts
+++ b/src/types/obiTypes.ts
@@ -355,7 +355,7 @@ export interface Case {
      * Value which must match the condition property
      */
     value: string;
-    case:  any;
+    case?:  any;
 }
 
 export enum Event {


### PR DESCRIPTION
This PR adds initial support for `SwitchCondition` .dialog nodes.

* Branches from the `SwitchCondition` are traversed and included in construction of the dialog tree
* Conditions from each `SwitchCondition` case are used to generate enum entity values
  * Eg, if a switch has cases for `isProductKey == Windows` and `isProductKey == Office`, we will generate an enum entity `isProductKey`  with values `Windows` and `Office`:

![enum_entity](https://user-images.githubusercontent.com/53840199/66961848-6fff4500-f024-11e9-845e-40acda6b1711.png)

Not implemented in this PR (coming later):
* Setting bot memory following the API call
* Adding "condition" restrictions to the actions generated from switch statements
* Generating turns for the input and output values of the API call
* Unit testing against interesting .dialog structures

Notes:
* Condition values are truncated to 10 characters during enum creation.  If multiple conditions map to the same truncated value, import will fail with an error message.
* There are some limitations on the contents of `SwitchCondition `nodes; see code comments for details
