### PR TITLE
feat: add row selection to cypress label event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13729,7 +13729,7 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -424,8 +424,8 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
 
     /**
      * For cypress end to end unit testing.  Event selects phrase in entity labeller
-     * The following will select the word "hello" in the second row (row is 1 based)
-     *   var event = new CustomEvent("Test_SelectWord", { detail: { phrase: "hello", row: 2 }})
+     * The following will select the word "hello" in the second row (index is 0 based)
+     *   var event = new CustomEvent("Test_SelectWord", { detail: { phrase: "hello", index: 1 }})
      *   event.initEvent("Test_SelectWord", true, true)}
      *   element.dispatchEvent(event)
      * 
@@ -435,14 +435,14 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
      *   element.dispatchEvent(event)
      */
     @autobind
-    onTestSelectWord(val: { detail: { phrase: string, row: number } } | { detail: string }) {
+    onTestSelectWord(val: { detail: { phrase: string, index: number } } | { detail: string }) {
         
         if (!val.detail) {
             throw new Error("Test_SelectWord expecting detail phrase")
         }
 
         const phrase: string = (typeof val.detail !== "string") ? val.detail.phrase : val.detail
-        const row: number = (typeof val.detail !== "string") ? (val.detail.row - 1) : 0
+        const index: number = (typeof val.detail !== "string") ? val.detail.index : 0
 
         const words = phrase.split(" ")
         const firstWord = words[0]
@@ -450,11 +450,11 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
 
         // Get row
         const rows = Array.from(document.querySelectorAll('[data-testid="extractor-response-editor-entity-labeler"]'))
-        if (row > rows.length - 1) {
+        if (index > rows.length || index < 0) {
             throw new Error("Row index does not exist")
         }
 
-        const selectedRow = rows[row]
+        const selectedRow = rows[index]
         // Get start div
         const tokens = Array.from(selectedRow.querySelectorAll(".cl-token-node"))
         const firstWordToken = tokens.filter(element => element.children[0].textContent === firstWord)[0]

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -414,18 +414,18 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
 
     componentDidMount() {
         // For end 2 end unit testing.
-        document.addEventListener("Test_SelectWord", this.onTestSelectWord)
+        document.addEventListener("Test_SelectWord", this.onTestSelectWord as any)
     }
 
     componentWillUnmount() {
         // For end 2 end unit testing.
-        document.removeEventListener("Test_SelectWord", this.onTestSelectWord)
+        document.removeEventListener("Test_SelectWord", this.onTestSelectWord as any)
     }
 
     /**
      * For cypress end to end unit testing.  Event selects phrase in entity labeller
      * The following will select the word "hello" in the second row (row is 1 based)
-     *   var event = new CustomEvent("Test_SelectWord", { detail: { phrase: "hello", r:ow: 2 }})
+     *   var event = new CustomEvent("Test_SelectWord", { detail: { phrase: "hello", row: 2 }})
      *   event.initEvent("Test_SelectWord", true, true)}
      *   element.dispatchEvent(event)
      * 
@@ -435,20 +435,21 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
      *   element.dispatchEvent(event)
      */
     @autobind
-    onTestSelectWord(val: any) {
+    onTestSelectWord(val: { detail: { phrase: string, row: number } } | { detail: string }) {
+        
         if (!val.detail) {
             throw new Error("Test_SelectWord expecting detail phrase")
         }
 
-        const phrase: string = val.detail.phrase || val.detail
-        const row: number = val.detail.row - 1 || 0
+        const phrase: string = (typeof val.detail !== "string") ? val.detail.phrase : val.detail
+        const row: number = (typeof val.detail !== "string") ? (val.detail.row - 1) : 0
 
         const words = phrase.split(" ")
         const firstWord = words[0]
         const lastWord = words[words.length - 1]
 
         // Get row
-        const rows = Array.from(document.querySelectorAll(".entity-labeler"))
+        const rows = Array.from(document.querySelectorAll('[data-testid="extractor-response-editor-entity-labeler"]'))
         if (row > rows.length - 1) {
             throw new Error("Row index does not exist")
         }

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -422,16 +422,35 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
         document.removeEventListener("Test_SelectWord", this.onTestSelectWord)
     }
 
-    // For end 2 end unit testing.
+    /**
+     * For cypress end to end unit testing.  Event selects phrase in entity labeller
+     * The following will select the work "hello" in the second row
+     *   var event = new CustomEvent("Test_SelectWord", { detail: { phrase: "hello", row: 2 })
+     *   event.initEvent("Test_SelectWord", true, true)}
+     *   element.dispatchEvent(event)
+     */
     @autobind
     onTestSelectWord(val: any) {
-        const phrase: string = val.detail
+        if (!val.detail) {
+            throw new Error("Test_SelectWord expecting detail phrase")
+        }
+
+        const phrase: string = val.detail.phrase || val.detail
+        const row: number = val.detail.row || 0
+
         const words = phrase.split(" ")
         const firstWord = words[0]
         const lastWord = words[words.length - 1]
 
+        // Get row
+        const rows = Array.from(document.querySelectorAll(".entity-labeler"))
+        if (row > rows.length - 1) {
+            throw new Error("Row index does not exist")
+        }
+
+        const selectedRow = rows[row]
         // Get start div
-        const tokens = Array.from(document.querySelectorAll(".cl-token-node"))
+        const tokens = Array.from(selectedRow.querySelectorAll(".cl-token-node"))
         const firstWordToken = tokens.filter(element => element.children[0].textContent === firstWord)[0]
         const lastWordToken = tokens.filter(element => element.children[0].textContent === lastWord)[0]
 

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -436,7 +436,7 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
         }
 
         const phrase: string = val.detail.phrase || val.detail
-        const row: number = val.detail.row || 0
+        const row: number = val.detail.row - 1 || 0
 
         const words = phrase.split(" ")
         const firstWord = words[0]

--- a/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
+++ b/src/components/ExtractorResponseEditor/ExtractorResponseEditor.tsx
@@ -424,8 +424,13 @@ class ExtractorResponseEditor extends React.Component<Props, State> {
 
     /**
      * For cypress end to end unit testing.  Event selects phrase in entity labeller
-     * The following will select the work "hello" in the second row
-     *   var event = new CustomEvent("Test_SelectWord", { detail: { phrase: "hello", row: 2 })
+     * The following will select the word "hello" in the second row (row is 1 based)
+     *   var event = new CustomEvent("Test_SelectWord", { detail: { phrase: "hello", r:ow: 2 }})
+     *   event.initEvent("Test_SelectWord", true, true)}
+     *   element.dispatchEvent(event)
+     * 
+     * Or default to the first row:
+     *   var event = new CustomEvent("Test_SelectWord", { detail: "hello"})
      *   event.initEvent("Test_SelectWord", true, true)}
      *   element.dispatchEvent(event)
      */


### PR DESCRIPTION
Cypress event tool can optionally choose row to select from.  Is backwards compatible:

Select "hello" in the 2nd row
```
     var event = new CustomEvent("Test_SelectWord", { detail: { phrase: "hello", index: 1 })
     event.initEvent("Test_SelectWord", true, true)}
     element.dispatchEvent(event)
```
or default to the first row
 ```
    var event = new CustomEvent("Test_SelectWord", { detail: "hello")
     event.initEvent("Test_SelectWord", true, true)}
     element.dispatchEvent(event)
```
