### PR TITLE
Fix Bug in cy.ExactMatch Command

### DIFF
--- a/cypress/support/Helpers.js
+++ b/cypress/support/Helpers.js
@@ -155,23 +155,18 @@ export function VerifyNoErrorMessages() { cy.DoesNotContain('div.cl-errorpanel')
 export function HasErrorMessage() { return Cypress.$('div.cl-errorpanel').length > 0 }
 export function CloseErrorMessagePanel() { cy.Get('button.ms-Panel-closeButton[title="Close"]').Click() }
 
+// This behaves slightly different than the cy.contains command does in that the elements returned
+// can contain multiple parent elements as well compared to the cy.contains command. To zoom in
+// to a smaller set of elements you can sometimes get away with calling it like this:
+//    cy.contains('your search string').ExactMatch('your search string')
 export function ExactMatch(elements, expectedText) {
   const funcName = `ExactMatch('${expectedText}')`
   ConLog(funcName, `Start`)
-
-  // We start with contains because it zooms in to the minimum element with the text we are looking for,
-  // then after we have a list of just the single elements (as opposed to nested elements) then we find the
-  // one that has exactly the expectedText.
-  let possibleMatches = Cypress.$(elements).find(`:contains(${expectedText})`)
-  if (possibleMatches.length == 0) {
-    ConLog(funcName, `":contains" found nothing, reverting back to the original elements we were given which contain ${elements.length} elements.`)
-    possibleMatches = elements
-  }
-
-  for (let i = 0; i < possibleMatches.length; i++) {
-    const elementText = TextContentWithoutNewlines(possibleMatches[i])
+  
+  for (let i = 0; i < elements.length; i++) {
+    const elementText = TextContentWithoutNewlines(elements[i])
     ConLog(funcName, `elementText: '${elementText}'`)
-    if (elementText === expectedText) return [possibleMatches[i]]
+    if (elementText === expectedText) return [elements[i]]
   }
   return []
 }

--- a/cypress/support/components/ActionModal.js
+++ b/cypress/support/components/ActionModal.js
@@ -145,6 +145,8 @@ export function RemoveDisqualifyingCondition(entityNameOrCondition) { RemoveEnti
 function RemoveEntityOrCondition(dataTestId, entityNameOrCondition) { 
   cy.Get(`[data-testid="${dataTestId}"]`)
     .find('[data-testid="tag-item"]')
+    // We need 'contains' here as well as 'ExactMatch' because it returns a single element
+    .contains(entityNameOrCondition)
     .ExactMatch(entityNameOrCondition)
     .next('span[role="button"]')
     .Click()


### PR DESCRIPTION
I had changed the cy.ExactMatch command to behave more like the cy.contains command in terms of the number of elements it returns, however this caused too many tests to fail and the fix was necessary for only one function. So I worked out how to fix the issue for that one function without affecting all of the other tests.