### PR TITLE
fix: prevent crash when accessing undefined selected option

### DIFF
--- a/src/components/modals/ConditionModal.tsx
+++ b/src/components/modals/ConditionModal.tsx
@@ -266,7 +266,7 @@ const Component: React.FC<Props> = (props) => {
     }
 
     const isOperatorDisabled = selectedEntityOption?.data.entityType === CLM.EntityType.ENUM
-    const conditionsUsingEntity = props.conditions.filter(c => c.entityId === selectedEntityOption.key)
+    const conditionsUsingEntity = props.conditions.filter(c => c.entityId === selectedEntityOption?.key)
     const currentCondition = createConditionFromState()
 
     return <OF.Modal


### PR DESCRIPTION
There was assumption that the filter function wasn't executed since if having a condition, would imply there must be entities/options available for the condition. However, we can have stale conditions exist even when no suitable entities exist due to edits.