### PR TITLE
fix: release test - app selector

### DIFF
--- a/cypress/support/selectors.ts
+++ b/cypress/support/selectors.ts
@@ -8,7 +8,7 @@ const selectors = {
         link: '#uiLink',
     },
     app: {
-        container: '.cl-app'
+        container: '.cl-o-app-columns'
     },
     officePicker: {
         buttonSuggestion: '.ms-Suggestions-itemButton',

--- a/src/routes/App.css
+++ b/src/routes/App.css
@@ -74,7 +74,7 @@
 }
 
 /**
-Most of our classes are component classes but this is object class (not o- prefix) to be re-used across app
+Most of our classes are component classes but this is object class (note o- prefix) to be re-used across app
 https://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/
 
 .cl-app prefix refers to the UI as an Application


### PR DESCRIPTION
When we changed the UI to have the grey banner / sub navigation per model I changed the selectors available and forgot to update the test.  As I was going through tests on new build/repo I discovered this.  Porting back to this repo.