### PR TITLE
fix: empty string fallback for undefined locale

### DIFF
--- a/src/components/modals/AppCreator.tsx
+++ b/src/components/modals/AppCreator.tsx
@@ -60,10 +60,12 @@ class AppCreator extends React.Component<Props, ComponentState> {
     componentDidUpdate(prevProps: Props) {
         // Reset when opening modal
         if (this.props.open === false && prevProps.open === true) {
-            const firstValue = this.state.localeOptions[0].text
+            // Component might update before localOptions have been loaded
+            // TODO: Remove explicit types, should be inferrable
+            const firstValue: string | undefined = this.state.localeOptions[0]?.text
             this.setState({
                 appNameVal: '',
-                localeVal: firstValue,
+                localeVal: firstValue ?? '',
                 clFile: null,
                 obiFiles: null
             })


### PR DESCRIPTION
As code comment says "Component might update before `localeOptions` have been loaded" meaning their might not be first value and should default to empty string again