### PR TITLE
fix: discard overlapping entities for proper render

### DIFF
--- a/src/components/ExtractorResponseEditor/utilities.test.ts
+++ b/src/components/ExtractorResponseEditor/utilities.test.ts
@@ -411,5 +411,85 @@ describe('ExtractResponseEditor', () => {
             })
 
         })
+
+        describe('warnAboutOverlappingEntities', () => {
+            test('given no entities return false', () => {
+                expect(utilities.warnAboutOverlappingEntities([])).toBe(false)
+            })
+
+            test('given entities NOT overlapping return false', () => {
+                const customEntities: models.IGenericEntity<any>[] = [
+                    {
+                        startIndex: 1,
+                        endIndex: 3,
+                        data: {},
+                    },
+                    {
+                        startIndex: 5,
+                        endIndex: 7,
+                        data: {},
+                    }
+                ]
+
+                expect(utilities.warnAboutOverlappingEntities(customEntities)).toBe(false)
+            })
+
+            test('given entities WITH overlap return true', () => {
+                const customEntities: models.IGenericEntity<any>[] = [
+                    {
+                        startIndex: 1,
+                        endIndex: 3,
+                        data: {},
+                    },
+                    {
+                        startIndex: 0,
+                        endIndex: 4,
+                        data: {},
+                    },
+                ]
+
+                expect(utilities.warnAboutOverlappingEntities(customEntities)).toBe(true)
+            })
+        })
+
+        describe('discardOverlappingEntities', () => {
+            test('given empty array return empty array', () => {
+                expect(utilities.discardOverlappingEntities([])).toEqual([])
+            })
+
+            test('given entities NOT overlapping, dont discard any, ensure length is same', () => {
+                const customEntities: models.IGenericEntity<any>[] = [
+                    {
+                        startIndex: 1,
+                        endIndex: 3,
+                        data: {},
+                    },
+                    {
+                        startIndex: 5,
+                        endIndex: 7,
+                        data: {},
+                    }
+                ]
+
+                expect(utilities.discardOverlappingEntities(customEntities).length).toBe(2)
+            })
+
+            test('given entities WITH overlap, discard', () => {
+                const customEntities: models.IGenericEntity<any>[] = [
+                    {
+                        startIndex: 1,
+                        endIndex: 3,
+                        data: {},
+                    },
+                    {
+                        startIndex: 0,
+                        endIndex: 4,
+                        data: {},
+                    },
+                ]
+
+                expect(utilities.discardOverlappingEntities(customEntities).length).toBe(1)
+            })
+        })
     })
 })


### PR DESCRIPTION
Adds two functions

 `warnAboutOverlappingEntities` which detects overlapping entities and logs warning to the console so we can look out for this in future. In most case we should never see these warnings, but if we do we know somethings wrong.

Note the output shows in test logs, but is intentional to send warning for browsers.

`discardOverlappingEntities` which removed the overlapping entities from rendering in the extractor editor. Alternative seems like throwing an error since we can't render them properly.



In long term we should probably support overlapping labels but there was talk of using LUIS extraction editor in future so likely bad investment.

Picture of warning.
![image](https://user-images.githubusercontent.com/2856501/70194178-58544c80-16b6-11ea-8274-5988a069d5db.png)
