### PR TITLE
fix: don't highlight incomplete nodes

### DIFF
--- a/src/components/actionPayloadRenderers/PayloadRendererWithHighlights.tsx
+++ b/src/components/actionPayloadRenderers/PayloadRendererWithHighlights.tsx
@@ -21,12 +21,13 @@ interface NodeProps extends EntityComponentProps {
 }
 
 export const EntityHighlight = (props: NodeProps) => {
-    const isEntityMissing = props.node.data.get('missing')
-    const isEntityRequired = props.node.data.get('required')
-    const isEntityFilled = props.node.data.get('filled')
+    const isEntityCompleted = props.node.data.get('completed') === true
+    const isEntityMissing = props.node.data.get('missing') === true
+    const isEntityRequired = props.node.data.get('required') === true
+    const isEntityFilled = props.node.data.get('filled') === true
 
     const classNames = classnames({
-        'cl-action-payload-entity': true,
+        'cl-action-payload-entity': isEntityCompleted,
         'cl-action-payload-entity--filled': isEntityFilled,
         'cl-action-payload-entity--missing': isEntityMissing,
         'cl-action-payload-entity--required': isEntityRequired,
@@ -52,7 +53,6 @@ interface Props {
     slateValue: SlateValue
 }
 
-
 const renderNode = (props: any): React.ReactNode | void => {
     switch (props.node.type) {
         case NodeTypes.Mention:
@@ -72,7 +72,6 @@ const Component: React.FC<Props> = (props) => {
 
     return (
         <Editor
-            data-testid="action-scorer-text-response"
             className={editorClassnames}
             value={props.slateValue}
             renderNode={renderNode}

--- a/src/components/modals/ActionPayloadEditor/MentionNode.tsx
+++ b/src/components/modals/ActionPayloadEditor/MentionNode.tsx
@@ -16,7 +16,7 @@ interface Props extends EntityComponentProps {
 }
 
 export const MentionNode = (props: Props) => {
-    const isCompleted = props.node.data.get('completed')
+    const isCompleted = props.node.data.get('completed') === true
 
     return (
         <span className={`mention-node ${isCompleted ? 'mention-node--completed' : ''}`} {...props.attributes}>

--- a/src/components/modals/ActionPayloadEditor/slateSerializer.ts
+++ b/src/components/modals/ActionPayloadEditor/slateSerializer.ts
@@ -63,12 +63,13 @@ function getEntityIds(node: any): string[] {
             : node.data
         const option = data.option
 
-        if (!option) {
-            throw new Error(`Attempting to serialize inline node but it did not have option`)
+        if (option) {
+            const entityId = option.id
+            entityIds.push(entityId)
         }
-
-        const entityId = option.id
-        entityIds.push(entityId)
+        else {
+            console.warn(`Attempting to serialize inline node but it did not have option`)
+        }
     }
 
     // Technically this would never get called because inline nodes shouldn't have other children which are inline nodes


### PR DESCRIPTION
A while back I added highlighting to entities. At that time we only dealt with incomplete nodes inside the action creator editor but now we also have to deal with them inside this payload renderer.

- Adds check for `complete` property
- Changes from `throw` ing errors to logging `warnings`